### PR TITLE
update dependency causing security alerts

### DIFF
--- a/Tests/ApiEndpoints/requirements.txt
+++ b/Tests/ApiEndpoints/requirements.txt
@@ -1,2 +1,2 @@
 py==1.4.31
-requests==2.10.0
+requests>=2.10.0


### PR DESCRIPTION
our test framework uses the request dependency to tests the api endpoints, and it is out of date, therefore needs to be updated. Since this is strictly use for API testing it will not affect anything else.