### PR TITLE
Modified Packages.config to upgrade Bootstrap: 3.0.0 to 3.4.1 (Security issue)

### DIFF
--- a/Gordon360/packages.config
+++ b/Gordon360/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.4.1.9004" targetFramework="net461" />
-  <package id="bootstrap" version="3.0.0" targetFramework="net461" />
+  <package id="bootstrap" version="3.4.1" targetFramework="net461" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net461" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net461" />
   <package id="jQuery" version="1.10.2" targetFramework="net461" />


### PR DESCRIPTION
Bootstrap version 3.0.0 has [major security issues with XSS ](https://blog.getbootstrap.com/2019/02/13/bootstrap-4-3-1-and-3-4-1/). Therefore I changed the package configuration to use Bootstrap version 3.4.1 which fixed the issue.