### PR TITLE
Standardized path syntax for postID

### DIFF
--- a/Gordon360/ApiControllers/ProfilesController.cs
+++ b/Gordon360/ApiControllers/ProfilesController.cs
@@ -661,7 +661,7 @@ namespace Gordon360.Controllers.Api
                 {
 
                     di = new DirectoryInfo(root); //di is declared at beginning of try.
-                    System.IO.File.Move(file.LocalFileName, di.FullName + "\\" + fileName); //upload
+                    System.IO.File.Move(file.LocalFileName, di.FullName + fileName); //upload
                 }
                 return Request.CreateResponse(HttpStatusCode.OK);
             }


### PR DESCRIPTION
File path now includes backslash, no need to add one in postID function, when joining paths