### PR TITLE
Bon appetit secrets fix

### DIFF
--- a/Gordon360/Services/DiningService.cs
+++ b/Gordon360/Services/DiningService.cs
@@ -31,8 +31,8 @@ namespace Gordon360.Services
     {
         // See UnitOfWork class
         private IUnitOfWork _unitOfWork;
-        private static string issuerID = "219";
-        private static string applicationId = "000001";
+        private static string issuerID = System.Web.Configuration.WebConfigurationManager.AppSettings["bonAppetitIssuerID"];
+        private static string applicationId = System.Web.Configuration.WebConfigurationManager.AppSettings["bonAppetitApplicationID"];
         private static string secret = System.Web.Configuration.WebConfigurationManager.AppSettings["bonAppetitSecret"];
 
         public DiningService(IUnitOfWork unitOfWork)
@@ -42,7 +42,6 @@ namespace Gordon360.Services
 
         private static string getTimestamp()
         {
-            //DateTime baseDate = new DateTime(1969, 12, 31, 20, 0, 0);
             DateTime baseDate = new DateTime(1970, 1, 1, 0, 0, 0);
             TimeSpan diff = DateTime.UtcNow - baseDate;
             Int64 millis = Convert.ToInt64(diff.TotalMilliseconds);

--- a/Gordon360/Services/DiningService.cs
+++ b/Gordon360/Services/DiningService.cs
@@ -33,7 +33,7 @@ namespace Gordon360.Services
         private IUnitOfWork _unitOfWork;
         private static string issuerID = "219";
         private static string applicationId = "000001";
-        private static string secret = "test";
+        private static string secret = System.Web.Configuration.WebConfigurationManager.AppSettings["bonAppetitSecret"];
 
         public DiningService(IUnitOfWork unitOfWork)
         {
@@ -42,8 +42,9 @@ namespace Gordon360.Services
 
         private static string getTimestamp()
         {
-            DateTime baseDate = new DateTime(1969, 12, 31, 20, 0, 0);
-            TimeSpan diff = DateTime.Now - baseDate;
+            //DateTime baseDate = new DateTime(1969, 12, 31, 20, 0, 0);
+            DateTime baseDate = new DateTime(1970, 1, 1, 0, 0, 0);
+            TimeSpan diff = DateTime.UtcNow - baseDate;
             Int64 millis = Convert.ToInt64(diff.TotalMilliseconds);
             return millis.ToString();
         }


### PR DESCRIPTION
This makes two changes:

Change datetime used in hash constructed for accessing Bon Appetit server to use UTC rather than either EST or EDT.

Seed for Bon Appetit server (called "secret" in the source code) changed this spring - moved to our secrets config file, along with other Bon Appetit server access information.

