### PR TITLE
ScheduleControl tests

### DIFF
--- a/Gordon360/ApiControllers/MyScheduleController.cs
+++ b/Gordon360/ApiControllers/MyScheduleController.cs
@@ -45,9 +45,9 @@ namespace Gordon360.Controllers.Api
         }
 
         /// <summary>
-        ///  Gets all myschedule objects for a user
+        ///  Gets all custom events for a user
         /// </summary>
-        /// <returns>A IEnumerable of myschedule objects</returns>
+        /// <returns>A IEnumerable of custom events</returns>
         [HttpGet]
         [Route("")]
         public IHttpActionResult Get()
@@ -75,9 +75,9 @@ namespace Gordon360.Controllers.Api
 
 
         /// <summary>
-        ///  Gets specific myschedule object for a user
+        ///  Gets specific custom event for a user
         /// </summary>
-        /// <returns>The requested myschedule object</returns>
+        /// <returns>The requested custom event</returns>
         [HttpGet]
         [Route("event/{event_id}")]
         public IHttpActionResult GetByEventId(string event_Id)

--- a/Gordon360/ApiControllers/MyScheduleController.cs
+++ b/Gordon360/ApiControllers/MyScheduleController.cs
@@ -24,6 +24,7 @@ namespace Gordon360.Controllers.Api
         private IProfileService _profileService;
         private IAccountService _accountService;
         private IRoleCheckingService _roleCheckingService;
+        private IScheduleControlService _scheduleControlService;
 
 
         private IMyScheduleService _myScheduleService;
@@ -35,6 +36,7 @@ namespace Gordon360.Controllers.Api
             _profileService = new ProfileService(_unitOfWork);
             _accountService = new AccountService(_unitOfWork);
             _roleCheckingService = new RoleCheckingService(_unitOfWork);
+            _scheduleControlService = new ScheduleControlService(_unitOfWork);
         }
 
         public MyScheduleController(IMyScheduleService myScheduleService)
@@ -127,6 +129,7 @@ namespace Gordon360.Controllers.Api
         public IHttpActionResult Post([FromBody] MYSCHEDULE mySchedule)
         {
             const int MAX = 50;
+            DateTime localDate = DateTime.Now;
 
             // Verify Input
             if (!ModelState.IsValid || mySchedule == null)
@@ -167,6 +170,9 @@ namespace Gordon360.Controllers.Api
                 return NotFound();
             }
 
+
+            _scheduleControlService.UpdateModifiedTimeStamp(id, localDate);
+
             return Created("myschedule", mySchedule);
         }
 
@@ -177,6 +183,7 @@ namespace Gordon360.Controllers.Api
         [Route("{event_id}")]
         public IHttpActionResult Delete(string event_id)
         {
+            DateTime localDate = DateTime.Now;
             var authenticatedUser = this.ActionContext.RequestContext.Principal as ClaimsPrincipal;
             var username = authenticatedUser.Claims.FirstOrDefault(x => x.Type == "user_name").Value;
 
@@ -187,6 +194,8 @@ namespace Gordon360.Controllers.Api
             {
                 return NotFound();
             }
+
+            _scheduleControlService.UpdateModifiedTimeStamp(id, localDate);
 
             return Ok(result);
         }
@@ -199,6 +208,7 @@ namespace Gordon360.Controllers.Api
         [Route("")]
         public IHttpActionResult Put([FromBody] MYSCHEDULE mySchedule)
         {
+            DateTime localDate = DateTime.Now;
             if (!ModelState.IsValid || mySchedule == null)
             {
                 string errors = "";
@@ -219,6 +229,13 @@ namespace Gordon360.Controllers.Api
             {
                 return NotFound();
             }
+
+            var authenticatedUser = this.ActionContext.RequestContext.Principal as ClaimsPrincipal;
+            var username = authenticatedUser.Claims.FirstOrDefault(x => x.Type == "user_name").Value;
+
+            var id = _accountService.GetAccountByUsername(username).GordonID;
+
+            _scheduleControlService.UpdateModifiedTimeStamp(id, localDate);
 
             return Ok(result);
         }

--- a/Gordon360/ApiControllers/ScheduleControlController.cs
+++ b/Gordon360/ApiControllers/ScheduleControlController.cs
@@ -9,6 +9,7 @@ using Gordon360.Models.ViewModels;
 using Gordon360.AuthorizationFilters;
 using Gordon360.Static.Names;
 using System;
+using Newtonsoft.Json.Linq;
 using Gordon360.Exceptions.ExceptionFilters;
 using Gordon360.Exceptions.CustomExceptions;
 using System.Collections.Generic;
@@ -64,7 +65,12 @@ namespace Gordon360.Controllers.Api
                 return NotFound();
             }
 
-            return Ok(scheduleControlResult);
+            JObject jresult = JObject.FromObject(scheduleControlResult);
+
+            jresult.Property("gordon_id").Remove();
+
+            return Ok(jresult);
+            
 
         }
 

--- a/Gordon360/ApiControllers/ScheduleControlController.cs
+++ b/Gordon360/ApiControllers/ScheduleControlController.cs
@@ -142,6 +142,9 @@ namespace Gordon360.Controllers.Api
         [Route("description/{value}")]
         public IHttpActionResult UpdateDescription(string value)
         {
+
+            DateTime localDate = DateTime.Now;
+
             // Verify Input
             if (!ModelState.IsValid)
             {
@@ -160,42 +163,12 @@ namespace Gordon360.Controllers.Api
             var authenticatedUser = this.ActionContext.RequestContext.Principal as ClaimsPrincipal;
             var id = authenticatedUser.Claims.FirstOrDefault(x => x.Type == "id").Value;
             _scheduleControlService.UpdateDescription(id, value);
+            _scheduleControlService.UpdateModifiedTimeStamp(id, localDate);
 
             return Ok();
 
         }
 
-        /// <summary>
-        /// Update timestamp of last modified schedule
-        /// </summary>
-        /// <param name="value">Datetime in string</param>
-        /// <returns></returns>
-        [HttpPut]
-        [Route("timestamp/{value}")]
-        public IHttpActionResult UpdateModifiedTimeStamp(string value)
-        {
-            // Verify Input
-            if (!ModelState.IsValid)
-            {
-                string errors = "";
-                foreach (var modelstate in ModelState.Values)
-                {
-                    foreach (var error in modelstate.Errors)
-                    {
-                        errors += "|" + error.ErrorMessage + "|" + error.Exception;
-                    }
-
-                }
-                throw new BadInputException() { ExceptionMessage = errors };
-            }
-
-            var authenticatedUser = this.ActionContext.RequestContext.Principal as ClaimsPrincipal;
-            var id = authenticatedUser.Claims.FirstOrDefault(x => x.Type == "id").Value;
-            _scheduleControlService.UpdateModifiedTimeStamp(id, Convert.ToDateTime(value));
-
-            return Ok();
-
-        }
 
     }
 

--- a/Gordon360/ApiControllers/ScheduleControlController.cs
+++ b/Gordon360/ApiControllers/ScheduleControlController.cs
@@ -47,6 +47,7 @@ namespace Gordon360.Controllers.Api
 
         /// <summary>
         /// Get schedule information of logged in user
+        /// Info one gets: privacy, time last updated, description, and Gordon ID 
         /// </summary>
         /// <returns></returns>
         [HttpGet]
@@ -78,6 +79,7 @@ namespace Gordon360.Controllers.Api
 
         /// <summary>
         /// Get schedule information of specific user
+        /// Info one gets: privacy, time last updated, description, and Gordon ID 
         /// </summary>
         /// <param name="username">username</param>
         /// <returns></returns>

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -246,11 +246,10 @@
             <param name="value">New description</param>
             <returns></returns>
         </member>
-        <member name="M:Gordon360.Controllers.Api.ScheduleControlController.UpdateModifiedTimeStamp(System.String)">
+        <member name="M:Gordon360.Controllers.Api.ScheduleControlController.UpdateModifiedTimeStamp">
             <summary>
             Update timestamp of last modified schedule
             </summary>
-            <param name="value">Datetime in string</param>
             <returns></returns>
         </member>
         <member name="M:Gordon360.Controllers.Api.ProfilesController.Get">

--- a/Gordon360/Services/MyScheduleService.cs
+++ b/Gordon360/Services/MyScheduleService.cs
@@ -83,7 +83,7 @@ namespace Gordon360.Services
         /// Adds a new mySchedule record to storage.
         /// </summary>
         /// <param name="mySchedule">The membership to be added</param>
-        /// <returns>The newly added mySchedule object</returns>
+        /// <returns>The newly added custom event</returns>
         public MYSCHEDULE Add(MYSCHEDULE mySchedule)
         {
 

--- a/Gordon360/Services/MyScheduleService.cs
+++ b/Gordon360/Services/MyScheduleService.cs
@@ -67,9 +67,6 @@ namespace Gordon360.Services
                 throw new ResourceNotFoundException() { ExceptionMessage = "The account was not found." };
             }
 
-            var idParam = new SqlParameter("@GORDON_ID", gordon_id);
-
-            var context = new CCTEntities1();
             var result = _unitOfWork.MyScheduleRepository.GetAll(x => x.GORDON_ID == gordon_id);
             if (result == null)
             {

--- a/README.md
+++ b/README.md
@@ -771,9 +771,9 @@ What is it? Resource that represents information related to schedule.
 
 ##### GET
 
-`api/schedulecontrol` Get the schedulecontrol object of the currently logged in user.
+`api/schedulecontrol` Get the schedulecontrol object of the currently logged in user. Specifically, get the privacy, time last updated, description, and Gordon ID of the currently logged in user's schedule.
 
-`api/schedulecontrol/:username` Get the schedulecontrol object of a user with username `username` as a parameter.
+`api/schedulecontrol/:username` Get the schedulecontrol object of a user with username `username` as a parameter. Specifically, Get the privacy, time last updated, description, and Gordon ID of the user's schedule.
 
 ##### PUT
 

--- a/README.md
+++ b/README.md
@@ -747,23 +747,23 @@ What is it? Resource that represents a customized schedule of user.
 
 ##### GET
 
-`api/myschedule` Get all myschedule objects of the currently logged in user.
+`api/myschedule` Get all custom events of the currently logged in user.
 
-`api/myschedule/:username` Get all myschedule objects of a user with username `username` as a parameter.
+`api/myschedule/:username` Get all custom events of a user with username `username` as a parameter.
 
-`api/myschedule/event/:eventId` Get a specific myschedule object of the currently logged in user with `eventId` as a parameter
+`api/myschedule/event/:eventId` Get a specific custom event of the currently logged in user with `eventId` as a parameter
 
 ##### PUT
 
-`api/myschedule/` Update a myschedule object of the currently logged in user.
+`api/myschedule/` Update a custom event of the currently logged in user.
 
 ##### POST
 
-`api/myschedule/`  Create a myschedule object of the currently logged in user.
+`api/myschedule/`  Create a custom event of the currently logged in user.
 
 ##### DELETE
 
-`api/myschedule/:eventID`  Delete a myschedule object of the currently logged in user.
+`api/myschedule/:eventID`  Delete a custom event of the currently logged in user.
 
 
 ### Schedule Control

--- a/README.md
+++ b/README.md
@@ -781,8 +781,6 @@ What is it? Resource that represents information related to schedule.
 
 `api/schedulecontrol/description/:value` Update a schedule description of the currently logged in user.
 
-`api/schedulecontrol/timestamp/:value` Update a timestamp of last modified schedule of the currently logged in user.
-
 
 ### Victory Promise
 What is it? Resource that represents the user's scores on the four pillars of the victory promise.

--- a/Tests/ApiEndpoints/test_gordon360_pytest.py
+++ b/Tests/ApiEndpoints/test_gordon360_pytest.py
@@ -89,7 +89,6 @@ class Test_allMyScheduleTest(testCase):
         self.url = hostURL + 'api/myschedule/'
         self.token_payload = { 'username':username, 'password':password, 'grant_type':'password' }
         response = api.get(self.session, self.url)
-        print (response.status_code)
 
         if not response.status_code == 200:
             pytest.fail('Expected 200 OK, got {0}.'.format(response.status_code))
@@ -109,8 +108,6 @@ class Test_allMyScheduleTest(testCase):
         self.session = self.createAuthorizedSession(username, password)
         self.url = hostURL + 'api/myschedule/' + leader_username + '/'
         response = api.get(self.session, self.url)
-        print (response.json())
-        print (response.status_code)
 
         if not response.status_code == 200:
             pytest.fail('Expected 200 OK, got {0}.'.format(response.status_code))
@@ -139,8 +136,6 @@ class Test_allMyScheduleTest(testCase):
             'IS_ALLDAY' : 1,
         }
         response = api.postAsJson(self.session, self.url, self.data)
-        print (response.json())
-        print (response.status_code)
         if not response.status_code == 201:
             pytest.fail('Expected 201 Created, got {0}.'.format(response.status_code))
         try:
@@ -154,16 +149,12 @@ class Test_allMyScheduleTest(testCase):
         # delete the test post
         # Expectations:
         # Expected Status Code -- 200 OK.
-        print (response.json()["GORDON_ID"])
-        print (response.json()["EVENT_ID"])
         try:
             self.GordonID = response.json()["GORDON_ID"]
-            print(self.GordonID)
             if self.GordonID == str(my_id_number):
                 response = api.delete(self.session, self.url + str(response.json()["EVENT_ID"]))
         except KeyError:
             pytest.fail('Expected REQUEST_ID in response body, got {0}.'.format(response.json()))
-        print (response.status_code)
         if not response.status_code == 200:
             pytest.fail('Expected 200 OK, got {0}.'.format(response.status_code))
 
@@ -214,8 +205,6 @@ class Test_allMyScheduleTest(testCase):
         except (KeyError, ValueError):
             pytest.fail('Error in setup.')
         response = api.putAsJson(self.session, self.url, self.data)
-        print (response.json())
-        print (response.status_code)
         if not response.status_code == 200:
             pytest.fail('Expected 200 OK, got {0}.'.format(response.status_code))
         try:
@@ -241,8 +230,6 @@ class Test_allScheduleTest(testCase):
         self.session = self.createAuthorizedSession(username, password)
         self.url = hostURL + 'api/schedule/' + username + '/'
         response = api.get(self.session, self.url)
-        print (response.json())
-        print (response.status_code)
 
         if not response.status_code == 200:
             pytest.fail('Expected 200 OK, got {0}.'.format(response.status_code))
@@ -262,8 +249,6 @@ class Test_allScheduleTest(testCase):
         self.session = self.createAuthorizedSession(username, password)
         self.url = hostURL + 'api/schedule/' + leader_username + '/'
         response = api.get(self.session, self.url)
-        print (response.json())
-        print (response.status_code)
 
         if not response.status_code == 200:
             pytest.fail('Expected 200 OK, got {0}.'.format(response.status_code))

--- a/Tests/ApiEndpoints/test_gordon360_pytest.py
+++ b/Tests/ApiEndpoints/test_gordon360_pytest.py
@@ -3,6 +3,7 @@ import warnings
 import string
 import pytest_components as api
 from pytest_components import requests
+from datetime import datetime
 
 # # # # # # # # #
 # Configuration #
@@ -115,6 +116,44 @@ class Test_allScheduleControlTest(testCase):
         except ValueError:
             pytest.fail('Expected Json, got {0}.'.format(response.text))
 
+#    Update a schedule privacy of the currently logged in user.
+#    Endpoint -- api/schedulecontrol/privacy/{value}
+#    Expected Status code -- 200 Ok
+#    Expected Content -- all schedule objects of the currently logged in user.
+
+    def test_schedulecontrol_put_privacy(self):
+        self.session = self.createAuthorizedSession(username, password)
+        self.url = hostURL + 'api/schedulecontrol/privacy/N/'
+        response = api.put(self.session, self.url, 'N')
+        if not response.status_code == 200:
+            pytest.fail('Expected 200 OK, got {0}.'.format(response.status_code))
+
+#    Update a schedule description of the currently logged in user.
+#    Endpoint -- api/schedulecontrol/description/{value}
+#    Expected Status code -- 200 Ok
+#    Expected Content -- all schedule objects of the currently logged in user.
+
+    def test_schedulecontrol_put_description(self):
+        self.session = self.createAuthorizedSession(username, password)
+        self.url = hostURL + 'api/schedulecontrol/description/DOING_TESTS_IGNORE/'
+        response = api.put(self.session, self.url, 'DOING_TESTS_IGNORE')
+        if not response.status_code == 200:
+            pytest.fail('Expected 200 OK, got {0}.'.format(response.status_code))
+
+#    Update a timestamp of last modified schedule of the currently logged in user.
+#    Endpoint -- api/schedulecontrol/timestamp/{value}
+#    Expected Status code -- 200 Ok
+#    Expected Content -- all schedule objects of the currently logged in user.
+
+    def test_schedulecontrol_put_timestamp(self):
+        self.session = self.createAuthorizedSession(username, password)
+        print(str(datetime.now()))
+        self.url = hostURL + 'api/schedulecontrol/timestamp/2019-07-16_14:56:59.000/'
+        response = api.put(self.session, self.url, '2019-07-16_14:56:59.000')
+        print(response.status_code)
+        if not response.status_code == 200:
+            pytest.fail('Expected 200 OK, got {0}.'.format(response.status_code))
+
 
 class Test_allMyScheduleTest(testCase):
 
@@ -161,7 +200,7 @@ class Test_allMyScheduleTest(testCase):
             pytest.fail('Expected Json, got {0}.'.format(response.text))
         assert response.json()[0]["EVENT_ID"] == '1100'
 
-# Verify that an activity leader can create a Guest membership for someone.
+# Create a myschedule object of the currently logged in user.
 
 # Expectations:
 # Endpoints -- api/myschedule/

--- a/Tests/ApiEndpoints/test_gordon360_pytest.py
+++ b/Tests/ApiEndpoints/test_gordon360_pytest.py
@@ -72,6 +72,52 @@ class testCase:
         authorized_session.headers.update({ "Authorization":authorization_header })
         return authorized_session
 
+
+class Test_allScheduleControlTest(testCase):
+
+# # # # # # # # # # # # #
+# SCHEDULECONTROL TESTS #
+# # # # # # # # # # # # #
+
+#    Get the schedulecontrol object of the currently logged in user.
+#    Endpoint -- api/schedulecontrol
+#    Expected Status code -- 200 Ok
+#    Expected Content -- all schedule objects of the currently logged in user.
+
+    def test_get_all_schedulecontrol_objects_of_current_user(self):
+        self.session = self.createAuthorizedSession(username, password)
+        self.url = hostURL + 'api/schedulecontrol/'
+        self.token_payload = { 'username':username, 'password':password, 'grant_type':'password' }
+        response = api.get(self.session, self.url)
+
+        if not response.status_code == 200:
+            pytest.fail('Expected 200 OK, got {0}.'.format(response.status_code))
+        try:
+            response.json()
+        except ValueError:
+            pytest.fail('Expected Json, got {0}.'.format(response.text))
+
+#    Get the schedulecontrol object of a user with username `username` as a parameter.
+#    Endpoint -- api/schedulecontrol/{username}
+#    Expected Status code -- 200 Ok
+#    Expected Content -- all schedule objects of the currently logged in user.
+
+    def test_get_all_schedulecontrol_objects_of_user(self):
+        self.session = self.createAuthorizedSession(username, password)
+        self.url = hostURL + 'api/schedulecontrol/' + leader_username + '/'
+        self.token_payload = { 'username':username, 'password':password, 'grant_type':'password' }
+        response = api.get(self.session, self.url)
+        print(response.json())
+        print(response.status_code)
+
+        if not response.status_code == 200:
+            pytest.fail('Expected 200 OK, got {0}.'.format(response.status_code))
+        try:
+            response.json()
+        except ValueError:
+            pytest.fail('Expected Json, got {0}.'.format(response.text))
+
+
 class Test_allMyScheduleTest(testCase):
 
 
@@ -80,7 +126,7 @@ class Test_allMyScheduleTest(testCase):
 # # # # # # # # # # 
 
 #    Get all myschedule objects of the currently logged in user.
-#    Endpoint -- api/myschedule/{username}
+#    Endpoint -- api/myschedule/
 #    Expected Status code -- 200 Ok
 #    Expected Content -- all schedule objects of the currently logged in user.
     def test_get_all_myschedule_objects_of_current_user(self):

--- a/Tests/ApiEndpoints/test_gordon360_pytest.py
+++ b/Tests/ApiEndpoints/test_gordon360_pytest.py
@@ -68,6 +68,9 @@ description = 'Summer Practicum'
 begintime = '09:00:00.0000000'
 endtime = '17:00:00.0000000'
 
+#Global variable for schedulecontrol test events
+controldescription = "DOING TESTS - IGNORE"
+
 class testCase:
 
     def createAuthorizedSession(self, userLogin, userPassword):
@@ -148,10 +151,16 @@ class Test_allScheduleControlTest(testCase):
 
     def test_schedulecontrol_put_description(self):
         self.session = self.createAuthorizedSession(username, password)
-        self.url = hostURL + 'api/schedulecontrol/description/DOING_TESTS_IGNORE/'
-        response = api.put(self.session, self.url, 'DOING_TESTS_IGNORE')
+        self.url = hostURL + 'api/schedulecontrol/description/' + controldescription + '/'
+        response = api.put(self.session, self.url, controldescription)
         if not response.status_code == 200:
             pytest.fail('Expected 200 OK, got {0}.'.format(response.status_code))
+        self.url = hostURL + 'api/schedulecontrol/'
+        response = api.get(self.session, self.url)
+        if not response.status_code == 200:
+            pytest.fail('Expected 200 OK, got {0}.'.format(response.status_code))
+        assert response.json()["Description"] == controldescription
+
 
 
 class Test_allMyScheduleTest(testCase):

--- a/Tests/ApiEndpoints/test_gordon360_pytest.py
+++ b/Tests/ApiEndpoints/test_gordon360_pytest.py
@@ -245,17 +245,17 @@ class Test_allMyScheduleTest(testCase):
         # The event to modify
         self.predata = {
             'EVENT_ID' : '9999',
-            'GORDON_ID' : '999999097',
-            'LOCATION' : 'KOSC 244',
-            'DESCRIPTION' : 'Summer Practicum',
+            'GORDON_ID' : str(my_id_number),
+            'LOCATION' : location,
+            'DESCRIPTION' : description,
             'MON_CDE' : 'M',
             'TUE_CDE' : 'T',
             'WED_CDE' : 'W',
             'THU_CDE' : 'R',
             'FRI_CDE' : 'F',
             'IS_ALLDAY' : 0,
-            'BEGIN_TIME' : '09:00:00.0000000',
-            'END_TIME' : '17:00:00.0000000',
+            'BEGIN_TIME' : begintime,
+            'END_TIME' : endtime,
         }
         r = api.postAsJson(self.session, self.url, self.predata)
         try:

--- a/Tests/ApiEndpoints/test_gordon360_pytest.py
+++ b/Tests/ApiEndpoints/test_gordon360_pytest.py
@@ -38,8 +38,8 @@ FILE_PATH = '\\gotrain\pref_photos'
 FILE_NAME = 'profile.jpg'
 
 # API 
-#hostURL = 'https://360ApiTrain.gordon.edu/'
-hostURL = 'http://localhost:9999/'
+hostURL = 'https://360ApiTrain.gordon.edu/'
+#hostURL = 'http://localhost:9999/'
 
 # Constants
 LEADERSHIP_POSITIONS = ['CAPT','CODIR','CORD','DIREC','PRES','VICEC','VICEP']

--- a/Tests/ApiEndpoints/test_gordon360_pytest.py
+++ b/Tests/ApiEndpoints/test_gordon360_pytest.py
@@ -70,6 +70,8 @@ endtime = '17:00:00.0000000'
 
 #Global variable for new description for test events
 put_description = 'DOING TESTS - IGNORE'
+shortened_begintime = '09:00:00'
+shortened_endtime = '17:00:00'
 
 class testCase:
 
@@ -295,6 +297,8 @@ class Test_allMyScheduleTest(testCase):
         assert response.json()["GORDON_ID"] == str(my_id_number)
         assert response.json()["LOCATION"] == location
         assert response.json()["DESCRIPTION"] == put_description
+        assert response.json()["BEGIN_TIME"] == shortened_begintime
+        assert response.json()["END_TIME"] == shortened_endtime
 
 
 class Test_allScheduleTest(testCase):

--- a/Tests/ApiEndpoints/test_gordon360_pytest.py
+++ b/Tests/ApiEndpoints/test_gordon360_pytest.py
@@ -61,6 +61,11 @@ leader_password = 'Gordon16'
 leader_id_number = 999999099
 leader_grant_payload = { 'username':leader_username, 'password':leader_password, 'grant_type':'password' }
 
+location = 'KOSC 244'
+description = 'Summer Practicum'
+begintime = '09:00:00.0000000'
+endtime = '17:00:00.0000000'
+
 class testCase:
 
     def createAuthorizedSession(self, userLogin, userPassword):
@@ -140,20 +145,6 @@ class Test_allScheduleControlTest(testCase):
         if not response.status_code == 200:
             pytest.fail('Expected 200 OK, got {0}.'.format(response.status_code))
 
-#    Update a timestamp of last modified schedule of the currently logged in user.
-#    Endpoint -- api/schedulecontrol/timestamp/{value}
-#    Expected Status code -- 200 Ok
-#    Expected Content -- all schedule objects of the currently logged in user.
-
-    def test_schedulecontrol_put_timestamp(self):
-        self.session = self.createAuthorizedSession(username, password)
-        print(str(datetime.now()))
-        self.url = hostURL + 'api/schedulecontrol/timestamp/2019-07-16_14:56:59.000/'
-        response = api.put(self.session, self.url, '2019-07-16_14:56:59.000')
-        print(response.status_code)
-        if not response.status_code == 200:
-            pytest.fail('Expected 200 OK, got {0}.'.format(response.status_code))
-
 
 class Test_allMyScheduleTest(testCase):
 
@@ -170,7 +161,6 @@ class Test_allMyScheduleTest(testCase):
         session = None
         self.session = self.createAuthorizedSession(username, password)
         self.url = hostURL + 'api/myschedule/'
-        self.token_payload = { 'username':username, 'password':password, 'grant_type':'password' }
         response = api.get(self.session, self.url)
 
         if not response.status_code == 200:
@@ -207,14 +197,16 @@ class Test_allMyScheduleTest(testCase):
 # Expected Status Code -- 201 Created.
 # Expected Content -- A Json object with a GORDON_ID attribute.
 
+    
+
     def test_myschedule_post(self):
         session = None
         self.session = self.createAuthorizedSession(username, password)
         self.url = hostURL + 'api/myschedule/'
         self.data = {
-            'GORDON_ID' : '999999097',
-            'LOCATION' : 'KOSC 118',
-            'DESCRIPTION' : "Intro to Prog. Lab",
+            'GORDON_ID' : str(my_id_number),
+            'LOCATION' : location,
+            'DESCRIPTION' : description,
             'TUE_CDE' : 'T',
             'IS_ALLDAY' : 1,
         }

--- a/Tests/ApiEndpoints/test_gordon360_pytest.py
+++ b/Tests/ApiEndpoints/test_gordon360_pytest.py
@@ -218,8 +218,6 @@ class Test_allMyScheduleTest(testCase):
         except ValueError:
             pytest.fail('Expected Json response body, got {0}.'.format(response.text))
         assert response.json()["GORDON_ID"] == str(my_id_number)
-        # Get the object to double check the test actually worked
-        # Expected Status Code -- 200 OK.
 
         # delete the test post
         # Expectations:

--- a/Tests/ApiEndpoints/test_gordon360_pytest.py
+++ b/Tests/ApiEndpoints/test_gordon360_pytest.py
@@ -92,7 +92,8 @@ class Test_allScheduleControlTest(testCase):
 # SCHEDULECONTROL TESTS #
 # # # # # # # # # # # # #
 
-#    Get the schedulecontrol object of the currently logged in user.
+#    Get the privacy, time last updated, description, and Gordon ID 
+#    of the currently logged in user's schedule.
 #    Endpoint -- api/schedulecontrol
 #    Expected Status code -- 200 Ok
 #    Expected Content -- all schedule objects of the currently logged in user.
@@ -109,8 +110,8 @@ class Test_allScheduleControlTest(testCase):
         except ValueError:
             pytest.fail('Expected Json, got {0}.'.format(response.text))
         
-
-#    Get the schedulecontrol object of a user with username `username` as a parameter.
+#    Get the privacy, time last updated, description, and Gordon ID of a user's schedule
+#    with username `username` as a parameter.
 #    Endpoint -- api/schedulecontrol/{username}
 #    Expected Status code -- 200 Ok
 #    Expected Content -- all schedule objects of the currently logged in user.

--- a/Tests/ApiEndpoints/test_gordon360_pytest.py
+++ b/Tests/ApiEndpoints/test_gordon360_pytest.py
@@ -61,6 +61,7 @@ leader_password = 'Gordon16'
 leader_id_number = 999999099
 leader_grant_payload = { 'username':leader_username, 'password':leader_password, 'grant_type':'password' }
 
+# Global variables for myschedule test events
 location = 'KOSC 244'
 description = 'Summer Practicum'
 begintime = '09:00:00.0000000'

--- a/Tests/ApiEndpoints/test_gordon360_pytest.py
+++ b/Tests/ApiEndpoints/test_gordon360_pytest.py
@@ -201,6 +201,24 @@ class Test_allMyScheduleTest(testCase):
         except ValueError:
             pytest.fail('Expected Json, got {0}.'.format(response.text))
         assert response.json()[0]["EVENT_ID"] == '1100'
+        
+#    Get a specific custom event of the currently logged in user with `eventId` as a parameter
+#    Endpoint --  api/myschedule/event/{eventID}
+#    Expected Status code -- 200 Ok
+#    Expected Content -- a specific custom event of the currently logged in user with `eventId` as a parameter
+    def test_get_myschedule_objects_of_id(self):
+        session = None
+        self.session = self.createAuthorizedSession(username, password)
+        self.url = hostURL + 'api/myschedule/event/' + event_id + '/'
+        response = api.get(self.session, self.url)
+
+        if not response.status_code == 200:
+            pytest.fail('Expected 200 OK, got {0}.'.format(response.status_code))
+        try:
+            response.json()
+        except ValueError:
+            pytest.fail('Expected Json, got {0}.'.format(response.text))
+        assert response.json()["EVENT_ID"] == event_id
 
 # Create a custom event of the currently logged in user.
 # Expectations:

--- a/Tests/ApiEndpoints/test_gordon360_pytest.py
+++ b/Tests/ApiEndpoints/test_gordon360_pytest.py
@@ -62,6 +62,7 @@ leader_id_number = 999999099
 leader_grant_payload = { 'username':leader_username, 'password':leader_password, 'grant_type':'password' }
 
 # Global variables for myschedule test events
+event_id = '10000'
 location = 'KOSC 244'
 description = 'Summer Practicum'
 begintime = '09:00:00.0000000'
@@ -103,6 +104,7 @@ class Test_allScheduleControlTest(testCase):
             response.json()
         except ValueError:
             pytest.fail('Expected Json, got {0}.'.format(response.text))
+        
 
 #    Get the schedulecontrol object of a user with username `username` as a parameter.
 #    Endpoint -- api/schedulecontrol/{username}
@@ -170,7 +172,7 @@ class Test_allMyScheduleTest(testCase):
             response.json()
         except ValueError:
             pytest.fail('Expected Json, got {0}.'.format(response.text))
-        assert response.json()[0]["EVENT_ID"] == '10000'
+        assert response.json()[0]["EVENT_ID"] == event_id
         
     
 #    Get all myschedule objects of a user with username `username` as a parameter.
@@ -243,12 +245,12 @@ class Test_allMyScheduleTest(testCase):
         session = None
         self.session = self.createAuthorizedSession(username, password)
         self.url = hostURL + 'api/myschedule/'
-        # The event to modify
-        self.predata = {
-            'EVENT_ID' : '9999',
+        try:
+            self.data = {
+            'EVENT_ID' : event_id,
             'GORDON_ID' : str(my_id_number),
             'LOCATION' : location,
-            'DESCRIPTION' : description,
+            'DESCRIPTION' : 'DOING TESTS - IGNORE',
             'MON_CDE' : 'M',
             'TUE_CDE' : 'T',
             'WED_CDE' : 'W',
@@ -257,24 +259,6 @@ class Test_allMyScheduleTest(testCase):
             'IS_ALLDAY' : 0,
             'BEGIN_TIME' : begintime,
             'END_TIME' : endtime,
-        }
-        r = api.postAsJson(self.session, self.url, self.predata)
-        try:
-            self.GordonID = r.json()['GORDON_ID']
-            # Updated Data
-            self.data = {
-            'EVENT_ID' : '9999',
-            'GORDON_ID' : '999999097',
-            'LOCATION' : 'KOSC 244',
-            'DESCRIPTION' : 'TESTING - JUST IGNORE',
-            'MON_CDE' : 'M',
-            'TUE_CDE' : 'T',
-            'WED_CDE' : 'W',
-            'THU_CDE' : 'R',
-            'FRI_CDE' : 'F',
-            'IS_ALLDAY' : 0,
-            'BEGIN_TIME' : '09:00:00.0000000',
-            'END_TIME' : '17:00:00.0000000',
             }
         except (KeyError, ValueError):
             pytest.fail('Error in setup.')

--- a/Tests/ApiEndpoints/test_gordon360_pytest.py
+++ b/Tests/ApiEndpoints/test_gordon360_pytest.py
@@ -135,6 +135,11 @@ class Test_allScheduleControlTest(testCase):
         response = api.put(self.session, self.url, 'N')
         if not response.status_code == 200:
             pytest.fail('Expected 200 OK, got {0}.'.format(response.status_code))
+        self.url = hostURL + 'api/schedulecontrol/'
+        response = api.get(self.session, self.url)
+        if not response.status_code == 200:
+            pytest.fail('Expected 200 OK, got {0}.'.format(response.status_code))
+        assert response.json()["IsSchedulePrivate"] == 0
 
 #    Update a schedule description of the currently logged in user.
 #    Endpoint -- api/schedulecontrol/description/{value}

--- a/Tests/ApiEndpoints/test_gordon360_pytest.py
+++ b/Tests/ApiEndpoints/test_gordon360_pytest.py
@@ -94,7 +94,6 @@ class Test_allScheduleControlTest(testCase):
 #    Endpoint -- api/schedulecontrol
 #    Expected Status code -- 200 Ok
 #    Expected Content -- all schedule objects of the currently logged in user.
-
     def test_get_all_schedulecontrol_objects_of_current_user(self):
         self.session = self.createAuthorizedSession(username, password)
         self.url = hostURL + 'api/schedulecontrol/'
@@ -113,7 +112,6 @@ class Test_allScheduleControlTest(testCase):
 #    Endpoint -- api/schedulecontrol/{username}
 #    Expected Status code -- 200 Ok
 #    Expected Content -- all schedule objects of the currently logged in user.
-
     def test_get_all_schedulecontrol_objects_of_user(self):
         self.session = self.createAuthorizedSession(username, password)
         self.url = hostURL + 'api/schedulecontrol/' + leader_username + '/'
@@ -127,11 +125,10 @@ class Test_allScheduleControlTest(testCase):
         except ValueError:
             pytest.fail('Expected Json, got {0}.'.format(response.text))
 
-#    Update a schedule privacy of the currently logged in user.
+#    Update schedule privacy of the currently logged in user.
 #    Endpoint -- api/schedulecontrol/privacy/{value}
 #    Expected Status code -- 200 Ok
 #    Expected Content -- all schedule objects of the currently logged in user.
-
     def test_schedulecontrol_put_privacy(self):
         self.session = self.createAuthorizedSession(username, password)
         self.url = hostURL + 'api/schedulecontrol/privacy/N/'
@@ -144,11 +141,10 @@ class Test_allScheduleControlTest(testCase):
             pytest.fail('Expected 200 OK, got {0}.'.format(response.status_code))
         assert response.json()["IsSchedulePrivate"] == 0
 
-#    Update a schedule description of the currently logged in user.
+#    Update the schedule description of the currently logged in user.
 #    Endpoint -- api/schedulecontrol/description/{value}
 #    Expected Status code -- 200 Ok
 #    Expected Content -- all schedule objects of the currently logged in user.
-
     def test_schedulecontrol_put_description(self):
         self.session = self.createAuthorizedSession(username, password)
         self.url = hostURL + 'api/schedulecontrol/description/' + controldescription + '/'
@@ -170,7 +166,7 @@ class Test_allMyScheduleTest(testCase):
 # MYSCHEDULE TESTS #
 # # # # # # # # # # 
 
-#    Get all myschedule objects of the currently logged in user.
+#    Get all custom events of the currently logged in user.
 #    Endpoint -- api/myschedule/
 #    Expected Status code -- 200 Ok
 #    Expected Content -- all schedule objects of the currently logged in user.
@@ -188,8 +184,7 @@ class Test_allMyScheduleTest(testCase):
             pytest.fail('Expected Json, got {0}.'.format(response.text))
         assert response.json()[0]["EVENT_ID"] == event_id
         
-    
-#    Get all myschedule objects of a user with username `username` as a parameter.
+#    Get all custom events of a user with username `username` as a parameter.
 #    Endpoint --  api/myschedule/{username}
 #    Expected Status code -- 200 Ok
 #    Expected Content -- all schedule objects of a user with username `username` as a parameter
@@ -207,15 +202,11 @@ class Test_allMyScheduleTest(testCase):
             pytest.fail('Expected Json, got {0}.'.format(response.text))
         assert response.json()[0]["EVENT_ID"] == '1100'
 
-# Create a myschedule object of the currently logged in user.
-
+# Create a custom event of the currently logged in user.
 # Expectations:
 # Endpoints -- api/myschedule/
 # Expected Status Code -- 201 Created.
 # Expected Content -- A Json object with a GORDON_ID attribute.
-
-    
-
     def test_myschedule_post(self):
         session = None
         self.session = self.createAuthorizedSession(username, password)
@@ -248,13 +239,12 @@ class Test_allMyScheduleTest(testCase):
         if not response.status_code == 200:
             pytest.fail('Expected 200 OK, got {0}.'.format(response.status_code))
 
-# Update a myschedule object of the currently logged in user.
+# Update a custom event of the currently logged in user.
 #    500 Error
 #    Expectations:
 #    Endpoints -- api/myschedule/
 #    Expected Status Code -- 200 OK.
 #    Expected Content -- The Json object with a GORDON_ID attribute.
-
     def test_myschedule_put(self , session=None):
         session = None
         self.session = self.createAuthorizedSession(username, password)

--- a/Tests/ApiEndpoints/test_gordon360_pytest.py
+++ b/Tests/ApiEndpoints/test_gordon360_pytest.py
@@ -107,8 +107,6 @@ class Test_allScheduleControlTest(testCase):
         self.url = hostURL + 'api/schedulecontrol/' + leader_username + '/'
         self.token_payload = { 'username':username, 'password':password, 'grant_type':'password' }
         response = api.get(self.session, self.url)
-        print(response.json())
-        print(response.status_code)
 
         if not response.status_code == 200:
             pytest.fail('Expected 200 OK, got {0}.'.format(response.status_code))

--- a/Tests/ApiEndpoints/test_gordon360_pytest.py
+++ b/Tests/ApiEndpoints/test_gordon360_pytest.py
@@ -68,8 +68,8 @@ description = 'Summer Practicum'
 begintime = '09:00:00.0000000'
 endtime = '17:00:00.0000000'
 
-#Global variable for schedulecontrol test events
-controldescription = "DOING TESTS - IGNORE"
+#Global variable for new description for test events
+put_description = 'DOING TESTS - IGNORE'
 
 class testCase:
 
@@ -147,15 +147,15 @@ class Test_allScheduleControlTest(testCase):
 #    Expected Content -- all schedule objects of the currently logged in user.
     def test_schedulecontrol_put_description(self):
         self.session = self.createAuthorizedSession(username, password)
-        self.url = hostURL + 'api/schedulecontrol/description/' + controldescription + '/'
-        response = api.put(self.session, self.url, controldescription)
+        self.url = hostURL + 'api/schedulecontrol/description/' + put_description + '/'
+        response = api.put(self.session, self.url, put_description)
         if not response.status_code == 200:
             pytest.fail('Expected 200 OK, got {0}.'.format(response.status_code))
         self.url = hostURL + 'api/schedulecontrol/'
         response = api.get(self.session, self.url)
         if not response.status_code == 200:
             pytest.fail('Expected 200 OK, got {0}.'.format(response.status_code))
-        assert response.json()["Description"] == controldescription
+        assert response.json()["Description"] == put_description
 
 
 
@@ -169,7 +169,7 @@ class Test_allMyScheduleTest(testCase):
 #    Get all custom events of the currently logged in user.
 #    Endpoint -- api/myschedule/
 #    Expected Status code -- 200 Ok
-#    Expected Content -- all schedule objects of the currently logged in user.
+#    Expected Content -- all custom events of the currently logged in user.
     def test_get_all_myschedule_objects_of_current_user(self):
         session = None
         self.session = self.createAuthorizedSession(username, password)
@@ -187,7 +187,7 @@ class Test_allMyScheduleTest(testCase):
 #    Get all custom events of a user with username `username` as a parameter.
 #    Endpoint --  api/myschedule/{username}
 #    Expected Status code -- 200 Ok
-#    Expected Content -- all schedule objects of a user with username `username` as a parameter
+#    Expected Content -- all custom events of a user with username `username` as a parameter
     def test_get_all_myschedule_objects_of_user(self):
         session = None
         self.session = self.createAuthorizedSession(username, password)
@@ -224,7 +224,6 @@ class Test_allMyScheduleTest(testCase):
 # Expectations:
 # Endpoints -- api/myschedule/
 # Expected Status Code -- 201 Created.
-# Expected Content -- A Json object with a GORDON_ID attribute.
     def test_myschedule_post(self):
         session = None
         self.session = self.createAuthorizedSession(username, password)
@@ -244,6 +243,8 @@ class Test_allMyScheduleTest(testCase):
         except ValueError:
             pytest.fail('Expected Json response body, got {0}.'.format(response.text))
         assert response.json()["GORDON_ID"] == str(my_id_number)
+        assert response.json()["LOCATION"] == location
+        assert response.json()["DESCRIPTION"] == description
 
         # delete the test post
         # Expectations:
@@ -262,7 +263,7 @@ class Test_allMyScheduleTest(testCase):
 #    Expectations:
 #    Endpoints -- api/myschedule/
 #    Expected Status Code -- 200 OK.
-#    Expected Content -- The Json object with a GORDON_ID attribute.
+#    Expected Content -- The Json object (custom event) with a GORDON_ID attribute.
     def test_myschedule_put(self , session=None):
         session = None
         self.session = self.createAuthorizedSession(username, password)
@@ -272,7 +273,7 @@ class Test_allMyScheduleTest(testCase):
             'EVENT_ID' : event_id,
             'GORDON_ID' : str(my_id_number),
             'LOCATION' : location,
-            'DESCRIPTION' : 'DOING TESTS - IGNORE',
+            'DESCRIPTION' : put_description,
             'MON_CDE' : 'M',
             'TUE_CDE' : 'T',
             'WED_CDE' : 'W',
@@ -292,6 +293,8 @@ class Test_allMyScheduleTest(testCase):
         except ValueError:
             pytest.fail('Expected Json response body, got {0}.'.format(response.text))
         assert response.json()["GORDON_ID"] == str(my_id_number)
+        assert response.json()["LOCATION"] == location
+        assert response.json()["DESCRIPTION"] == put_description
 
 
 class Test_allScheduleTest(testCase):


### PR DESCRIPTION
Here we have four Schedule Control tests. 

- The first test gets all schedule control objects of the currently logged in user. A code of 200 Ok is expected for this test.

- The second test gets all schedule control objects of another user. A code of 200 Ok is expected for this test.

- The third test changes the privacy of the schedule of the currently logged in user. Although the privacy displays as 0 or 1 in the database, Y or N should be used in the url.

- The fourth test changes the description of the schedule of the currently logged in user. Again, the description goes in the url.