### PR TITLE
add missing documentation for MyGordon Table 

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,11 +275,11 @@ A record in this table stores
 - Subject - subject, written by the poster, of the news entry
 - Body - the actual text of the news entry, written by the poster
 - Accepted - whether this entry has been approved to be shown publicly
-- Sent - unknown what this is for
-- thisPastMailing - unknown what this is for
+- Sent - whether the item has been sent
+- thisPastMailing - whether it belongs to this past mailing
 - Entered - when, in datetime format, the post was submitted by the poster
-- fname - not used
-- lname - not used
+- fname - not used (NULL)
+- lname - not used (NULL)
 - ManualExpirationDate - given by the poster, the last day on which this entry should be displayed publicly
 
 ##### StudentNewsCategory


### PR DESCRIPTION
Small update to README to fix some gaps in the documentation of the MyGordon Table. 
To be sure I had the right idea I cross-checked this with the database and the info stored in the src\services\news.js file in the IU. 