### PR TITLE
(S20) "Delete News" API Endpoint

### DIFF
--- a/Gordon360/ApiControllers/MembershipRequestController.cs
+++ b/Gordon360/ApiControllers/MembershipRequestController.cs
@@ -259,8 +259,8 @@ namespace Gordon360.Controllers.Api
         /// <summary>
         /// Sets the membership request to Denied
         /// </summary>
-        /// <param name="id">The id of the membership reuqest in question.</param>
-        /// <returns>If successful: THe updated membership request wrapped in an OK Http status code.</returns>
+        /// <param name="id">The id of the membership request in question.</param>
+        /// <returns>If successful: The updated membership request wrapped in an OK Http status code.</returns>
         [HttpPost]
         [Route("{id}/deny")]
         [StateYourBusiness(operation = Operation.DENY_ALLOW, resource = Resource.MEMBERSHIP_REQUEST)]
@@ -290,7 +290,7 @@ namespace Gordon360.Controllers.Api
             return Ok(result);
         }
         /// <summary>
-        /// Delets a membership request
+        /// Deletes a membership request
         /// </summary>
         /// <param name="id">The id of the membership request to delete</param>
         /// <returns>The deleted object</returns>

--- a/Gordon360/ApiControllers/NewsController.cs
+++ b/Gordon360/ApiControllers/NewsController.cs
@@ -153,6 +153,7 @@ namespace Gordon360.Controllers.Api
         /// <summary>Deletes a news item from the database</summary>
         /// <param name="newsID">The id of the news item to delete</param>
         /// <returns>The deleted news item</returns>
+        /// <remarks>The news item must be authored by the user and must not be expired</remarks>
         [HttpDelete]
         [Route("{newsID}")]
         [StateYourBusiness(operation = Operation.DELETE, resource = Resource.NEWS)]

--- a/Gordon360/ApiControllers/NewsController.cs
+++ b/Gordon360/ApiControllers/NewsController.cs
@@ -2,19 +2,17 @@
 using Gordon360.Repositories;
 using Gordon360.Services;
 using Gordon360.Models;
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Web;
 using System.Web.Http;
 using System.Security.Claims;
 using Gordon360.Exceptions.ExceptionFilters;
+using Gordon360.AuthorizationFilters;
 
 namespace Gordon360.Controllers.Api
 {
-    [Authorize]
-    [CustomExceptionFilter]
     [RoutePrefix("api/news")]
+    [CustomExceptionFilter]
+    [StateYourBusiness]
     public class NewsController : ApiController
     {
         private INewsService _newsService;
@@ -151,6 +149,32 @@ namespace Gordon360.Controllers.Api
             return Created("News", result);
         }
 
+        /// <summary>
+        /// Deletes a news item from the database
+        /// </summary>
+        /// <param name="newsID">The id of the news item to delete</param>
+        /// <returns></returns>
+        [HttpDelete]
+        [Route("")]
+        public IHttpActionResult Delete([FromBody] int newsID)
+        {
+            // Get authenticated username/id
+            var authenticatedUser = this.ActionContext.RequestContext.Principal as ClaimsPrincipal;
+            var username = authenticatedUser.Claims.FirstOrDefault(x => x.Type == "user_name").Value;
+            var id = _accountService.GetAccountByUsername(username).GordonID;
+            
+            
+            var result = _newsService.DeleteNews(id, newsID);
+            return Ok(result);
 
+            // Call appropriate service
+            //var result = _newsService.DeleteNews(newsID, username, id);
+            //if (result == null)
+            //{
+            //    return NotFound();
+            //}
+            //return Ok(result);
+        }
+        
     }
 }

--- a/Gordon360/AuthorizationFilters/StateYourBusiness.cs
+++ b/Gordon360/AuthorizationFilters/StateYourBusiness.cs
@@ -52,8 +52,9 @@ namespace Gordon360.AuthorizationFilters
                 user_id = authenticatedUser.Claims.FirstOrDefault(x => x.Type == "id").Value;
                 user_name = authenticatedUser.Claims.FirstOrDefault(x => x.Type == "user_name").Value;
 
-                System.Diagnostics.Debug.WriteLine("User name: " + user_name);
-                System.Diagnostics.Debug.WriteLine("User Position: " + user_position);
+                // Keeping these for now commented out as more permissions testing needs to be done in future
+                //System.Diagnostics.Debug.WriteLine("User name: " + user_name);
+                //System.Diagnostics.Debug.WriteLine("User Position: " + user_position);
 
                 if (user_position == Position.SUPERADMIN)
                 {
@@ -71,7 +72,6 @@ namespace Gordon360.AuthorizationFilters
            
             // Can the user perform the operation on the resource?
             isAuthorized = canPerformOperation(resource, operation);
-            System.Diagnostics.Debug.WriteLine(isAuthorized);
             if (!isAuthorized)
             {
                 actionContext.Response = new HttpResponseMessage(System.Net.HttpStatusCode.Unauthorized);
@@ -563,7 +563,6 @@ namespace Gordon360.AuthorizationFilters
         }
         private bool canDelete(string resource)
         {
-            System.Diagnostics.Debug.WriteLine("can delete resource?: " + resource);
             switch (resource)
             {
                 case Resource.SHIFT:

--- a/Gordon360/AuthorizationFilters/StateYourBusiness.cs
+++ b/Gordon360/AuthorizationFilters/StateYourBusiness.cs
@@ -18,7 +18,7 @@ namespace Gordon360.AuthorizationFilters
      * Proceed at your own risk. If you can understand this code, you can understand the whole project. 
      * 
      * 1st Observation: You can't authorize access to a resource that isn't owned by someone. Resources like Sessions, Participations,
-     * and Activity Definitions are accessbile by anyone.
+     * and Activity Definitions are accessibile by anyone.
      * 2nd Observation: To Authorize someone to perform an action on a resource, you need to know the following:
      * 1. Who is to be authorized? 2.What resource are they trying to access? 3. What operation are they trying to make on the resource?
      * This "algorithm" uses those three points and decides through a series of switch statements if the current user
@@ -65,12 +65,11 @@ namespace Gordon360.AuthorizationFilters
                 }
             }
            
-            // Can the user perfom the operation on the resource?
+            // Can the user perform the operation on the resource?
             isAuthorized = canPerformOperation(resource, operation);
             if(!isAuthorized)
             {
                 actionContext.Response = new HttpResponseMessage(System.Net.HttpStatusCode.Unauthorized);
-                
             }
 
             base.OnActionExecuting(actionContext);
@@ -174,6 +173,8 @@ namespace Gordon360.AuthorizationFilters
                     {
                         return true;
                     }
+                case Resource.NEWS:
+                    return true;
                 default: return false;
                     
             }
@@ -268,6 +269,10 @@ namespace Gordon360.AuthorizationFilters
                         return true;
                     }
                 case Resource.GROUP_ADMIN_BY_ACTIVITY:
+                    {
+                        return true;
+                    }
+                case Resource.NEWS:
                     {
                         return true;
                     }
@@ -606,6 +611,8 @@ namespace Gordon360.AuthorizationFilters
                     return false;
                 case Resource.ADMIN:
                     return false;
+                case Resource.NEWS:
+                    return false; // temporary
                 default: return false;
             }
         }

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -284,11 +284,17 @@
         </member>
         <member name="M:Gordon360.Controllers.Api.NewsController.GetNewsPersonalUnapproved">
             Call the service that gets all unapproved student news entries (by a particular user)
-            not yet expired, filtering
-            out the expired by comparing 2 weeks past date entered to current date
+            not yet expired, filtering out the expired news
         </member>
         <member name="M:Gordon360.Controllers.Api.NewsController.Post(Gordon360.Models.StudentNews)">
             Create a new news item to be added to the database
+        </member>
+        <member name="M:Gordon360.Controllers.Api.NewsController.Delete(System.Int32)">
+            <summary>
+            Deletes a news item from the database
+            </summary>
+            <param name="newsID">The id of the news item to delete</param>
+            <returns></returns>
         </member>
         <member name="M:Gordon360.Controllers.Api.ContentManagementController.GetSliderContent">
             <summary>Get all the slider content for the dashboard slider</summary>
@@ -725,6 +731,12 @@
             </summary>
         </member>
         <member name="M:Gordon360.Repositories.GenericRepository`1.#ctor(Gordon360.Models.CCTEntities1)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Gordon360.Repositories.GenericRepository`1" /> class.
+            </summary>
+            <param name="context">The context for the repository</param>
+        </member>
+        <member name="M:Gordon360.Repositories.GenericRepository`1.#ctor(Gordon360.Models.MyGordonEntities)">
             <summary>
                 Initializes a new instance of the <see cref="T:Gordon360.Repositories.GenericRepository`1" /> class.
             </summary>
@@ -1220,7 +1232,7 @@
             <summary>
             Execute the sql query on the StudentTimesheets database
             </summary>
-            <param name="query">An sql statment. Can be a stored procedure or even a simple SELECT statment</param>
+            <param name="query">An sql statement. Can be a stored procedure or even a simple SELECT statment</param>
             <param name="parameters">Parameters to pass into the stored procedure</param>
             <returns></returns>
         </member>
@@ -1366,6 +1378,14 @@
             <param name="sched">The schedule information</param>
             <returns>The original schedule</returns>
         </member>
+        <member name="M:Gordon360.Services.NewsService.GetNewsPersonalUnapproved(System.String,System.String)">
+            <summary>
+            Gets unapproved unexpired news submitted by user.
+            </summary>
+            <param name="id">user id</param>
+            <param name="username">username</param>
+            <returns>Result of query</returns>
+        </member>
         <member name="M:Gordon360.Services.NewsService.SubmitNews(Gordon360.Models.StudentNews,System.String,System.String)">
             <summary>
             Adds a news item record to storage.
@@ -1375,12 +1395,27 @@
             <param name="id">id</param>
             <returns>The newly added Membership object</returns>
         </member>
+        <member name="M:Gordon360.Services.NewsService.DeleteNews(System.String,System.Int32)">
+            <summary>
+            (Service) Deletes a news item from the database
+            </summary>
+            <param name="id">The id of the requester</param>
+            <param name="newsID">The id of the news item to delete</param>
+            <returns></returns>
+        </member>
         <member name="M:Gordon360.Services.NewsService.ValidateNewsItem(Gordon360.Models.StudentNews)">
             <summary>
             Helper method to validate a news item
             </summary>
             <param name="newsItem">The news item to validate</param>
             <returns>True if valid. Throws ResourceNotFoundException if not. Exception is caught in an Exception Filter</returns>
+        </member>
+        <member name="M:Gordon360.Services.NewsService.VerifyAccount(System.String)">
+            <summary>
+            Verifies that a student account exists
+            </summary>
+            <param name="id">The id of the student</param>
+            <returns>true if account exists, ResourceNotFoundException if null</returns>
         </member>
         <member name="M:Gordon360.Services.ProfileService.GetStudentProfileByUsername(System.String)">
             <summary>

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -290,11 +290,9 @@
             Create a new news item to be added to the database
         </member>
         <member name="M:Gordon360.Controllers.Api.NewsController.Delete(System.Int32)">
-            <summary>
-            Deletes a news item from the database
-            </summary>
+            <summary>Deletes a news item from the database</summary>
             <param name="newsID">The id of the news item to delete</param>
-            <returns></returns>
+            <returns>The deleted news item</returns>
         </member>
         <member name="M:Gordon360.Controllers.Api.ContentManagementController.GetSliderContent">
             <summary>Get all the slider content for the dashboard slider</summary>
@@ -353,12 +351,12 @@
             <summary>
             Sets the membership request to Denied
             </summary>
-            <param name="id">The id of the membership reuqest in question.</param>
-            <returns>If successful: THe updated membership request wrapped in an OK Http status code.</returns>
+            <param name="id">The id of the membership request in question.</param>
+            <returns>If successful: The updated membership request wrapped in an OK Http status code.</returns>
         </member>
         <member name="M:Gordon360.Controllers.Api.MembershipRequestController.Delete(System.Int32)">
             <summary>
-            Delets a membership request
+            Deletes a membership request
             </summary>
             <param name="id">The id of the membership request to delete</param>
             <returns>The deleted object</returns>
@@ -1378,6 +1376,13 @@
             <param name="sched">The schedule information</param>
             <returns>The original schedule</returns>
         </member>
+        <member name="M:Gordon360.Services.NewsService.Get(System.Int32)">
+            <summary>
+            Gets a news item entity by id
+            </summary>
+            <param name="newsID">The SNID (id of news item)</param>
+            <returns>The news item</returns>
+        </member>
         <member name="M:Gordon360.Services.NewsService.GetNewsPersonalUnapproved(System.String,System.String)">
             <summary>
             Gets unapproved unexpired news submitted by user.
@@ -1395,13 +1400,12 @@
             <param name="id">id</param>
             <returns>The newly added Membership object</returns>
         </member>
-        <member name="M:Gordon360.Services.NewsService.DeleteNews(System.String,System.Int32)">
+        <member name="M:Gordon360.Services.NewsService.DeleteNews(System.Int32)">
             <summary>
             (Service) Deletes a news item from the database
             </summary>
-            <param name="id">The id of the requester</param>
             <param name="newsID">The id of the news item to delete</param>
-            <returns></returns>
+            <returns>The deleted news item</returns>
         </member>
         <member name="M:Gordon360.Services.NewsService.ValidateNewsItem(Gordon360.Models.StudentNews)">
             <summary>

--- a/Gordon360/Exceptions/CustomExceptionFilter.cs
+++ b/Gordon360/Exceptions/CustomExceptionFilter.cs
@@ -45,6 +45,17 @@ namespace Gordon360.Exceptions.ExceptionFilters
                     Content = new StringContent(exception.ExceptionMessage)
                 };
             }
+
+            // UNAUTHORIZED ACCESS EXCEPTION
+            else if (actionExecutedContext.Exception is UnauthorizedAccessException)
+            {
+                var exception = actionExecutedContext.Exception as UnauthorizedAccessException;
+                actionExecutedContext.Response = new HttpResponseMessage()
+                {
+                    StatusCode = System.Net.HttpStatusCode.Unauthorized,
+                    Content = new StringContent(exception.ExceptionMessage)
+                };
+            }
         }
     }
 }

--- a/Gordon360/Exceptions/CustomExceptionFilter.cs
+++ b/Gordon360/Exceptions/CustomExceptionFilter.cs
@@ -1,27 +1,30 @@
-﻿using System;
-using System.Net.Http;
+﻿using System.Net.Http;
 using System.Web.Http.Filters;
 using Gordon360.Exceptions.CustomExceptions;
 
+/// <summary>
+/// These exception filters catch unhandled exceptions and convert them
+/// into HTTP Responses
+/// </summary>
 namespace Gordon360.Exceptions.ExceptionFilters
 {
     public class CustomExceptionFilter : ExceptionFilterAttribute
     {
         public override void OnException(HttpActionExecutedContext actionExecutedContext)
         {
-            
+            // RESOURCE NOT FOUND
             if (actionExecutedContext.Exception is ResourceNotFoundException)
             {
                 var exception = actionExecutedContext.Exception as ResourceNotFoundException;
                 actionExecutedContext.Response = new HttpResponseMessage()
                 {
-
                     StatusCode = System.Net.HttpStatusCode.NotFound,
                     Content = new StringContent(exception.ExceptionMessage),
-                    ReasonPhrase = "LOL"
+                    //ReasonPhrase = "LOL"
                 };
             }
 
+            // RESOURCE CREATION CONFLICT
             else if (actionExecutedContext.Exception is ResourceCreationException)
             {
                 var exception = actionExecutedContext.Exception as ResourceCreationException;
@@ -32,6 +35,7 @@ namespace Gordon360.Exceptions.ExceptionFilters
                 };
             }
 
+            // BAD INPUT
             else if( actionExecutedContext.Exception is BadInputException)
             {
                 var exception = actionExecutedContext.Exception as BadInputException;

--- a/Gordon360/Exceptions/CustomExceptions.cs
+++ b/Gordon360/Exceptions/CustomExceptions.cs
@@ -16,4 +16,8 @@ namespace Gordon360.Exceptions.CustomExceptions
     {
         public string ExceptionMessage { get; set; }
     }
+    public class UnauthorizedAccessException : Exception
+    {
+        public string ExceptionMessage { get; set; }
+    }
 }

--- a/Gordon360/Exceptions/CustomExceptions.cs
+++ b/Gordon360/Exceptions/CustomExceptions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 // <summary>
-// Namespace where we will define custom exceptions to be throwl later on.
+// Namespace where we will define custom exceptions to be thrown later on.
 // </summary>
 namespace Gordon360.Exceptions.CustomExceptions
 {
@@ -8,7 +8,6 @@ namespace Gordon360.Exceptions.CustomExceptions
     {
         public string ExceptionMessage { get; set; }
     }
-
     public class ResourceCreationException : Exception
     {
         public string ExceptionMessage { get; set; }

--- a/Gordon360/Gordon360.csproj
+++ b/Gordon360/Gordon360.csproj
@@ -276,7 +276,7 @@
       <DependentUpon>CCT_DB_Models.tt</DependentUpon>
     </Compile>
     <Compile Include="Models\Countries.cs">
-      <DependentUpon>CCT_DB_Models.tt</DependentUpon>
+      <DependentUpon>MyGordon_DB_Models.tt</DependentUpon>
     </Compile>
     <Compile Include="Models\COURSES_FOR_PROFESSOR_Result.cs">
       <DependentUpon>CCT_DB_Models.tt</DependentUpon>
@@ -604,6 +604,16 @@
       <DependentUpon>CCT_DB_Models.edmx</DependentUpon>
       <LastGenOutput>CCT_DB_Models.cs</LastGenOutput>
     </Content>
+    <Content Include="Models\MyGordon_DB_Models.Context.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <DependentUpon>MyGordon_DB_Models.edmx</DependentUpon>
+      <LastGenOutput>MyGordon_DB_Models.Context.cs</LastGenOutput>
+    </Content>
+    <Content Include="Models\MyGordon_DB_Models.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <DependentUpon>MyGordon_DB_Models.edmx</DependentUpon>
+      <LastGenOutput>MyGordon_DB_Models.cs</LastGenOutput>
+    </Content>
     <Content Include="Models\StudentTimesheet_DB_Models.edmx.diagram">
       <DependentUpon>StudentTimesheet_DB_Models.edmx</DependentUpon>
     </Content>
@@ -627,16 +637,6 @@
     <EmbeddedResource Include="version.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </EmbeddedResource>
-    <Content Include="Models\MyGordon_DB_Models.Context.tt">
-      <Generator>TextTemplatingFileGenerator</Generator>
-      <DependentUpon>MyGordon_DB_Models.edmx</DependentUpon>
-      <LastGenOutput>MyGordon_DB_Models.Context.cs</LastGenOutput>
-    </Content>
-    <Content Include="Models\MyGordon_DB_Models.tt">
-      <Generator>TextTemplatingFileGenerator</Generator>
-      <DependentUpon>MyGordon_DB_Models.edmx</DependentUpon>
-      <LastGenOutput>MyGordon_DB_Models.cs</LastGenOutput>
-    </Content>
     <Content Include="Models\StudentTimesheet_DB_Models.Context.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <DependentUpon>StudentTimesheet_DB_Models.edmx</DependentUpon>

--- a/Gordon360/Gordon360.csproj
+++ b/Gordon360/Gordon360.csproj
@@ -450,7 +450,7 @@
     <Compile Include="Models\STUDENT_COURSES_BY_ID_NUM_AND_SESS_CDE_Result.cs">
       <DependentUpon>CCT_DB_Models.tt</DependentUpon>
     </Compile>
-	    <!-- <Compile Include="Models\STUDENT_JOBS_PER_ID_NUM_Result.cs" /> -->
+    <!-- <Compile Include="Models\STUDENT_JOBS_PER_ID_NUM_Result.cs" /> -->
     <Compile Include="Models\student_timesheets.cs">
       <DependentUpon>StudentTimesheet_DB_Models.tt</DependentUpon>
     </Compile>
@@ -506,7 +506,7 @@
     <Compile Include="AuthorizationServer\CustomJWTFormat.cs" />
     <Compile Include="AuthorizationServer\TokenIssuer.cs" />
     <Compile Include="Exceptions\CustomExceptions.cs" />
-    <Compile Include="Exceptions\CustomExcpetionFilter.cs" />
+    <Compile Include="Exceptions\CustomExceptionFilter.cs" />
     <Compile Include="Models\Metadata.cs" />
     <Compile Include="Models\ModelPartialClasses.cs" />
     <Compile Include="Models\ViewModels\BasicInfoViewModel.cs" />

--- a/Gordon360/Models/MyGordon_DB_Models.edmx
+++ b/Gordon360/Models/MyGordon_DB_Models.edmx
@@ -50,7 +50,6 @@
         <EntityType Name="StudentNews">
           <Key>
             <PropertyRef Name="SNID" />
-            <PropertyRef Name="categoryID" />
           </Key>
           <Property Name="SNID" Type="int" StoreGeneratedPattern="Identity" Nullable="false" />
           <Property Name="ADUN" Type="varchar" MaxLength="50" Nullable="false" />
@@ -642,7 +641,6 @@ warning 6002: The table/view 'MyGordon.dbo.view_cct_student' does not have a pri
         <EntityType Name="StudentNews">
           <Key>
             <PropertyRef Name="SNID" />
-            <PropertyRef Name="categoryID" />
           </Key>
           <Property Name="SNID" Type="Int32" Nullable="false" annotation:StoreGeneratedPattern="Identity" />
           <Property Name="ADUN" Type="String" MaxLength="50" FixedLength="false" Unicode="false" Nullable="false" />

--- a/Gordon360/Models/MyGordon_DB_Models.edmx.diagram
+++ b/Gordon360/Models/MyGordon_DB_Models.edmx.diagram
@@ -4,7 +4,7 @@
   <edmx:Designer xmlns="http://schemas.microsoft.com/ado/2009/11/edmx">
     <!-- Diagram content (shape and connector positions) -->
     <edmx:Diagrams>
-      <Diagram DiagramId="9a0d4474e14742d28f63b6954fa1ccbb" Name="Diagram1">
+      <Diagram DiagramId="8d27e9f10105446b9eeee991b5aca304" Name="Diagram1">
         <EntityTypeShape EntityType="Gordon360.ChapelSummary" Width="1.5" PointX="5.75" PointY="0.75" IsExpanded="true" />
         <EntityTypeShape EntityType="Gordon360.dtproperties" Width="1.5" PointX="0.75" PointY="5.75" IsExpanded="true" />
         <EntityTypeShape EntityType="Gordon360.StudentNews" Width="1.5" PointX="3" PointY="1" IsExpanded="true" />

--- a/Gordon360/Repositories/GenericRepository.cs
+++ b/Gordon360/Repositories/GenericRepository.cs
@@ -15,6 +15,7 @@ namespace Gordon360.Repositories
         ///     The database context for the repository
         /// </summary>
         private readonly CCTEntities1 _context;
+        private readonly MyGordonEntities _myGordonCtx;
 
         /// <summary>
         ///     The data set of the repository
@@ -29,6 +30,18 @@ namespace Gordon360.Repositories
         {
             _context = context;
             _dbSet = _context.Set<T>();
+            System.Diagnostics.Debug.WriteLine("CCT Context");
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="GenericRepository{T}" /> class.
+        /// </summary>
+        /// <param name="context">The context for the repository</param>
+        public GenericRepository(MyGordonEntities context)
+        {
+            _myGordonCtx = context;
+            _dbSet = _myGordonCtx.Set<T>();
+            System.Diagnostics.Debug.WriteLine("MyGordon Context");
         }
 
         /// <summary>
@@ -37,6 +50,8 @@ namespace Gordon360.Repositories
         /// <returns>All entities</returns>
         public T GetById(int id)
         {
+            System.Diagnostics.Debug.WriteLine("_dbSet: ");
+            System.Diagnostics.Debug.WriteLine(_dbSet);
             return _dbSet.Find(id);
         }
 

--- a/Gordon360/Repositories/GenericRepository.cs
+++ b/Gordon360/Repositories/GenericRepository.cs
@@ -30,7 +30,6 @@ namespace Gordon360.Repositories
         {
             _context = context;
             _dbSet = _context.Set<T>();
-            System.Diagnostics.Debug.WriteLine("CCT Context");
         }
 
         /// <summary>
@@ -41,7 +40,6 @@ namespace Gordon360.Repositories
         {
             _myGordonCtx = context;
             _dbSet = _myGordonCtx.Set<T>();
-            System.Diagnostics.Debug.WriteLine("MyGordon Context");
         }
 
         /// <summary>
@@ -50,8 +48,6 @@ namespace Gordon360.Repositories
         /// <returns>All entities</returns>
         public T GetById(int id)
         {
-            System.Diagnostics.Debug.WriteLine("_dbSet: ");
-            System.Diagnostics.Debug.WriteLine(_dbSet);
             return _dbSet.Find(id);
         }
 

--- a/Gordon360/Repositories/IUnitOfWork.cs
+++ b/Gordon360/Repositories/IUnitOfWork.cs
@@ -38,8 +38,9 @@ namespace Gordon360.Repositories
         IRepository<INSTRUCTOR_COURSES_BY_ID_NUM_AND_SESS_CDE_Result> FacultyScheduleRepository { get; }
         IRepository<VICTORY_PROMISE_BY_STUDENT_ID_Result> VictoryPromiseByStudentIDRepository { get; }
         //IRepository<STUDENT_JOBS_PER_ID_NUM_Result> StudentEmploymentByStudentIDRepository { get; }
-        IRepository<StudentNewsViewModel> StudentNewsRepository { get; }
-        IRepository<StudentNewsCategoryViewModel> StudentNewsCategoryRepository { get; }
+
+        IRepository<StudentNews> StudentNewsRepository { get; }
+        IRepository<StudentNewsCategory> StudentNewsCategoryRepository { get; }
 
         bool Save();
 

--- a/Gordon360/Repositories/UnitOfWork.cs
+++ b/Gordon360/Repositories/UnitOfWork.cs
@@ -37,14 +37,16 @@ namespace Gordon360.Repositories
         private IRepository<DiningInfo> _DiningInfoRepository;
         private IRepository<ERROR_LOG> _ErrorLogRepository;
         private IRepository<Schedule_Control> _ScheduleControlRepository;
-        private IRepository<StudentNewsViewModel> _StudentNewsRepository;
-        private IRepository<StudentNewsCategoryViewModel> _StudentNewsCategoryRepository;
+        private IRepository<StudentNews> _StudentNewsRepository;
+        private IRepository<StudentNewsCategory> _StudentNewsCategoryRepository;
 
         private CCTEntities1 _context;
+        private MyGordonEntities _myGordonCtx;
 
         public UnitOfWork()
         {
             _context = new CCTEntities1();
+            _myGordonCtx = new MyGordonEntities();
         }
         public IRepository<Student> StudentRepository
         {
@@ -155,13 +157,13 @@ namespace Gordon360.Repositories
         {
             get { return _ErrorLogRepository ?? (_ErrorLogRepository = new GenericRepository<ERROR_LOG>(_context)); }
         }
-        public IRepository<StudentNewsViewModel> StudentNewsRepository
+        public IRepository<StudentNews> StudentNewsRepository
         {
-            get { return _StudentNewsRepository ?? (_StudentNewsRepository = new GenericRepository<StudentNewsViewModel>(_context)); }
+            get { return _StudentNewsRepository ?? (_StudentNewsRepository = new GenericRepository<StudentNews>(_myGordonCtx)); }
         }
-        public IRepository<StudentNewsCategoryViewModel> StudentNewsCategoryRepository
+        public IRepository<StudentNewsCategory> StudentNewsCategoryRepository
         {
-            get { return _StudentNewsCategoryRepository ?? (_StudentNewsCategoryRepository = new GenericRepository<StudentNewsCategoryViewModel>(_context)); }
+            get { return _StudentNewsCategoryRepository ?? (_StudentNewsCategoryRepository = new GenericRepository<StudentNewsCategory>(_myGordonCtx)); }
         }
         public IRepository<Save_Rides> RideRepository
         {
@@ -178,6 +180,7 @@ namespace Gordon360.Repositories
             try
             {
                 _context.SaveChanges();
+                _myGordonCtx.SaveChanges();
             }
             catch (DbEntityValidationException ex)
             {

--- a/Gordon360/Services/ComplexQueries/RawSqlQuery.cs
+++ b/Gordon360/Services/ComplexQueries/RawSqlQuery.cs
@@ -30,7 +30,7 @@ namespace Gordon360.Services.ComplexQueries
         /// <summary>
         /// Execute the sql query on the StudentTimesheets database
         /// </summary>
-        /// <param name="query">An sql statment. Can be a stored procedure or even a simple SELECT statment</param>
+        /// <param name="query">An sql statement. Can be a stored procedure or even a simple SELECT statment</param>
         /// <param name="parameters">Parameters to pass into the stored procedure</param>
         /// <returns></returns>
         public static IEnumerable<T> StudentTimesheetQuery(string query, params object[] parameters)

--- a/Gordon360/Services/NewsService.cs
+++ b/Gordon360/Services/NewsService.cs
@@ -164,6 +164,7 @@ namespace Gordon360.Services
         /// </summary>
         /// <param name="newsID">The id of the news item to delete</param>
         /// <returns>The deleted news item</returns>
+        /// <remarks>The news item must be authored by the user and must not be expired</remarks>
         public StudentNews DeleteNews(int newsID)
         {
             var newsItem = _unitOfWork.StudentNewsRepository.GetById(newsID);
@@ -172,6 +173,11 @@ namespace Gordon360.Services
             {
                 throw new ResourceNotFoundException() { ExceptionMessage = "The news item was not found." };
             }
+            // DateTime of date entered is nullable, so we need to check that here before comparing
+            // If the entered date is null we shouldn't allow deletion to be safe
+            // Note: This check has been duplicated from StateYourBusiness because we do not SuperAdmins
+            //    to be able to delete expired news, this should be fixed eventually by removing some of
+            //    the SuperAdmin permissions that are not explicitly given
             if(newsItem.Entered == null)
             {
                 throw new ResourceNotFoundException() { ExceptionMessage = "The news item date could not be verified." };
@@ -186,39 +192,6 @@ namespace Gordon360.Services
             var result = _unitOfWork.StudentNewsRepository.Delete(newsItem);
             _unitOfWork.Save();
             return result;
-
-            //VerifyAccount(id);
-
-            //var newsItem = _unitOfWork.StudentNewsRepository.GetById(newsID);
-            //if(newsItem == null)
-            //{
-            //    throw new ResourceNotFoundException() { ExceptionMessage = "The news item does not exist" };
-            //}
-            //if(newsItem.ADUN != username)
-            //{
-
-            //}
-            //var result = _unitOfWork.StudentNewsRepository.Delete(newsItem);
-            //return result;
-            //return newsItem;
-
-            // TODO: Eventually, there should be a check that the user has authored this posting
-            // so that the API can return a 403 Forbidden instead of just doing nothing
-            // (the SQL procedure itself safeguards that this cannot be done)
-            // to do this a NEWS_ITEM procedure of some sort will need to be made to select single item by SNID
-
-            // SQL Parameters
-            //var SNIDParam = new SqlParameter("@SNID", newsID);
-            //var usernameParam = new SqlParameter("@Username", username);
-
-            // Run stored procedure
-            //var result = RawSqlQuery<StudentNewsViewModel>.query("DELETE_NEWS_ITEM @SNID, @Username", SNIDParam, usernameParam);
-            //if (result == null)
-            //{
-            //    throw new ResourceNotFoundException() { ExceptionMessage = "The news item does not exist" };
-            //}
-
-            //return new StudentNewsViewModel();
         }
 
         /// <summary>

--- a/Gordon360/Services/NewsService.cs
+++ b/Gordon360/Services/NewsService.cs
@@ -1,4 +1,5 @@
 ﻿using Gordon360.Exceptions.CustomExceptions;
+using Gordon360.Exceptions.ExceptionFilters;
 using Gordon360.Models;
 using Gordon360.Models.ViewModels;
 using Gordon360.Repositories;
@@ -6,9 +7,6 @@ using Gordon360.Services.ComplexQueries;
 using System;
 using System.Collections.Generic;
 using System.Data.SqlClient;
-using System.Diagnostics;
-using System.Linq;
-using System.Web;
 
 namespace Gordon360.Services
 {
@@ -133,13 +131,7 @@ namespace Gordon360.Services
             // Not currently used
             ValidateNewsItem(newsItem);
 
-            // Verify account
-            var _unitOfWork = new UnitOfWork();
-            var query = _unitOfWork.AccountRepository.FirstOrDefault(x => x.gordon_id == id);
-            if (query == null)
-            {
-                throw new ResourceNotFoundException() { ExceptionMessage = "The account was not found." };
-            }
+            VerifyAccount(id);
 
             // SQL Parameters
             var usernameParam = new SqlParameter("@Username", username);
@@ -158,6 +150,48 @@ namespace Gordon360.Services
         }
 
         /// <summary>
+        /// (Service) Deletes a news item from the database
+        /// </summary>
+        /// <param name="id">The id of the requester</param>
+        /// <param name="newsID">The id of the news item to delete</param>
+        /// <returns></returns>
+        public StudentNewsViewModel DeleteNews(string id, int newsID)
+        {
+            //VerifyAccount(id);
+
+            var newsItem = _unitOfWork.StudentNewsRepository.GetById(newsID);
+            if(newsItem == null)
+            {
+                throw new ResourceNotFoundException() { ExceptionMessage = "The news item does not exist" };
+            }
+            //if(newsItem.ADUN != username)
+            //{
+
+            //}
+            //var result = _unitOfWork.StudentNewsRepository.Delete(newsItem);
+            //return result;
+            return newsItem;
+
+            // TODO: Eventually, there should be a check that the user has authored this posting
+            // so that the API can return a 403 Forbidden instead of just doing nothing
+            // (the SQL procedure itself safeguards that this cannot be done)
+            // to do this a NEWS_ITEM procedure of some sort will need to be made to select single item by SNID
+
+            // SQL Parameters
+            //var SNIDParam = new SqlParameter("@SNID", newsID);
+            //var usernameParam = new SqlParameter("@Username", username);
+
+            // Run stored procedure
+            //var result = RawSqlQuery<StudentNewsViewModel>.query("DELETE_NEWS_ITEM @SNID, @Username", SNIDParam, usernameParam);
+            //if (result == null)
+            //{
+            //    throw new ResourceNotFoundException() { ExceptionMessage = "The news item does not exist" };
+            //}
+
+            //return new StudentNewsViewModel();
+        }
+
+        /// <summary>
         /// Helper method to validate a news item
         /// </summary>
         /// <param name="newsItem">The news item to validate</param>
@@ -166,6 +200,23 @@ namespace Gordon360.Services
         {
             // any input sanitization should go here
 
+            return true;
+        }
+
+        /// <summary>
+        /// Verifies that a student account exists
+        /// </summary>
+        /// <param name="id">The id of the student</param>
+        /// <returns>true if account exists, ResourceNotFoundException if null</returns>
+        private bool VerifyAccount(string id)
+        {
+            // Verify account
+            var _unitOfWork = new UnitOfWork();
+            var query = _unitOfWork.AccountRepository.FirstOrDefault(x => x.gordon_id == id);
+            if (query == null)
+            {
+                throw new ResourceNotFoundException() { ExceptionMessage = "The account was not found." };
+            }
             return true;
         }
     }

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -227,6 +227,7 @@ namespace Gordon360.Services
         IEnumerable<StudentNewsCategoryViewModel> GetNewsCategories();
         IEnumerable<StudentNewsViewModel> GetNewsPersonalUnapproved(string id, string username);
         StudentNews SubmitNews(StudentNews newsItem, string username, string id);
+        StudentNewsViewModel DeleteNews(string id, int newsID);
     }
 
 }

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -227,7 +227,7 @@ namespace Gordon360.Services
         IEnumerable<StudentNewsCategoryViewModel> GetNewsCategories();
         IEnumerable<StudentNewsViewModel> GetNewsPersonalUnapproved(string id, string username);
         StudentNews SubmitNews(StudentNews newsItem, string username, string id);
-        StudentNewsViewModel DeleteNews(string id, int newsID);
+        StudentNews DeleteNews(int newsID);
     }
 
 }

--- a/Gordon360/Static Classes/Names.cs
+++ b/Gordon360/Static Classes/Names.cs
@@ -12,7 +12,7 @@ namespace Gordon360.Static.Names
         public const string ACCOUNT = "An Account Resource.";
         public const string ADVISOR = "An Advisor Resource";
         public const string GROUP_ADMIN = "A Group Admin Resource";
-        public const string ADMIN = "An admininistrator Ressource";
+        public const string ADMIN = "An admininistrator Resource";
         public const string ACTIVITY_INFO = "An Activity Info Service.";
         public const string ACTIVITY_STATUS = "The open or closed status of an activity";
         public const string ChapelEvent = "The info of chapel events";

--- a/Gordon360/Web.config
+++ b/Gordon360/Web.config
@@ -17,7 +17,7 @@
     <add key="DEFAULT_PROFILE_IMAGE_PATH" value="https://360apitrain.gordon.edu/browseable/profile/Default/profile.png" />
     <add key="DEFAULT_PREF_IMAGE_PATH" value="\\gotrain\pref_photos\" />
     <add key="DEFAULT_IMAGE_PATH" value="\\gotrain\photos\" />
-    <add key="DEFAULT_ID_SUBMISSION_PATH" value="\\gotrain\ID_photo_submissions\" /> 
+    <add key="DEFAULT_ID_SUBMISSION_PATH" value="\\gotrain\ID_photo_submissions\" />
     <!-- <add key="DEFAULT_ACTIVITY_IMAGE_PATH" value="https://360api.gordon.edu/browseable/uploads/Default/activityImage.png" />
     <add key="DEFAULT_PROFILE_IMAGE_PATH" value="https://360api.gordon.edu/browseable/profile/Default/profile.png" />
     <add key="DEFAULT_PREF_IMAGE_PATH" value="\\go\pref_photos\" />

--- a/README.md
+++ b/README.md
@@ -880,10 +880,21 @@ What is it? Resource that represents accepted student news entries and news cate
 `api/news/new` Gets every student news entry that has been accepted, has not expired (as described above), and is new since 10am on the day before.
 
 `api/news/personal-unapproved` Gets all of the unexpired and unapproved news submissions by the authenticated user
+_(uses stored procedure)_
 
 ##### POST
 
 `api/news` Submits a news item into the database (initally unapproved)
+_(uses stored procedure)_
+
+##### DELETE
+
+`api/news/:id` Deletes a news item from the database by its id (SNID = student news id). In order to delete, the following conditions must be met:
+
+- news item is unexpired
+- user is author of news item or SUPER_ADMIN (perhaps should be changed in future)
+
+_(uses repository)_
 
 ## API Testing
 


### PR DESCRIPTION
### "Delete News" API Endpoint
Creates 1 new endpoint for student news.
Allows deletion of student news with the following conditions outlined in the README:
- news item is unexpired
- user is author of news item or SUPER_ADMIN (perhaps should be changed in future)

Note that this endpoint makes use of **repositories rather than a stored procedure**. There is currently a stored procedure in the database for deleting news, but this may soon be deleted (probably following this merge I will delete it). This endpoint also makes use of the StateYourBusiness authorization action filter as well as Custom Exception handling. This code can be used as an example for creating an endpoint using the Generic Repository.

Note: The MyGordon context was not properly set up to handle use with the Generic Repository before this PR because previous people working on news endpoints used Stored Procedures instead, so they did not know it was broken (guessing they just tried to follow example code). So **this PR also completes/fixes that MyGordon context integration**.

**Notes for future work:**
- The StateYourBusiness Action Filter should be taken a second look at. There is an explanation of why it was created as an Action Filter rather than an Authorization Filter, but this results in poor encapsulation and security. The filter should safeguard anyone from using Generic Repositories from performing unauthorized actions, but it is dependent upon putting an [action filter tag] above the method, as you will see preceding the delete news controller method. This should probably be looked at and changed.
- SUPER_ADMIN has too many privileges. There is essentially a defaulting true where Super Admins are given ALL permissions, but this should be done on a case by case basis. For example, Super Admins should not be allowed to delete expired news (hence why I had to add that catch in the service as well as the filter).

Closes #355