### PR TITLE
Keep Tests/ApiEndpoints/credentials.py out of repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -270,6 +270,7 @@ paket-files/
 ## Secret Files
 secrets.config
 test_credentials.py
+credentials.py
 
 
 ## Python


### PR DESCRIPTION
It appears test_credentials.py was at some point renamed credentials.py.  But regardless of the history, we don't want this file in the repo, so this adds it to .gitignore.