### PR TITLE
(S20) "Edit News" API Endpoint

### DIFF
--- a/Gordon360/ApiControllers/NewsController.cs
+++ b/Gordon360/ApiControllers/NewsController.cs
@@ -50,6 +50,25 @@ namespace Gordon360.Controllers.Api
             _newsService = newsService;
         }
 
+        /// <summary>Gets a news item by id from the database</summary>
+        /// <param name="newsID">The id of the news item to retrieve</param>
+        /// <returns>The news item</returns>
+        [HttpGet]
+        [Route("{newsID}")]
+        [StateYourBusiness(operation = Operation.READ_ONE, resource = Resource.NEWS)]
+        // Private route to authenticated users
+        public IHttpActionResult GetByID(int newsID)
+        {
+            // StateYourBusiness verifies that user is authenticate
+            var result = _newsService.Get(newsID);
+            // Shouldn't be necessary
+            if (result == null)
+            {
+                return NotFound();
+            }
+            return Ok(result);
+        }
+
         /** Call the service that gets all approved student news entries not yet expired, filtering
          * out the expired by comparing 2 weeks past date entered to current date
          */
@@ -160,7 +179,7 @@ namespace Gordon360.Controllers.Api
         // Private route to authenticated authors of the news entity
         public IHttpActionResult Delete(int newsID)
         {
-            // StateYourBusiness verfies that user is authenticated
+            // StateYourBusiness verifies that user is authenticated
             // Delete permission should be allowed only to authors of the news item
             // News item must not have already expired
             var result = _newsService.DeleteNews(newsID);

--- a/Gordon360/ApiControllers/NewsController.cs
+++ b/Gordon360/ApiControllers/NewsController.cs
@@ -8,6 +8,7 @@ using System.Security.Claims;
 using Gordon360.Exceptions.ExceptionFilters;
 using Gordon360.AuthorizationFilters;
 using Gordon360.Static.Names;
+using Gordon360.Models.ViewModels;
 
 namespace Gordon360.Controllers.Api
 {
@@ -60,8 +61,7 @@ namespace Gordon360.Controllers.Api
         public IHttpActionResult GetByID(int newsID)
         {
             // StateYourBusiness verifies that user is authenticated
-            var result = _newsService.Get(newsID);
-            // Shouldn't be necessary
+            var result = (StudentNewsViewModel)_newsService.Get(newsID);
             if (result == null)
             {
                 return NotFound();
@@ -202,7 +202,7 @@ namespace Gordon360.Controllers.Api
         [Route("{newsID}")]
         [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.NEWS)]
         // Private route to authenticated users - authors of posting or admins
-        public IHttpActionResult EditPosting(int newsID, StudentNews newData)
+        public IHttpActionResult EditPosting(int newsID,[FromBody] StudentNews newData)
         {
             // StateYourBusiness verifies that user is authenticated
             var result = _newsService.EditPosting(newsID, newData);

--- a/Gordon360/ApiControllers/NewsController.cs
+++ b/Gordon360/ApiControllers/NewsController.cs
@@ -59,7 +59,7 @@ namespace Gordon360.Controllers.Api
         // Private route to authenticated users
         public IHttpActionResult GetByID(int newsID)
         {
-            // StateYourBusiness verifies that user is authenticate
+            // StateYourBusiness verifies that user is authenticated
             var result = _newsService.Get(newsID);
             // Shouldn't be necessary
             if (result == null)
@@ -190,6 +190,24 @@ namespace Gordon360.Controllers.Api
             }
             return Ok(result);
         }
-        
+
+        /// <summary>
+        /// (Controller) Edits a news item in the database
+        /// </summary>
+        /// <param name="newsID">The id of the news item to edit</param>
+        /// <param name="newData">The news object that contains updated values</param>
+        /// <returns>The updated news item</returns>
+        /// <remarks>The news item must be authored by the user and must not be expired and must be unapproved</remarks>
+        [HttpPut]
+        [Route("{newsID}")]
+        [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.NEWS)]
+        // Private route to authenticated users - authors of posting or admins
+        public IHttpActionResult EditPosting(int newsID, StudentNews newData)
+        {
+            // StateYourBusiness verifies that user is authenticated
+            var result = _newsService.EditPosting(newsID, newData);
+            return Ok(result);
+        }
+
     }
 }

--- a/Gordon360/AuthorizationFilters/StateYourBusiness.cs
+++ b/Gordon360/AuthorizationFilters/StateYourBusiness.cs
@@ -557,7 +557,21 @@ namespace Gordon360.AuthorizationFilters
                         return false;
                     }
                 case Resource.NEWS:
-                    return true; // TODO only allow the poster of a news entry to update it 
+                    var newsID = context.ActionArguments["newsID"];
+                    var newsService = new NewsService(new UnitOfWork());
+                    var newsItem = newsService.Get((int)newsID);
+                    // only unapproved posts may be updated
+                    var approved = newsItem.Accepted;
+                    if (approved == null || approved == true)
+                        return false;
+                    // can update if user is admin
+                    if (user_position == Position.SUPERADMIN)
+                        return true;
+                    // can update if user is news item author
+                    string newsAuthor = newsItem.ADUN;
+                    if (user_name == newsAuthor)
+                        return true;
+                    return false;
                 default: return false;
             }
         }
@@ -627,7 +641,7 @@ namespace Gordon360.AuthorizationFilters
                         var todaysDate = System.DateTime.Now;
                         var newsDate = (System.DateTime)newsItem.Entered;
                         var dateDiff = (todaysDate - newsDate).Days;
-                        if (dateDiff >= 14)
+                        if (newsDate == null || dateDiff >= 14)
                         {
                             return false;
                         }

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -314,6 +314,7 @@
             <summary>Deletes a news item from the database</summary>
             <param name="newsID">The id of the news item to delete</param>
             <returns>The deleted news item</returns>
+            <remarks>The news item must be authored by the user and must not be expired</remarks>
         </member>
         <member name="M:Gordon360.Controllers.Api.ContentManagementController.GetSliderContent">
             <summary>Get all the slider content for the dashboard slider</summary>
@@ -1447,6 +1448,7 @@
             </summary>
             <param name="newsID">The id of the news item to delete</param>
             <returns>The deleted news item</returns>
+            <remarks>The news item must be authored by the user and must not be expired</remarks>
         </member>
         <member name="M:Gordon360.Services.NewsService.ValidateNewsItem(Gordon360.Models.StudentNews)">
             <summary>

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -291,6 +291,11 @@
                         }
                     }
         </member>
+        <member name="M:Gordon360.Controllers.Api.NewsController.GetByID(System.Int32)">
+            <summary>Gets a news item by id from the database</summary>
+            <param name="newsID">The id of the news item to retrieve</param>
+            <returns>The news item</returns>
+        </member>
         <member name="M:Gordon360.Controllers.Api.NewsController.GetNotExpired">
             Call the service that gets all approved student news entries not yet expired, filtering
             out the expired by comparing 2 weeks past date entered to current date
@@ -315,6 +320,15 @@
             <param name="newsID">The id of the news item to delete</param>
             <returns>The deleted news item</returns>
             <remarks>The news item must be authored by the user and must not be expired</remarks>
+        </member>
+        <member name="M:Gordon360.Controllers.Api.NewsController.EditPosting(System.Int32,Gordon360.Models.StudentNews)">
+            <summary>
+            (Controller) Edits a news item in the database
+            </summary>
+            <param name="newsID">The id of the news item to edit</param>
+            <param name="newData">The news object that contains updated values</param>
+            <returns>The updated news item</returns>
+            <remarks>The news item must be authored by the user and must not be expired and must be unapproved</remarks>
         </member>
         <member name="M:Gordon360.Controllers.Api.ContentManagementController.GetSliderContent">
             <summary>Get all the slider content for the dashboard slider</summary>
@@ -1421,6 +1435,9 @@
         <member name="M:Gordon360.Services.NewsService.Get(System.Int32)">
             <summary>
             Gets a news item entity by id
+            NOTE: Also a helper method, hence why it returns a StudentNews model
+            rather than a StudentNewsViewModel - must be casted as the latter in its own
+            controller
             </summary>
             <param name="newsID">The SNID (id of news item)</param>
             <returns>The news item</returns>
@@ -1449,6 +1466,30 @@
             <param name="newsID">The id of the news item to delete</param>
             <returns>The deleted news item</returns>
             <remarks>The news item must be authored by the user and must not be expired</remarks>
+        </member>
+        <member name="M:Gordon360.Services.NewsService.EditPosting(System.Int32,Gordon360.Models.StudentNews)">
+            <summary>
+            (Service) Edits a news item in the database
+            </summary>
+            <param name="newsID">The id of the news item to edit</param>
+            <param name="newData">The news object that contains updated values</param>
+            <returns>The updated news item's view model</returns>
+            <remarks>The news item must be authored by the user and must not be expired and must be unapproved</remarks>
+        </member>
+        <member name="M:Gordon360.Services.NewsService.VerifyUnapproved(Gordon360.Models.StudentNews)">
+            <summary>
+            Helper method to verify that a given news item has not yet been approved
+            </summary>
+            <param name="newsItem">The news item to verify</param>
+            <returns>true if unapproved, otherwise throws some kind of meaningful exception</returns>
+        </member>
+        <member name="M:Gordon360.Services.NewsService.VerifyUnexpired(Gordon360.Models.StudentNews)">
+            <summary>
+            Helper method to verify that a given news item has not expired 
+            (see documentation for expiration definition)
+            </summary>
+            <param name="newsItem">The news item to verify</param>
+            <returns>true if unexpired, otherwise throws some kind of meaningful exception</returns>
         </member>
         <member name="M:Gordon360.Services.NewsService.ValidateNewsItem(Gordon360.Models.StudentNews)">
             <summary>

--- a/Gordon360/Gordon360.csproj
+++ b/Gordon360/Gordon360.csproj
@@ -700,7 +700,9 @@
           <AutoAssignPort>True</AutoAssignPort>
           <DevelopmentServerPort>49645</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
-          <IISUrl>http://localhost:5849</IISUrl>
+          <IISUrl>http://localhost:3417</IISUrl>
+          <OverrideIISAppRootUrl>True</OverrideIISAppRootUrl>
+          <IISAppRootUrl>http://localhost:3417/</IISAppRootUrl>
           <NTLMAuthentication>False</NTLMAuthentication>
           <UseCustomServer>False</UseCustomServer>
           <CustomServerUrl>

--- a/Gordon360/Models/ViewModels/StudentNewsViewModel.cs
+++ b/Gordon360/Models/ViewModels/StudentNewsViewModel.cs
@@ -1,7 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
+﻿/********************************
+ * This file is manually created and may be edited
+ * The view model allows access to all of the model's data without
+ * anything unnecessary. It prevents a self-referencing loop error
+ * in models that need a category that need a model etc.
+ * The implicit operator allows conversion between the model and the view model
+ ********************************/
+
+using System;
 
 namespace Gordon360.Models.ViewModels
 {
@@ -12,8 +17,10 @@ namespace Gordon360.Models.ViewModels
         public int categoryID { get; set; }
         public string Subject { get; set; }
         public string Body { get; set; }
-        public bool? Sent { get; set; }
-        public bool? thisPastMailing { get; set; }
+        // defaults below to unapproved (if null), hence not a nullable bool
+        public bool Accepted { get; set; }
+        public Nullable<bool> Sent { get; set; }
+        public Nullable<bool> thisPastMailing { get; set; }
         public Nullable<DateTime> Entered { get; set; }
         public string categoryName { get; set; }
         public Nullable<int> SortOrder { get; set; }
@@ -28,6 +35,8 @@ namespace Gordon360.Models.ViewModels
                 categoryID = n.categoryID,
                 Subject = n.Subject,
                 Body = n.Body,
+                // should default to unapproved (if null)
+                Accepted = n.Accepted ?? false,
                 Sent = n.Sent,
                 thisPastMailing = n.thisPastMailing,
                 Entered = n.Entered,

--- a/Gordon360/Services/NewsService.cs
+++ b/Gordon360/Services/NewsService.cs
@@ -23,9 +23,14 @@ namespace Gordon360.Services
         /// </summary>
         /// <param name="newsID">The SNID (id of news item)</param>
         /// <returns>The news item</returns>
-        public StudentNewsViewModel Get(int newsID)
+        public StudentNews Get(int newsID)
         {
             var newsItem = _unitOfWork.StudentNewsRepository.GetById(newsID);
+            // Thrown exceptions will be converted to HTTP Responses by the CustomExceptionFilter
+            if (newsItem == null)
+            {
+                throw new ResourceNotFoundException() { ExceptionMessage = "The news item was not found." };
+            }
             return newsItem;
         }
 
@@ -167,12 +172,9 @@ namespace Gordon360.Services
         /// <remarks>The news item must be authored by the user and must not be expired</remarks>
         public StudentNews DeleteNews(int newsID)
         {
-            var newsItem = _unitOfWork.StudentNewsRepository.GetById(newsID);
-            // Thrown exceptions will be converted to HTTP Responses by the CustomExceptionFilter
-            if (newsItem == null)
-            {
-                throw new ResourceNotFoundException() { ExceptionMessage = "The news item was not found." };
-            }
+            // Service method 'Get' throws its own exceptions
+            var newsItem = Get(newsID);
+
             // DateTime of date entered is nullable, so we need to check that here before comparing
             // If the entered date is null we shouldn't allow deletion to be safe
             // Note: This check has been duplicated from StateYourBusiness because we do not SuperAdmins

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -239,6 +239,7 @@ namespace Gordon360.Services
         IEnumerable<StudentNewsViewModel> GetNewsPersonalUnapproved(string id, string username);
         StudentNews SubmitNews(StudentNews newsItem, string username, string id);
         StudentNews DeleteNews(int newsID);
+        StudentNews EditPosting(int newsID, StudentNews newsItem);
     }
 
 }

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -232,6 +232,7 @@ namespace Gordon360.Services
 
     public interface INewsService
     {
+        StudentNews Get(int newsID);
         IEnumerable<StudentNewsViewModel> GetNewsNotExpired();
         IEnumerable<StudentNewsViewModel> GetNewsNew();
         IEnumerable<StudentNewsCategoryViewModel> GetNewsCategories();
@@ -241,4 +242,3 @@ namespace Gordon360.Services
     }
 
 }
-

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -239,7 +239,7 @@ namespace Gordon360.Services
         IEnumerable<StudentNewsViewModel> GetNewsPersonalUnapproved(string id, string username);
         StudentNews SubmitNews(StudentNews newsItem, string username, string id);
         StudentNews DeleteNews(int newsID);
-        StudentNews EditPosting(int newsID, StudentNews newsItem);
+        StudentNewsViewModel EditPosting(int newsID, StudentNews newsItem);
     }
 
 }

--- a/README.md
+++ b/README.md
@@ -900,6 +900,16 @@ _(uses stored procedure)_
 
 _(uses repository)_
 
+##### PUT
+
+`api/news/:id` Edits a news item in the database by its id. In order to edit, the following conditions must be met:
+
+- news item is unexpired
+- user is author of news item or SUPER_ADMIN (perhaps should be changed in future)
+- news item has not yet been approved
+
+_(uses repository)_
+
 ### Wellness Check
 Back endpoint responsible for fetching and sending information to the database regarding the answers to the wellness check.
 


### PR DESCRIPTION
### "Edit News" API Endpoint
Creates 1 new endpoint for student news.
Allows editing of student news with the following conditions outlined in the README:
- news item is unexpired
- user is author of news item or SUPER_ADMIN (perhaps should be changed in future)
- news item is unapproved

Note that this endpoint makes use of **repositories rather than a stored procedure**. This endpoint also makes use of the StateYourBusiness authorization action filter as well as Custom Exception handling. This code can be used as an example for creating an endpoint using the Generic Repository.

Note: There were some edits made to the View Model, namely the addition of an approval field.

**Notes for future work:**
- Same as PR #364
- Write up an explanation of when view models should be used vs models, and include this article https://dotnetcoretutorials.com/2020/03/15/fixing-json-self-referencing-loop-exceptions/

Closes #369 