### PR TITLE
Update copyFiles.ps1 (Auto Deployment to Prod)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Dive in.
 ## Table of Contents
 - [Machines and Sites](#machines-and-sites)
     - [Deploying to the Api Site](#deploying-to-the-api-site)
+      - [Normal Case: Deploying Automatically via Travis](#normal-case-deploying-automatically-via-travis)
+      - [Unusual Case: Deploying Manually](#unusual-case-deploying-manually)
     - [Deploying to the Front-end site (deprecated)](#deploying-to-the-front-end-site)
 - [Running the API locally](#running-the-api-locally)
     - [Preliminary setup](#preliminary-setup)
@@ -72,6 +74,12 @@ The folders for these IIS sites can be found on the 360train machine under `F:\s
 - 360ApiTrain.gordon.edu -- Development JSON server site. C# using the ASP.NET Framework.
 
 ### Deploying to the Api Site
+#### Normal Case: Deploying Automatically via Travis
+When a pull request is merged into "develop", Travis will automatically build it and deploy it to 360apitrain.gordon.edu (for testing).
+
+When a pull request is merged into "master", Travis will automatically build it and deploy it to 360api.gordon.edu (for production).
+#### Unusual Case: Deploying Manually
+If there are problems with automatic deployment, or a specific need to revert or push manually, then this older procedure can be used.
 - Access the cts-360.gordon.edu VM (see [RemoteDesktopToVM.md](RemoteDesktopToVM.md) for instructions) as the cct.service user.
 - Before you publish your new version, be sure to copy the current stable version to make a backup. To do so:
 	- Navigate in File Explorer to `F:\Sites` and copy either 360Api or 360ApiTrain, whichever you're planning to publish to.

--- a/scripts/copyFiles.ps1
+++ b/scripts/copyFiles.ps1
@@ -21,7 +21,7 @@ try {
     Invoke-Command -Session $session {Copy-Item ("./" + $($using:env:SITE_DIR) + "/*") -Destination $($using:backupDir) -Recurse -Force}
   }
   Write-Output "Copying API files to remote destination..."
-  Copy-Item -Path "VSOutput\360ApiTrain" -Destination $env:DEPLOY_DESTINATION -ToSession $session -Recurse -Force
+  Copy-Item -Path ("VSOutput\" + $($using:env:SITE_DIR)) -Destination $env:DEPLOY_DESTINATION -ToSession $session -Recurse -Force
   Write-Output "Closing remote Powershell session..."
   $session | Remove-PSSession
   Write-Output "Done"

--- a/scripts/deploy.bat
+++ b/scripts/deploy.bat
@@ -1,5 +1,6 @@
 echo "Building application for deployment..."
-"C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin\msbuild" Gordon360.sln -p:DeployOnBuild=true -p:PublishProfile=..\travis-publish-profiles\travis-dev.pubxml
+set pubProfile = "..\travis-publish-profiles\%PUB_PROFILE%"
+"C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin\msbuild" Gordon360.sln -p:DeployOnBuild=true -p:PublishProfile=%pubProfile%
 
 echo "Preparing to copy API to remote server..."
 @echo off


### PR DESCRIPTION
This fixes an issue in [copyFiles.ps1](https://github.com/gordon-cs/gordon-360-api/blob/develop/scripts/copyFiles.ps1) that caused Travis to deploy a debug build every time instead of building a release variant when deploying `master`.

This will hopefully fix issues where the master branch is not automatically deployed to production by Travis.
Note: PUB_PROFILE is an environment variable on Travis
![image](https://user-images.githubusercontent.com/17221652/88066528-de38e100-cb3b-11ea-9998-66c9d3137f8d.png)
