### PR TITLE
Auto Travis Deployment Attempt 4: Put back original hard coded line

### DIFF
--- a/scripts/copyFiles.ps1
+++ b/scripts/copyFiles.ps1
@@ -24,7 +24,7 @@ try {
   Write-Output $($using:env:SITE_DIR)
   Write-Output $env:DEPLOY_DESTINATION
   Write-Output "Copying API files to remote destination..."
-  Copy-Item -Path ("VSOutput\" + $($using:env:SITE_DIR)) -Destination $env:DEPLOY_DESTINATION -ToSession $session -Recurse -Force
+  Copy-Item -Path ("VSOutput\360ApiTrain" -Destination $env:DEPLOY_DESTINATION -ToSession $session -Recurse -Force
   Write-Output "Closing remote Powershell session..."
   $session | Remove-PSSession
   Write-Output "Done"

--- a/scripts/deploy.bat
+++ b/scripts/deploy.bat
@@ -2,9 +2,6 @@ echo "Building application for deployment..."
 set pubProfile = "..\travis-publish-profiles\%PUB_PROFILE%"
 "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin\msbuild" Gordon360.sln -p:DeployOnBuild=true -p:PublishProfile=%pubProfile%
 
-echo "pubProfile is: "
-echo $pubProfile
-echo ${PUB_PROFILE}
 echo "Preparing to copy API to remote server..."
 @echo on
 powershell -ExecutionPolicy Bypass -File ./scripts/copyFiles.ps1


### PR DESCRIPTION
Put back the 360ApiTrain line to see if Travis should deploy cleanly again