### PR TITLE
Auto Travis Deployment Attempt 8: Changed how env variable is called in powershell file

### DIFF
--- a/scripts/copyFiles.ps1
+++ b/scripts/copyFiles.ps1
@@ -21,10 +21,10 @@ try {
     Invoke-Command -Session $session {Copy-Item ("./" + $($using:env:SITE_DIR) + "/*") -Destination $($using:backupDir) -Recurse -Force}
   }
   Write-Output "Debugging info..."
-  Write-Output $($using:env:SITE_DIR)
+  Write-Output $env:SITE_DIR
   Write-Output $env:DEPLOY_DESTINATION
   Write-Output "Copying API files to remote destination..."
-  Copy-Item -Path "VSOutput\360ApiTrain" -Destination $env:DEPLOY_DESTINATION -ToSession $session -Recurse -Force
+  Copy-Item -Path "VSOutput\$env:SITE_DIR" -Destination $env:DEPLOY_DESTINATION -ToSession $session -Recurse -Force
   Write-Output "Closing remote Powershell session..."
   $session | Remove-PSSession
   Write-Output "Done"


### PR DESCRIPTION
use $env:(variable name) rather than $($using:env:(variable name)) unless using the invoke-command statement etc.

This is why we change it:

```
A Using variable cannot be retrieved. A Using variable can be used only with
Invoke-Command, Start-Job, or InlineScript in the script workflow. When it is used
with Invoke-Command, the Using variable is valid only if the script block is
invoked on a remote computer.
At line:1 char:17
+ write-output  $($using:env:SITE_DIR)
+                 ~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : UsingWithoutInvokeCommand
```

See this thread for interesting information on this https://www.reddit.com/r/PowerShell/comments/asnu82/nested_variables_in_powershell/
Note that we shouldn't need to nest the variable like this $($env:<var>) as in the question asked there. Powershell parses $env:<var> as a substring just fine