### PR TITLE
Set on/off campus and dorm to private for semi-private students

### DIFF
--- a/Gordon360/Models/ViewModels/PublicStudentProfileViewModel.cs
+++ b/Gordon360/Models/ViewModels/PublicStudentProfileViewModel.cs
@@ -87,6 +87,8 @@ namespace Gordon360.Models.ViewModels
                 vm.HomeState = "";
                 vm.HomeCountry = "";
                 vm.Country = "";
+                vm.OnOffCampus = "P"; //Private, as parsed by front end service user.js
+                vm.Hall = "";
             }
             if (vm.KeepPrivate.Contains("Y") || vm.KeepPrivate.Contains("P"))
             {


### PR DESCRIPTION
Update the privacy of public student profiles so that students who are marked semi-private ('S' in the KeepPrivate column) will not have their on/off campus status and dorm shared with the front end.

This info will still be shared via myprofile and with FacStaff. The corresponding front-end changes will mark it as sensitive, private info to FacStaff.