### PR TITLE
Keep on/off campus and dorm private for semi-private students

### DIFF
--- a/Gordon360/Models/ViewModels/PublicStudentProfileViewModel.cs
+++ b/Gordon360/Models/ViewModels/PublicStudentProfileViewModel.cs
@@ -87,6 +87,8 @@ namespace Gordon360.Models.ViewModels
                 vm.HomeState = "";
                 vm.HomeCountry = "";
                 vm.Country = "";
+                vm.OnOffCampus = "P";
+                vm.Hall = "";
             }
             if (vm.KeepPrivate.Contains("Y") || vm.KeepPrivate.Contains("P"))
             {


### PR DESCRIPTION
Semi-private students want their personal information to not be shown to other students. This changes it so that on/off campus status and dorm are not sent to the front end. The front end needs a corresponding update to ensure that the private status of this info is displayed (i.e. it currently would default to on campus for a private campus location, whether or not this is accurate)

This change already exists in master.