### PR TITLE
Fix error when no status in DB

### DIFF
--- a/Gordon360/Services/WellnessService.cs
+++ b/Gordon360/Services/WellnessService.cs
@@ -41,6 +41,18 @@ namespace Gordon360.Services
 
             var wellnessStatus = result.SingleOrDefault();
 
+            if (wellnessStatus == null)
+            {
+                // No status was found for the given user, so return an invalid fake status
+                return new WellnessStatusViewModel
+                {
+                    Status = "GREEN",
+                    Created = new DateTime(1900, 01, 01),
+                    IsValid = false,
+                    IsOverride = false
+                };
+            }
+
             wellnessStatus.IsValid = IsValidStatus(wellnessStatus);
 
             return wellnessStatus;


### PR DESCRIPTION
The updated wellness routes were not tested on users who had no pre-existing check in data. When a user had no data, the routes would fail with a 500 internal server error, which would cause the frontend to load forever.

The Wellness service has been updated so that, when the stored procedure returns 0 results for a user, the service will create a mock result that is no longer valid, which will force the user to answer the question (the desired behavior in this case).