### PR TITLE
Account for null expiration when setting validity of wellness status

### DIFF
--- a/Gordon360/Services/WellnessService.cs
+++ b/Gordon360/Services/WellnessService.cs
@@ -54,7 +54,7 @@ namespace Gordon360.Services
                 {
                     Status = ((WellnessStatusColor)result.HealthStatusID).ToString(),
                     Created = result.Created,
-                    IsValid = DateTime.Now < result.Expires
+                    IsValid = result.Expires == null || DateTime.Now < result.Expires
                 };
             }
         }


### PR DESCRIPTION
Health statuses can have a null expiration, which signifies that the status should persist until it is overridden again. The API had a bug that would treat statuses with null expiration as invalid. Now, it will always treat null expiration as valid, which is the intended behavior.