### PR TITLE
Fix Account Bug

### DIFF
--- a/Gordon360/ApiControllers/AccountsController.cs
+++ b/Gordon360/ApiControllers/AccountsController.cs
@@ -13,6 +13,7 @@ using Gordon360.Models.ViewModels;
 using System.Collections;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json.Linq;
+using Gordon360.AuthorizationFilters;
 
 namespace Gordon360.ApiControllers
 {
@@ -35,6 +36,7 @@ namespace Gordon360.ApiControllers
         // GET: api/Accounts
         [HttpGet]
         [Route("email/{email}")]
+        [StateYourBusiness(operation = Operation.READ_ONE, resource = Resource.ACCOUNT)]
         public IHttpActionResult GetByAccountEmail(string email)
         {
             if (!ModelState.IsValid || string.IsNullOrWhiteSpace(email))
@@ -295,6 +297,7 @@ namespace Gordon360.ApiControllers
         // GET: api/Accounts
         [HttpGet]
         [Route("username/{username}")]
+        [StateYourBusiness(operation = Operation.READ_ONE, resource = Resource.ACCOUNT)]
         public IHttpActionResult GetByAccountUsername(string username)
         {
             if (!ModelState.IsValid || string.IsNullOrWhiteSpace(username))

--- a/Gordon360/ApiControllers/MembershipsController.cs
+++ b/Gordon360/ApiControllers/MembershipsController.cs
@@ -541,5 +541,18 @@ namespace Gordon360.Controllers.Api
 
             return Ok(result);
         }
+
+        /// <summary>	
+        /// Determines whether or not the given student is a Group Admin of some activity	
+        /// </summary>
+        /// <param name="id">The student id</param>
+        [HttpGet]
+        [Route("isGroupAdmin/{id}")]
+        public IHttpActionResult IsGroupAdmin(int id)
+        {
+            var result = _membershipService.IsGroupAdmin(id);
+
+            return Ok(result);
+        }
     }
 }

--- a/Gordon360/AuthorizationFilters/StateYourBusiness.cs
+++ b/Gordon360/AuthorizationFilters/StateYourBusiness.cs
@@ -2,6 +2,7 @@
 using Gordon360.Repositories;
 using Gordon360.Services;
 using Gordon360.Static.Names;
+using System;
 using System.Linq;
 using System.Net.Http;
 using System.Security.Claims;
@@ -180,14 +181,13 @@ namespace Gordon360.AuthorizationFilters
                         // NOTE: In the future, probably only email addresses should be stored 
                         // in memberships, since we would rather not give students access to
                         // other students' account information
-                        /*
+                        
                         var membershipService = new MembershipService(new UnitOfWork());
-                        var isGroupAdmin = membershipService.GetGroupAdminMembershipsForActivity(activityCode).Where(x => x.IDNumber.ToString() == user_id).Count() > 0;
+                        var isGroupAdmin = membershipService.IsGroupAdmin(Int32.Parse(user_id));
                         if (isGroupAdmin) // If user is a group admin of the activity that the request is sent to
                             return true;
 
-                        return false;*/
-                        return true;
+                        return false;
                     }
                 case Resource.NEWS:
                     return true;

--- a/Gordon360/AuthorizationFilters/StateYourBusiness.cs
+++ b/Gordon360/AuthorizationFilters/StateYourBusiness.cs
@@ -101,7 +101,7 @@ namespace Gordon360.AuthorizationFilters
          * Operations
          */
          // This operation is specifically for authorizing deny and allow operations on membership requests. These two operations don't
-         // Fit in nicely with the REST specificatino which is why there is a seperate case for them.
+         // Fit in nicely with the REST specification which is why there is a seperate case for them.
          private bool canDenyAllow(string resource)
         {
             // User is admin
@@ -168,14 +168,25 @@ namespace Gordon360.AuthorizationFilters
                     }
                 case Resource.STUDENT:
                     // To add a membership for a student, you need to have the students identifier.
+                    // NOTE: I don't believe the 'student' resource is currently being used in API
                     {
                         return true;
                     }
                 case Resource.ADVISOR:
                     return true;
                 case Resource.ACCOUNT:
-                    // To add a membership for a person, you need to have the the person's identifier.
                     {
+                        // Membership group admins can access ID of members using their email
+                        // NOTE: In the future, probably only email addresses should be stored 
+                        // in memberships, since we would rather not give students access to
+                        // other students' account information
+                        /*
+                        var membershipService = new MembershipService(new UnitOfWork());
+                        var isGroupAdmin = membershipService.GetGroupAdminMembershipsForActivity(activityCode).Where(x => x.IDNumber.ToString() == user_id).Count() > 0;
+                        if (isGroupAdmin) // If user is a group admin of the activity that the request is sent to
+                            return true;
+
+                        return false;*/
                         return true;
                     }
                 case Resource.NEWS:

--- a/Gordon360/AuthorizationFilters/StateYourBusiness.cs
+++ b/Gordon360/AuthorizationFilters/StateYourBusiness.cs
@@ -181,10 +181,14 @@ namespace Gordon360.AuthorizationFilters
                         // NOTE: In the future, probably only email addresses should be stored 
                         // in memberships, since we would rather not give students access to
                         // other students' account information
-                        
                         var membershipService = new MembershipService(new UnitOfWork());
                         var isGroupAdmin = membershipService.IsGroupAdmin(Int32.Parse(user_id));
                         if (isGroupAdmin) // If user is a group admin of the activity that the request is sent to
+                            return true;
+
+                        // faculty and police can access student account information
+                        if (user_position == Position.FACSTAFF
+                            || user_position == Position.POLICE)
                             return true;
 
                         return false;

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -1085,14 +1085,14 @@
             Fetches the account record with the specified email.
             </summary>
             <param name="email">The email address associated with the account.</param>
-            <returns></returns>
+            <returns>the student account information</returns>
         </member>
         <member name="M:Gordon360.Services.AccountService.GetAccountByUsername(System.String)">
             <summary>
             Fetches the account record with the specified username.
             </summary>
             <param name="username">The username associated with the account.</param>
-            <returns></returns>
+            <returns>the student account information</returns>
         </member>
         <member name="T:Gordon360.Services.ActivityService">
             <summary>

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -275,7 +275,7 @@
         </member>
         <member name="M:Gordon360.ApiControllers.JobsController.deleteShiftForStaff(System.Int32)">
             <summary>
-            Delee a user's active job
+            Delete a user's active job
             </summary>
             <returns>The result of deleting the shift for a Staff</returns>
         </member>
@@ -554,8 +554,11 @@
             <returns></returns>
         </member>
         <member name="M:Gordon360.Controllers.Api.ProfilesController.getAdvisors(System.String)">
-            <summary>Get the advisor of particular student</summary>
-             <returns></returns>
+            <summary>Get the advisor(s) of a particular student</summary>
+             <returns>
+             All advisors of the given student.  For each advisor,
+             provides first name, last name, and username.
+             </returns>
         </member>
         <member name="M:Gordon360.Controllers.Api.ProfilesController.getMyImg">
             <summary>Get the profile image of currently logged in user</summary>
@@ -828,6 +831,12 @@
             <summary>Delete an existing membership</summary>
             <param name="id">The identifier for the membership to be deleted</param>
             <remarks>Calls the server to make a call and remove the given membership from the database</remarks>
+        </member>
+        <member name="M:Gordon360.Controllers.Api.MembershipsController.IsGroupAdmin(System.Int32)">
+            <summary>	
+            Determines whether or not the given student is a Group Admin of some activity	
+            </summary>
+            <param name="id">The student id</param>
         </member>
         <member name="M:Gordon360.Controllers.Api.StudentEmploymentController.Get">
             <summary>
@@ -1146,7 +1155,7 @@
         </member>
         <member name="M:Gordon360.Services.ActivityService.GetClosedActivities(System.String)">
             <summary>
-            Gets a collection of all the current activitie already closed out, by finding which activities have 
+            Gets a collection of all the current activities already closed out, by finding which activities have 
             memberships with an END_DTE that is not null
             </summary>
             <returns>The collection of activity codes for open activities</returns>
@@ -1935,7 +1944,7 @@
             Fetches all the membership information linked to the student whose id appears as a parameter.
             </summary>
             <param name="id">The student id.</param>
-            <returns>A MembershipViewModel IEnumerable. If nothing is found, an empty IEnumberable is returned.</returns>
+            <returns>A MembershipViewModel IEnumerable. If nothing is found, an empty IEnumerable is returned.</returns>
         </member>
         <member name="M:Gordon360.Services.MembershipService.GetActivityFollowersCount(System.String)">
             <summary>
@@ -1997,6 +2006,13 @@
             </summary>
             <param name="membership">The membership to validate</param>
             <returns>True if the membership is valid. Throws ResourceNotFoundException if not. Exception is caught in an Exception Filter</returns>
+        </member>
+        <member name="M:Gordon360.Services.MembershipService.IsGroupAdmin(System.Int32)">
+            <summary>	
+            Determines whether or not the given student is a Group Admin of some activity	
+            </summary>
+            <param name="studentID">The student id</param>	
+            <returns>true if student is a Group Admin, else false</returns>	
         </member>
         <member name="T:Gordon360.Services.SessionService">
             <summary>

--- a/Gordon360/Gordon360.csproj
+++ b/Gordon360/Gordon360.csproj
@@ -775,7 +775,7 @@
           <AutoAssignPort>True</AutoAssignPort>
           <DevelopmentServerPort>49645</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
-          <IISUrl>http://localhost:6969</IISUrl>
+          <IISUrl>http://localhost:3417</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>
           <UseCustomServer>False</UseCustomServer>
           <CustomServerUrl>

--- a/Gordon360/Services/AccountService.cs
+++ b/Gordon360/Services/AccountService.cs
@@ -13,6 +13,7 @@ using System.Data.SqlClient;
 
 namespace Gordon360.Services
 {
+    
     /// <summary>
     /// Service Class that facilitates data transactions between the AccountsController and the Account database model.
     /// </summary>
@@ -63,7 +64,6 @@ namespace Gordon360.Services
         /// </summary>
         /// <param name="email">The email address associated with the account.</param>
         /// <returns></returns>
-        [StateYourBusiness(operation = Operation.READ_ONE, resource = Resource.ACCOUNT)]
         public AccountViewModel GetAccountByEmail(string email)
         {
             var query = _unitOfWork.AccountRepository.FirstOrDefault(x => x.email == email);

--- a/Gordon360/Services/AccountService.cs
+++ b/Gordon360/Services/AccountService.cs
@@ -63,7 +63,7 @@ namespace Gordon360.Services
         /// Fetches the account record with the specified email.
         /// </summary>
         /// <param name="email">The email address associated with the account.</param>
-        /// <returns></returns>
+        /// <returns>the student account information</returns>
         public AccountViewModel GetAccountByEmail(string email)
         {
             var query = _unitOfWork.AccountRepository.FirstOrDefault(x => x.email == email);
@@ -79,8 +79,7 @@ namespace Gordon360.Services
         /// Fetches the account record with the specified username.
         /// </summary>
         /// <param name="username">The username associated with the account.</param>
-        /// <returns></returns>
-        [StateYourBusiness(operation = Operation.READ_ONE, resource = Resource.ACCOUNT)]
+        /// <returns>the student account information</returns>
         public AccountViewModel GetAccountByUsername(string username)
         {
             var query = _unitOfWork.AccountRepository.FirstOrDefault(x => x.AD_Username == username);

--- a/Gordon360/Services/ActivityService.cs
+++ b/Gordon360/Services/ActivityService.cs
@@ -184,7 +184,7 @@ namespace Gordon360.Services
         }
 
         /// <summary>
-        /// Gets a collection of all the current activitie already closed out, by finding which activities have 
+        /// Gets a collection of all the current activities already closed out, by finding which activities have 
         /// memberships with an END_DTE that is not null
         /// </summary>
         /// <returns>The collection of activity codes for open activities</returns>

--- a/Gordon360/Services/MembershipService.cs
+++ b/Gordon360/Services/MembershipService.cs
@@ -247,7 +247,7 @@ namespace Gordon360.Services
         /// Fetches all the membership information linked to the student whose id appears as a parameter.
         /// </summary>
         /// <param name="id">The student id.</param>
-        /// <returns>A MembershipViewModel IEnumerable. If nothing is found, an empty IEnumberable is returned.</returns>
+        /// <returns>A MembershipViewModel IEnumerable. If nothing is found, an empty IEnumerable is returned.</returns>
         public IEnumerable<MembershipViewModel> GetMembershipsForStudent(string id)
         {
             var studentExists = _unitOfWork.AccountRepository.Where(x => x.gordon_id.Trim() == id).Count() > 0;
@@ -474,6 +474,30 @@ namespace Gordon360.Services
             }
 
             return true;
+        }
+
+        /// <summary>	
+        /// Determines whether or not the given student is a Group Admin of some activity	
+        /// </summary>
+        /// <param name="studentID">The student id</param>	
+        /// <returns>true if student is a Group Admin, else false</returns>	
+        public Boolean IsGroupAdmin(int studentID)
+        {
+            IEnumerable<MembershipViewModel> memberships = GetMembershipsForStudent("" + studentID);
+
+            var membershipsWhereStudentIsGroupAdmin = _unitOfWork.MembershipRepository.Where(
+                membership => membership.ID_NUM == studentID &&
+                              membership.GRP_ADMIN == true);
+            // probably should also add clauses to require membership to be recent
+
+            // potentially could modify this method to return the list of memberships where 
+            // student is group admin rather than a simple binary
+            if (membershipsWhereStudentIsGroupAdmin != null && membershipsWhereStudentIsGroupAdmin.Count() > 0)
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/Gordon360/Services/MembershipService.cs
+++ b/Gordon360/Services/MembershipService.cs
@@ -483,8 +483,7 @@ namespace Gordon360.Services
         /// <returns>true if student is a Group Admin, else false</returns>	
         public Boolean IsGroupAdmin(int studentID)
         {
-            IEnumerable<MembershipViewModel> memberships = GetMembershipsForStudent("" + studentID);
-
+            // find memberships that the student is both apart of and group admin
             var membershipsWhereStudentIsGroupAdmin = _unitOfWork.MembershipRepository.Where(
                 membership => membership.ID_NUM == studentID &&
                               membership.GRP_ADMIN == true);

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -161,6 +161,7 @@ namespace Gordon360.Services
         MEMBERSHIP ToggleGroupAdmin(int id, MEMBERSHIP membership);
         void TogglePrivacy(int id, bool p);
         MEMBERSHIP Delete(int id);
+        Boolean IsGroupAdmin(int studentID);
     }
 
     public interface IJobsService

--- a/README.md
+++ b/README.md
@@ -486,9 +486,9 @@ What is it? Resource that represents a gordon account.
 
 ##### GET
 
-`api/accounts/email/:email` Get the account with email `email`.
+`api/accounts/email/:email` Get the account with email `email`. Currently restricted to FacStaff, Police, and Group Admins.
 
-`api/accounts/username/:username` Get the account with `username`.
+`api/accounts/username/:username` Get the account with `username`. Currently restricted to FacStaff, Police, and Group Admins.
 
 `api/accounts/search/:searchString` Returns the basicinfoviewmodel with a Concatenated attribute matching some or all of the searchstring
 
@@ -693,6 +693,8 @@ What is it? Resource that represents the affiliation between a student and a clu
 `api/memberships/student/:id` Get the memberships of the student with student id `id`.
 
 `api/memberships/student/username:username` Get the public version of memberships of the student with student username `username`.
+
+`api/memberships/isgroupadmin/:id` Get whether or not a student with id `id` is a Group Admin for some activity. Service method is used for security purposes but Controller is currently just for testing convenience.
 
 ##### POST
 


### PR DESCRIPTION
## Fixes Security Issue Accessing Account Information
This PR fixes a security issue where any authenticated Gordon user was able to HTTP Get any Gordon user's account information. 

To see this bug in action, send an HTTP Get request with either the path `api/accounts/email/*insert_full_Gordon_email*/` or `api/accounts/username/*insert_Gordon_username*/` (be sure to include trailing slash because of special characters). You can also join the Postman workspace I use https://app.getpostman.com/join-team?invite_code=bad40c775e4aaace2ee10e33c4e3b100&ws=04c201fd-72b7-4cef-9cf8-123db063b9a2 and find the appropriate endpoint under 'Other' (and change from localhost to the api of course as necessary).

This resolves this issue by properly applying the StateYourBusiness authorization filter to the Controller rather than the Service Accounts class, and updating the appropriate filter to check if a user is FacStaff, Police, or a Group Admin. The latter is necessary for managing memberships (see lines 176-185 of `views/ActivityProfile/components/Membership/index.js` (line numbers subject to change) where a Group Admin needs a user's ID to add a membership. In best practice, this should probably be changed to only require Gordon emails for memberships and keep account IDs in the back end, or some other method. However, for now we will simply restrict access to only these administrative roles which will greatly improve security.

Resolves #345