### PR TITLE
Fix Auth Filter Failure in EventsController

### DIFF
--- a/Gordon360/ApiControllers/EventController.cs
+++ b/Gordon360/ApiControllers/EventController.cs
@@ -24,8 +24,7 @@ namespace Gordon360.ApiControllers
         [Authorize]
         [HttpGet]
         [Route("chapel/{term}")]
-        [StateYourBusiness(operation = Operation.READ_PARTIAL, resource = Resource.ChapelEvent)]
-        public IHttpActionResult GetEventsForStudentByTerm(string term)
+        public IHttpActionResult GetEventsByTerm(string term)
         {
             //get token data from context, username is the username of current logged in person
             var authenticatedUser = ActionContext.RequestContext.Principal as ClaimsPrincipal;


### PR DESCRIPTION
The GetEventsByTerm route `api/chapel/:term` does not need additional StateYourBusiness auth filtering because it only gets data for the currently logged-in user. Since there was no case to handle a partial read of the ChapelEvent reource, the filter was causing all requests to fail with a 403 unauthorized status. The filter was previously in the EventService on the GetEventsForStudentByTerm method. However, the filter never gets called when it isn't in an ApiController class, which is why it was never revealed that the filter would always fail.