### PR TITLE
Bug Fix: People Search by Major

### DIFF
--- a/Gordon360/ApiControllers/AccountsController.cs
+++ b/Gordon360/ApiControllers/AccountsController.cs
@@ -361,10 +361,17 @@ namespace Gordon360.ApiControllers
             if (majorSearchParam == "C\u266F")
             {
                 majorSearchParam = "";
-            } else if (majorSearchParam.Contains("_") || majorSearchParam.Contains("dash"))
+            } else if (
+                majorSearchParam.Contains("_") ||
+                majorSearchParam.Contains("dash") ||
+                majorSearchParam.Contains("colon") ||
+                majorSearchParam.Contains("slash")
+                )
             {
                 majorSearchParam = majorSearchParam.Replace("_", "&");
                 majorSearchParam = majorSearchParam.Replace("dash", "-");
+                majorSearchParam = majorSearchParam.Replace("colon", ":");
+                majorSearchParam = majorSearchParam.Replace("slash", "/");
             }
             if (minorSearchParam == "C\u266F")
             {


### PR DESCRIPTION
Added symbol replacements for people search by major. Substitutes colons and forward slashes. This API PR corresponds with UI PR #950 (see here https://github.com/gordon-cs/gordon-360-ui/pull/950).

Full Disclosure: I did not test this change due to the amount of effort it would require, and it is narrow in scope enough that we should be able to just test in once in develop.