### PR TITLE
Remove log4net unused package

### DIFF
--- a/Gordon360/Gordon360.csproj
+++ b/Gordon360/Gordon360.csproj
@@ -56,9 +56,6 @@
       <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.AspNet.Identity.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.Identity.Core.2.2.1\lib\net45\Microsoft.AspNet.Identity.Core.dll</HintPath>
       <Private>True</Private>
@@ -842,7 +839,7 @@
           <AutoAssignPort>True</AutoAssignPort>
           <DevelopmentServerPort>49645</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
-          <IISUrl>http://localhost:3417</IISUrl>
+          <IISUrl>http://localhost:2626</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>
           <UseCustomServer>False</UseCustomServer>
           <CustomServerUrl>

--- a/Gordon360/Web.config
+++ b/Gordon360/Web.config
@@ -94,10 +94,6 @@
         <bindingRedirect oldVersion="1.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.13.0" newVersion="1.2.13.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Microsoft.AspNet.SignalR.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.2.2.0" newVersion="2.2.2.0" />
       </dependentAssembly>

--- a/Gordon360/packages.config
+++ b/Gordon360/packages.config
@@ -6,7 +6,6 @@
   <package id="EntityFramework" version="6.1.3" targetFramework="net461" />
   <package id="jQuery" version="1.10.2" targetFramework="net461" />
   <package id="jQuery.Validation" version="1.11.1" targetFramework="net461" />
-  <package id="log4net" version="2.0.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.Cors" version="5.2.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.2.1" targetFramework="net461" />
   <package id="Microsoft.AspNet.Identity.Owin" version="2.2.1" targetFramework="net461" />


### PR DESCRIPTION
The log4net package was added to our project but never used anywhere. It has recently been marked with a vulnerability. Since we don't need it, we might as well delete it.

The API has been run locally and functions perfectly without the log4net package.