### PR TITLE
Update Session to use Wheel for begin and end dates

### DIFF
--- a/Gordon360/Gordon360.csproj
+++ b/Gordon360/Gordon360.csproj
@@ -842,7 +842,7 @@
           <AutoAssignPort>True</AutoAssignPort>
           <DevelopmentServerPort>49645</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
-          <IISUrl>http://localhost:3417</IISUrl>
+          <IISUrl>http://localhost:2626</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>
           <UseCustomServer>False</UseCustomServer>
           <CustomServerUrl>

--- a/Gordon360/Models/ViewModels/SessionViewModel.cs
+++ b/Gordon360/Models/ViewModels/SessionViewModel.cs
@@ -20,8 +20,8 @@ namespace Gordon360.Models.ViewModels
 
                 SessionCode = sess.SESS_CDE.Trim(),
                 SessionDescription = sess.SESS_DESC ?? "",
-                SessionBeginDate = sess.SESS_BEGN_DTE ?? DateTime.MinValue,
-                SessionEndDate = sess.SESS_END_DTE ?? DateTime.MaxValue,
+                SessionBeginDate = sess.WHEEL_BEGN_DTE ?? sess.SESS_BEGN_DTE ?? DateTime.MinValue,
+                SessionEndDate = sess.WHEEL_END_DTE ?? sess.SESS_END_DTE ?? DateTime.MaxValue,
 
             };
 


### PR DESCRIPTION
The WHEEL_BEGN_DTE and WHEEL_END_DTE fields were already added to the database (both Train and Prod) to allow more manual control of the begin and end dates used for the semester wheel on 360's home page. These dates come from an activity in Jenzabar called 'WHEEL', and can be edited by anyone with permission to edit activities in Jenzabar. This way, the wheel begin and end dates can more accurately reflect Students' expectations about the beginning, end, and days transpired of the semester.