### PR TITLE
Add endpoint to store a users connection id

### DIFF
--- a/Gordon360/ApiControllers/DirectMessageController.cs
+++ b/Gordon360/ApiControllers/DirectMessageController.cs
@@ -39,21 +39,7 @@ namespace Gordon360.ApiControllers
         {
             _DirectMessageService = DirectMessageService;
         }
-
-        /// <summary>
-        ///  returns hello world example
-        /// </summary>
-        /// <returns>string and date</returns>
-        [HttpGet]
-        [Route("")]
-        public IHttpActionResult Get()
-        {
-            DateTime currentTime = DateTime.Now;
-            var result = "hello world I'm coming from the back end at: " + currentTime;
-
-            return Ok(result);
-        }
-
+        
         /// <summary>
         ///  returns messages from a specified group
         /// </summary>
@@ -199,6 +185,8 @@ namespace Gordon360.ApiControllers
 
             }
 
+            
+        
             /// <summary>
             ///  stores connection associated with a user id
             /// </summary>
@@ -207,7 +195,6 @@ namespace Gordon360.ApiControllers
             [Route("userConnectionIds")]
             public IHttpActionResult StoreUserConnectionIds([FromBody] String connectionId)
             {
-
                 var authenticatedUser = this.ActionContext.RequestContext.Principal as ClaimsPrincipal;
                 var username = authenticatedUser.Claims.FirstOrDefault(x => x.Type == "user_name").Value;
 
@@ -247,7 +234,29 @@ namespace Gordon360.ApiControllers
 
             }
 
+            /// <summary>
+            ///  Deletes connection ids associated with a user id
+            /// </summary>
+            /// <returns>true if successful</returns>
+            [HttpPut]
+            [Route("deleteUserConnectionIds")]
+            public IHttpActionResult DeleteConnectionIds([FromBody] String connectionId)
+            {
 
-        }
+
+                var result = _DirectMessageService.DeleteUserConnectionIds(connectionId);
+
+                if (result == null)
+                {
+                    return NotFound();
+                }
+
+
+                return Ok(result);
+
+            }
+
+
+    }
 
 }

--- a/Gordon360/ApiControllers/DirectMessageController.cs
+++ b/Gordon360/ApiControllers/DirectMessageController.cs
@@ -200,7 +200,7 @@ namespace Gordon360.ApiControllers
             }
 
             /// <summary>
-            ///  stores rooms associated with a user id
+            ///  stores connection associated with a user id
             /// </summary>
             /// <returns>true if successful</returns>
             [HttpPost]
@@ -225,8 +225,29 @@ namespace Gordon360.ApiControllers
 
             }
 
+            /// <summary>
+            ///  Gets connection ids associated with a user id
+            /// </summary>
+            /// <returns>true if successful</returns>
+            [HttpPut]
+            [Route("userConnectionIds")]
+            public IHttpActionResult GetConnectionIds([FromBody] String userId)
+            {
 
 
-    }
+                var result = _DirectMessageService.GetUserConnectionIds(userId);
+
+                if (result == null)
+                {
+                    return NotFound();
+                }
+
+
+                return Ok(result);
+
+            }
+
+
+        }
 
 }

--- a/Gordon360/ApiControllers/DirectMessageController.cs
+++ b/Gordon360/ApiControllers/DirectMessageController.cs
@@ -199,8 +199,34 @@ namespace Gordon360.ApiControllers
 
             }
 
+            /// <summary>
+            ///  stores rooms associated with a user id
+            /// </summary>
+            /// <returns>true if successful</returns>
+            [HttpPost]
+            [Route("userConnectionIds")]
+            public IHttpActionResult StoreUserConnectionIds([FromBody] String connectionId)
+            {
+
+                var authenticatedUser = this.ActionContext.RequestContext.Principal as ClaimsPrincipal;
+                var username = authenticatedUser.Claims.FirstOrDefault(x => x.Type == "user_name").Value;
+
+                var userId = _accountService.GetAccountByUsername(username).GordonID;
+
+                var result = _DirectMessageService.StoreUserConnectionIds(userId, connectionId);
+
+                if (result == false)
+                {
+                    return NotFound();
+                }
 
 
-        }
+                return Ok(result);
+
+            }
+
+
+
+    }
 
 }

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -187,6 +187,12 @@
             </summary>
             <returns>true if successful</returns>
         </member>
+        <member name="M:Gordon360.ApiControllers.DirectMessageController.StoreUserConnectionIds(System.String)">
+            <summary>
+             stores rooms associated with a user id
+            </summary>
+            <returns>true if successful</returns>
+        </member>
         <member name="M:Gordon360.ApiControllers.DiningController.Get">
             <summary>
              Gets information about student's dining plan and balance

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -145,12 +145,6 @@
             </summary>
             <returns> All buildings</returns>
         </member>
-        <member name="M:Gordon360.ApiControllers.DirectMessageController.Get">
-            <summary>
-             returns hello world example
-            </summary>
-            <returns>string and date</returns>
-        </member>
         <member name="M:Gordon360.ApiControllers.DirectMessageController.GetMessages(System.String)">
             <summary>
              returns messages from a specified group
@@ -196,6 +190,12 @@
         <member name="M:Gordon360.ApiControllers.DirectMessageController.GetConnectionIds(System.String)">
             <summary>
              Gets connection ids associated with a user id
+            </summary>
+            <returns>true if successful</returns>
+        </member>
+        <member name="M:Gordon360.ApiControllers.DirectMessageController.DeleteConnectionIds(System.String)">
+            <summary>
+             Deletes connection ids associated with a user id
             </summary>
             <returns>true if successful</returns>
         </member>

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -189,7 +189,13 @@
         </member>
         <member name="M:Gordon360.ApiControllers.DirectMessageController.StoreUserConnectionIds(System.String)">
             <summary>
-             stores rooms associated with a user id
+             stores connection associated with a user id
+            </summary>
+            <returns>true if successful</returns>
+        </member>
+        <member name="M:Gordon360.ApiControllers.DirectMessageController.GetConnectionIds(System.String)">
+            <summary>
+             Gets connection ids associated with a user id
             </summary>
             <returns>true if successful</returns>
         </member>

--- a/Gordon360/Gordon360.csproj
+++ b/Gordon360/Gordon360.csproj
@@ -598,6 +598,7 @@
       <DependentUpon>CCT_DB_Models.tt</DependentUpon>
     </Compile>
     <Compile Include="Models\ViewModels\ClockInViewModel.cs" />
+    <Compile Include="Models\ViewModels\ConnectionIdViewModel.cs" />
     <Compile Include="Models\ViewModels\CreateGroupViewModel.cs" />
     <Compile Include="Models\ViewModels\GroupViewModel.cs" />
     <Compile Include="Models\ViewModels\HourTypesViewModel.cs" />

--- a/Gordon360/Hubs/SignalRHub.cs
+++ b/Gordon360/Hubs/SignalRHub.cs
@@ -7,7 +7,12 @@ using System.Threading.Tasks;
 using Microsoft.AspNet.SignalR;
 using Microsoft.AspNet.SignalR.Hubs;
 using Gordon360;
+using Gordon360.Services;
+using Gordon360.ApiControllers;
 using System.Web.Http;
+using Gordon360.Models.ViewModels;
+using Gordon360.Repositories;
+using System.Security.Claims;
 
 namespace Gordon360.Hubs
 {
@@ -15,23 +20,45 @@ namespace Gordon360.Hubs
     [HubName("ChatHub")]
     public class ChatHub : Hub
     {
-       
-        public async Task refreshMessages(string user)
-         {
-                await Clients.All.SendAsync("ReceivedMessagerefresh", user);
+        //public DirectMessageService _DirectMessageService = new DirectMessageService();
 
+        public async Task refreshMessages(List<string> connectionIds, IEnumerable<MessageViewModel> message)
+         {
+            foreach(string connections in connectionIds)
+            {
+                await Groups.Add(connections, "list");
+            }
+            await Clients.Group("list").SendAsync("Received message refresh, Message: ", message);
          }
-        
-        public async Task test()
+
+        public string savedUserId;
+        public string savedConnectionId;
+
+        public  void saveConnection(string id)
         {
-            await Clients.All.SendAsync("It's working boss");
+            DirectMessageService _DirectMessageService = new DirectMessageService();
+            savedUserId = id;
+            savedConnectionId = Context.ConnectionId;
+            _DirectMessageService.StoreUserConnectionIds(id, Context.ConnectionId);
+             Clients.All.BroadcastMessage("It's working boss");
 
         }
-        
-        public string test2()
-        {
-            return "It worked";
 
+        public override Task OnDisconnected(bool stopCalled)
+        {
+            DirectMessageService _DirectMessageService = new DirectMessageService();
+
+            _DirectMessageService.DeleteUserConnectionIds(Context.ConnectionId);
+            return base.OnDisconnected(stopCalled);
+        }
+
+        public override Task OnReconnected()
+        {
+            DirectMessageService _DirectMessageService = new DirectMessageService();
+
+            _DirectMessageService.DeleteUserConnectionIds(savedConnectionId);
+            _DirectMessageService.StoreUserConnectionIds(savedUserId, Context.ConnectionId);
+            return base.OnReconnected();
         }
     }
  

--- a/Gordon360/Models/ViewModels/ConnectionIdViewModel.cs
+++ b/Gordon360/Models/ViewModels/ConnectionIdViewModel.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace Gordon360.Models.ViewModels
+{
+    public class ConnectionIdViewModel
+    {
+        //user websocket connection Id
+        public string connection_id { get; set; }
+
+    }
+}

--- a/Gordon360/Services/DirectMessageService.cs
+++ b/Gordon360/Services/DirectMessageService.cs
@@ -218,13 +218,12 @@ namespace Gordon360.Services
                 idParam, roomIdParam, textParam, createdAtParam, userIdParam, imageParam, videoParam, audioParam, systemParam, sentParam, receivedParam, pendingParam); //run stored procedure
 
             bool returnAnswer = true;
+
             if (result == null)
             {
                 returnAnswer = false;
                 throw new ResourceNotFoundException() { ExceptionMessage = "The data was not found." };
             }
-
-
 
             return returnAnswer;
 
@@ -285,6 +284,33 @@ namespace Gordon360.Services
 
 
             return returnAnswer;
+
+        }
+
+        public IEnumerable<ConnectionIdViewModel> GetUserConnectionIds(String userId)
+        {
+            var _unitOfWork = new UnitOfWork();
+            var query = _unitOfWork.AccountRepository.FirstOrDefault(x => x.gordon_id == userId);
+            if (query == null)
+            {
+                throw new ResourceNotFoundException() { ExceptionMessage = "The account was not found." };
+            }
+
+            var userIdParam = new SqlParameter("@user_id", userId);
+
+            var result = RawSqlQuery<ConnectionIdViewModel>.query("GET_ALL_CONNECTION_IDS_BY_ID @user_id", userIdParam); //run stored procedure
+
+            var model = result.Select(x =>
+            {
+                ConnectionIdViewModel y = new ConnectionIdViewModel();
+                y.connection_id = x.connection_id;
+               
+
+                return y;
+            });
+
+
+            return model;
 
         }
 

--- a/Gordon360/Services/DirectMessageService.cs
+++ b/Gordon360/Services/DirectMessageService.cs
@@ -229,6 +229,8 @@ namespace Gordon360.Services
 
         }
 
+        
+
         public bool StoreUserRooms(String userId, String roomId)
         {
             var _unitOfWork = new UnitOfWork();
@@ -257,6 +259,7 @@ namespace Gordon360.Services
             return returnAnswer;
 
         }
+
 
         public bool StoreUserConnectionIds(String userId, String connectionId)
         {
@@ -311,6 +314,26 @@ namespace Gordon360.Services
 
 
             return model;
+
+        }
+
+        public bool DeleteUserConnectionIds(String connectionId)
+        {
+            var connectionIdParam = new SqlParameter("@connection_id", connectionId);
+
+            var result = RawSqlQuery<MessageViewModel>.query("DELETE_USER_CONNECTION_ID  @connection_id", connectionIdParam); //run stored procedure
+
+            bool returnAnswer = true;
+
+            if (result == null)
+            {
+                returnAnswer = false;
+                throw new ResourceNotFoundException() { ExceptionMessage = "The data was not found." };
+            }
+
+
+
+            return returnAnswer;
 
         }
 

--- a/Gordon360/Services/DirectMessageService.cs
+++ b/Gordon360/Services/DirectMessageService.cs
@@ -259,6 +259,35 @@ namespace Gordon360.Services
 
         }
 
+        public bool StoreUserConnectionIds(String userId, String connectionId)
+        {
+            var _unitOfWork = new UnitOfWork();
+            var query = _unitOfWork.AccountRepository.FirstOrDefault(x => x.gordon_id == userId);
+            if (query == null)
+            {
+                throw new ResourceNotFoundException() { ExceptionMessage = "The account was not found." };
+            }
+
+            var userIdParam = new SqlParameter("@user_id", userId);
+            var connectionIdParam = new SqlParameter("@connection_id", connectionId);
+
+
+            var result = RawSqlQuery<MessageViewModel>.query("INSERT_USER_CONNECTION_ID @user_id, @connection_id", userIdParam, connectionIdParam); //run stored procedure
+
+            bool returnAnswer = true;
+
+            if (result == null)
+            {
+                returnAnswer = false;
+                throw new ResourceNotFoundException() { ExceptionMessage = "The data was not found." };
+            }
+
+
+
+            return returnAnswer;
+
+        }
+
 
     }
 

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -66,6 +66,7 @@ namespace Gordon360.Services
         bool CreateGroup(String id, String name, bool group, DateTime lastUpdated,string image);
         bool SendMessage(SendTextViewModel textInfo, string user_id);
         bool StoreUserRooms(String userId, String roomId);
+        bool StoreUserConnectionIds(String userId, String connectionId);
         IEnumerable<MessageViewModel> GetMessages(string roomId);
         IEnumerable<GroupViewModel> GetRooms(string userId);
         List<Object> GetRoomById(string userId);

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -67,6 +67,7 @@ namespace Gordon360.Services
         bool SendMessage(SendTextViewModel textInfo, string user_id);
         bool StoreUserRooms(String userId, String roomId);
         bool StoreUserConnectionIds(String userId, String connectionId);
+        bool DeleteUserConnectionIds(String connectionId);
         IEnumerable<ConnectionIdViewModel> GetUserConnectionIds(String userId);
         IEnumerable<MessageViewModel> GetMessages(string roomId);
         IEnumerable<GroupViewModel> GetRooms(string userId);

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -67,6 +67,7 @@ namespace Gordon360.Services
         bool SendMessage(SendTextViewModel textInfo, string user_id);
         bool StoreUserRooms(String userId, String roomId);
         bool StoreUserConnectionIds(String userId, String connectionId);
+        IEnumerable<ConnectionIdViewModel> GetUserConnectionIds(String userId);
         IEnumerable<MessageViewModel> GetMessages(string roomId);
         IEnumerable<GroupViewModel> GetRooms(string userId);
         List<Object> GetRoomById(string userId);


### PR DESCRIPTION
Added a endpoint called "UserConnectionIds" That handles the users connections identifiers from the websockets and allows us to call and reference the connection ids from a given user ID.

POST - Stores users connection id into a table 

PUT -  Grabs all the users connection Ids from the table based on the users ID