### PR TITLE
Fix timezone issues by accepting url query params in getJobs 

### DIFF
--- a/Gordon360/ApiControllers/JobsController.cs
+++ b/Gordon360/ApiControllers/JobsController.cs
@@ -44,6 +44,25 @@ namespace Gordon360.ApiControllers
             return userID;
         }
 
+        /// Get a user's active jobs
+        /// </summary>
+        /// <param name="details"></param>
+        /// <returns>The user's active jobs</returns>
+        [HttpGet]
+        [Route("")]
+        public IHttpActionResult GetJobs(DateTime shiftStart, DateTime shiftEnd) {
+            IEnumerable<ActiveJobViewModel> result;
+            try {
+                result = _jobsService.getActiveJobs(shiftStart, shiftEnd, GetCurrentUserID());
+            }
+            catch(Exception e) {
+                //
+                System.Diagnostics.Debug.WriteLine(e.Message);
+                return InternalServerError();
+            }
+            return Ok(result);
+        }
+
         /// <summary>
         /// Get a user's active jobs
         /// </summary>
@@ -51,7 +70,7 @@ namespace Gordon360.ApiControllers
         /// <returns>The user's active jobs</returns>
         [HttpPost]
         [Route("getJobs")]
-        public IHttpActionResult getJobsForUser([FromBody] ActiveJobSelectionParametersModel details)
+        public IHttpActionResult DEPRECATED_getJobsForUser([FromBody] ActiveJobSelectionParametersModel details)
         {
             IEnumerable<ActiveJobViewModel> result = null;
             int userID = GetCurrentUserID();

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -211,7 +211,8 @@
             </summary>
             <returns></returns>
         </member>
-        <member name="M:Gordon360.ApiControllers.JobsController.getJobsForUser(Gordon360.Models.ViewModels.ActiveJobSelectionParametersModel)">
+        <!-- Badly formed XML comment ignored for member "M:Gordon360.ApiControllers.JobsController.GetJobs(System.DateTime,System.DateTime)" -->
+        <member name="M:Gordon360.ApiControllers.JobsController.DEPRECATED_getJobsForUser(Gordon360.Models.ViewModels.ActiveJobSelectionParametersModel)">
             <summary>
             Get a user's active jobs
             </summary>


### PR DESCRIPTION
The old `getJobs` route was actually a HttpPost route that accepted an input object of just a shift start time and a shift end time. The new route that replaces it is a true HttpGet route and uses query params to pass datetimes directly.

This is not a breaking change since the old route has been left unchanged but deprecated in the code.