### PR TITLE
Wellness expiration date is changing from 5AM to 4:45AM

### DIFF
--- a/Gordon360/Services/WellnessService.cs
+++ b/Gordon360/Services/WellnessService.cs
@@ -125,7 +125,7 @@ namespace Gordon360.Services
         private DateTime ExpirationDate(DateTime currentTime)
         {
             // Answer expires at 5AM
-            DateTime expirationTime = new DateTime(currentTime.Year, currentTime.Month, currentTime.Day, 5, 0, 0);
+            DateTime expirationTime = new DateTime(currentTime.Year, currentTime.Month, currentTime.Day, 4, 45, 0);
 
             // If it's past 5AM, expirationTime is 5AM tomorrow.
             if (currentTime > expirationTime)


### PR DESCRIPTION
This was motivated by support ticket #137301

Certain campus activities (notably athletics) meet as early as 5AM, and would like to be able to complete their wellness check slightly before that time. This change coincides with one to the GO site Health Administration page to the same effect, as well as an update to the Powershell script that sends out reminder emails. That way, all 3 will use 4:45AM as the default expiration/rollover for wellness checks.