### PR TITLE
Fixing a typo of HousingService.cs

### DIFF
--- a/Gordon360/Services/HousingService.cs
+++ b/Gordon360/Services/HousingService.cs
@@ -503,7 +503,7 @@ namespace Gordon360.Services
                 // All SqlParameters must be remade before being reused in an SQL Query to prevent errors
                 appIdParam = new SqlParameter("@APPLICATION_ID", apartAppId);
                 buildingCodeParam = new SqlParameter("@BLDG_CDE", bldg);
-                apartmentChoiceResult = RawSqlQuery<ApartmentChoiceSaveViewModel>.query("DELETE_AA_APARTMENT_CHOICES @APPLICATION_ID, @BLDG_CDE", appIdParam, buildingCodeParam); // run stored procedure
+                apartmentChoiceResult = RawSqlQuery<ApartmentChoiceSaveViewModel>.query("DELETE_AA_APARTMENT_CHOICE @APPLICATION_ID, @BLDG_CDE", appIdParam, buildingCodeParam); // run stored procedure
                 if (apartmentChoiceResult == null)
                 {
                     throw new ResourceNotFoundException() { ExceptionMessage = "The apartment preference could not be saved." };


### PR DESCRIPTION
Removed "S" in the rawsqlquery statement to make it singular and to match it with the database.