### PR TITLE
Catch and log errors in JobsController saveShiftForUser

### DIFF
--- a/Gordon360/ApiControllers/JobsController.cs
+++ b/Gordon360/ApiControllers/JobsController.cs
@@ -25,12 +25,14 @@ namespace Gordon360.ApiControllers
     {
         private IJobsService _jobsService;
         private IAccountService _accountService;
+        private IErrorLogService _errorLogService;
 
         public JobsController()
         {
             IUnitOfWork _unitOfWork = new UnitOfWork();
             _jobsService = new JobsService(_unitOfWork);
             _accountService = new AccountService(_unitOfWork);
+            _errorLogService = new ErrorLogService(_unitOfWork);
         }
 
         private int GetCurrentUserID()
@@ -130,6 +132,13 @@ namespace Gordon360.ApiControllers
 
             try
             {
+
+                if (shiftDetails.SHIFT_START_DATETIME == null || shiftDetails.SHIFT_END_DATETIME == null || shiftDetails.SHIFT_START_DATETIME == shiftDetails.SHIFT_END_DATETIME)
+                {
+                    _errorLogService.Log($"Invalid timesheets shift saved. Student ID: {shiftDetails.ID}, job ID: {shiftDetails.EML}, shiftStart: {shiftDetails.SHIFT_START_DATETIME}, shift end time: {shiftDetails.SHIFT_END_DATETIME}, hours worked: {shiftDetails.HOURS_WORKED} at time {DateTime.Now}");
+                    throw new Exception("Invalid shift times. shiftStart and shiftEnd must be non-null and not the same.");
+                };
+
                 overlapCheckResult = _jobsService.checkForOverlappingShift(userID, shiftDetails.SHIFT_START_DATETIME, shiftDetails.SHIFT_END_DATETIME);
                 if (overlapCheckResult.Count() > 0)
                 {


### PR DESCRIPTION
when shifts are saved, some have started coming through with the Time part of DateTime lost, so the start and end time are both 12AM. This adds error logging to catch these errors, reject the improper shifts, and add a log to CCT's Error Log table detailing the erroneous shift.

This should allow users to access timesheets via 360 until we figure out the source of the issue, since people won't be able to submit erroneous shifts. It should also potentially help us track down the source of the issue.