### PR TITLE
Apartapp - Debugging the save feature

### DIFF
--- a/Gordon360/ApiControllers/HousingController.cs
+++ b/Gordon360/ApiControllers/HousingController.cs
@@ -91,10 +91,9 @@ namespace Gordon360.Controllers.Api
             ClaimsPrincipal authenticatedUser = this.ActionContext.RequestContext.Principal as ClaimsPrincipal;
             string username = authenticatedUser.Claims.FirstOrDefault(x => x.Type == "user_name").Value;
 
-            string editorID = _accountService.GetAccountByUsername(username).GordonID;
             string sessionID = Helpers.GetCurrentSession().SessionCode;
 
-            int? result = _housingService.GetApplicationID(editorID, sessionID);
+            int? result = _housingService.GetApplicationID(username, sessionID);
             if (result != null)
             {
                 return Ok(result);
@@ -156,17 +155,11 @@ namespace Gordon360.Controllers.Api
 
             string sessionID = Helpers.GetCurrentSession().SessionCode;
 
-            string editorID = _accountService.GetAccountByUsername(applicationDetails.EditorUsername).GordonID;
-
+            string editorUsername = applicationDetails.EditorUsername;
             ApartmentApplicantViewModel[] apartmentApplicants = applicationDetails.Applicants;
-            foreach (ApartmentApplicantViewModel applicant in apartmentApplicants)
-            {
-                applicant.StudentID = _accountService.GetAccountByUsername(applicant.Username).GordonID;
-            }
-
             ApartmentChoiceViewModel[] apartmentChoices = applicationDetails.ApartmentChoices;
 
-            int result = _housingService.SaveApplication(username, sessionID, editorID, apartmentApplicants, apartmentChoices);
+            int result = _housingService.SaveApplication(username, sessionID, editorUsername, apartmentApplicants, apartmentChoices);
 
             return Created("Status of application saving: ", result);
         }
@@ -200,13 +193,7 @@ namespace Gordon360.Controllers.Api
             string sessionID = Helpers.GetCurrentSession().SessionCode;
 
             string newEditorUsername = applicationDetails.EditorUsername;
-
             ApartmentApplicantViewModel[] newApartmentApplicants = applicationDetails.Applicants;
-            foreach (ApartmentApplicantViewModel applicant in newApartmentApplicants)
-            {
-                applicant.StudentID = _accountService.GetAccountByUsername(applicant.Username).GordonID;
-            }
-
             ApartmentChoiceViewModel[] newApartmentChoices = applicationDetails.ApartmentChoices;
 
             int result = _housingService.EditApplication(username, sessionID, applicationID, newEditorUsername, newApartmentApplicants, newApartmentChoices);

--- a/Gordon360/ApiControllers/HousingController.cs
+++ b/Gordon360/ApiControllers/HousingController.cs
@@ -91,9 +91,10 @@ namespace Gordon360.Controllers.Api
             ClaimsPrincipal authenticatedUser = this.ActionContext.RequestContext.Principal as ClaimsPrincipal;
             string username = authenticatedUser.Claims.FirstOrDefault(x => x.Type == "user_name").Value;
 
+            string userID = _accountService.GetAccountByUsername(username).GordonID;
             string sessionID = Helpers.GetCurrentSession().SessionCode;
 
-            int? result = _housingService.GetApplicationID(username, sessionID);
+            int? result = _housingService.GetApplicationID(userID, sessionID);
             if (result != null)
             {
                 return Ok(result);
@@ -113,9 +114,10 @@ namespace Gordon360.Controllers.Api
         [Route("apartment/{username}")]
         public IHttpActionResult GetUserApplicationID(string username)
         {
+            string userID = _accountService.GetAccountByUsername(username).GordonID;
             string sessionID = Helpers.GetCurrentSession().SessionCode;
 
-            int? result = _housingService.GetApplicationID(username, sessionID);
+            int? result = _housingService.GetApplicationID(userID, sessionID);
             if (result != null)
             {
                 return Ok(result);
@@ -152,14 +154,22 @@ namespace Gordon360.Controllers.Api
             //get token data from context, username is the username of current logged in person
             ClaimsPrincipal authenticatedUser = this.ActionContext.RequestContext.Principal as ClaimsPrincipal;
             string username = authenticatedUser.Claims.FirstOrDefault(x => x.Type == "user_name").Value;
+            string userID = _accountService.GetAccountByUsername(username).GordonID;
 
             string sessionID = Helpers.GetCurrentSession().SessionCode;
 
             string editorUsername = applicationDetails.EditorUsername;
+            string editorID = _accountService.GetAccountByUsername(username).GordonID;
+
             ApartmentApplicantViewModel[] apartmentApplicants = applicationDetails.Applicants;
+            foreach (ApartmentApplicantViewModel applicant in apartmentApplicants)
+            {
+                applicant.StudentID = _accountService.GetAccountByUsername(applicant.Username).GordonID;
+            }
+
             ApartmentChoiceViewModel[] apartmentChoices = applicationDetails.ApartmentChoices;
 
-            int result = _housingService.SaveApplication(username, sessionID, editorUsername, apartmentApplicants, apartmentChoices);
+            int result = _housingService.SaveApplication(userID, sessionID, editorID, apartmentApplicants, apartmentChoices);
 
             return Created("Status of application saving: ", result);
         }
@@ -189,14 +199,22 @@ namespace Gordon360.Controllers.Api
             //get token data from context, username is the username of current logged in person
             ClaimsPrincipal authenticatedUser = this.ActionContext.RequestContext.Principal as ClaimsPrincipal;
             string username = authenticatedUser.Claims.FirstOrDefault(x => x.Type == "user_name").Value;
+            string userID = _accountService.GetAccountByUsername(username).GordonID;
 
             string sessionID = Helpers.GetCurrentSession().SessionCode;
 
             string newEditorUsername = applicationDetails.EditorUsername;
+            string newEditorID = _accountService.GetAccountByUsername(username).GordonID;
+
             ApartmentApplicantViewModel[] newApartmentApplicants = applicationDetails.Applicants;
+            foreach (ApartmentApplicantViewModel applicant in newApartmentApplicants)
+            {
+                applicant.StudentID = _accountService.GetAccountByUsername(applicant.Username).GordonID;
+            }
+
             ApartmentChoiceViewModel[] newApartmentChoices = applicationDetails.ApartmentChoices;
 
-            int result = _housingService.EditApplication(username, sessionID, applicationID, newEditorUsername, newApartmentApplicants, newApartmentChoices);
+            int result = _housingService.EditApplication(userID, sessionID, applicationID, newEditorID, newApartmentApplicants, newApartmentChoices);
 
             return Created("Status of application saving: ", result);
         }
@@ -226,10 +244,12 @@ namespace Gordon360.Controllers.Api
             //get token data from context, username is the username of current logged in person
             ClaimsPrincipal authenticatedUser = this.ActionContext.RequestContext.Principal as ClaimsPrincipal;
             string username = authenticatedUser.Claims.FirstOrDefault(x => x.Type == "user_name").Value;
+            string userID = _accountService.GetAccountByUsername(username).GordonID;
 
             string newEditorUsername = applicationDetails.EditorUsername;
+            string newEditorID = _accountService.GetAccountByUsername(username).GordonID;
 
-            bool result = _housingService.ChangeApplicationEditor(username, applicationID, newEditorUsername);
+            bool result = _housingService.ChangeApplicationEditor(userID, applicationID, newEditorID);
 
             return Ok(result);
         }
@@ -246,10 +266,11 @@ namespace Gordon360.Controllers.Api
             //get token data from context, username is the username of current logged in person
             ClaimsPrincipal authenticatedUser = this.ActionContext.RequestContext.Principal as ClaimsPrincipal;
             string username = authenticatedUser.Claims.FirstOrDefault(x => x.Type == "user_name").Value;
+            string userID = _accountService.GetAccountByUsername(username).GordonID;
 
             string sessionID = Helpers.GetCurrentSession().SessionCode;
 
-            int? storedApplicationID = _housingService.GetApplicationID(username, sessionID);
+            int? storedApplicationID = _housingService.GetApplicationID(userID, sessionID);
             if (storedApplicationID == null)
             {
                 return NotFound();
@@ -282,7 +303,6 @@ namespace Gordon360.Controllers.Api
             //get token data from context, username is the username of current logged in person
             ClaimsPrincipal authenticatedUser = this.ActionContext.RequestContext.Principal as ClaimsPrincipal;
             string username = authenticatedUser.Claims.FirstOrDefault(x => x.Type == "user_name").Value;
-
             string userID = _accountService.GetAccountByUsername(username).GordonID;
 
             bool isAdmin = _housingService.CheckIfHousingAdmin(userID);

--- a/Gordon360/ApiControllers/HousingController.cs
+++ b/Gordon360/ApiControllers/HousingController.cs
@@ -159,7 +159,7 @@ namespace Gordon360.Controllers.Api
             string sessionID = Helpers.GetCurrentSession().SessionCode;
 
             string editorUsername = applicationDetails.EditorUsername;
-            string editorID = _accountService.GetAccountByUsername(username).GordonID;
+            string editorID = _accountService.GetAccountByUsername(editorUsername).GordonID;
 
             ApartmentApplicantViewModel[] apartmentApplicants = applicationDetails.Applicants;
             foreach (ApartmentApplicantViewModel applicant in apartmentApplicants)
@@ -204,7 +204,7 @@ namespace Gordon360.Controllers.Api
             string sessionID = Helpers.GetCurrentSession().SessionCode;
 
             string newEditorUsername = applicationDetails.EditorUsername;
-            string newEditorID = _accountService.GetAccountByUsername(username).GordonID;
+            string newEditorID = _accountService.GetAccountByUsername(newEditorUsername).GordonID;
 
             ApartmentApplicantViewModel[] newApartmentApplicants = applicationDetails.Applicants;
             foreach (ApartmentApplicantViewModel applicant in newApartmentApplicants)
@@ -247,7 +247,7 @@ namespace Gordon360.Controllers.Api
             string userID = _accountService.GetAccountByUsername(username).GordonID;
 
             string newEditorUsername = applicationDetails.EditorUsername;
-            string newEditorID = _accountService.GetAccountByUsername(username).GordonID;
+            string newEditorID = _accountService.GetAccountByUsername(newEditorUsername).GordonID;
 
             bool result = _housingService.ChangeApplicationEditor(userID, applicationID, newEditorID);
 

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -1970,12 +1970,6 @@
              </summary>
              <returns>Whether or not all the queries succeeded</returns>
         </member>
-        <member name="M:Gordon360.Services.HousingService.CreateCSV">
-            <summary>
-            Creates a string from the combination of AA_ApartementApplications and AA_Applicants Tables
-            and returns it to the frontend, so that it can convert it into a csv file.
-            </summary>
-        </member>
         <member name="M:Gordon360.Services.WellnessService.GetStatus(System.String)">
             <summary>
             Get the status of the user by id

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -1922,7 +1922,7 @@
             Calls a stored procedure that tries to get the id of an the application that a given user is 
             applicant on for a given session
             </summary>
-            <param name="username"> The student username to look for </param>
+            <param name="userID"> The student username to look for </param>
             /// <param name="sess_cde"> Session for which the application would be </param>
             <returns> 
             The id of the application or 
@@ -1939,9 +1939,9 @@
              which application on which they are an applicant
             
              </summary>
-             <param name="username"> The student username of the user who is attempting to save the apartment application (retrieved via authentication token) </param>
+             <param name="userID"> The student username of the user who is attempting to save the apartment application (retrieved via authentication token) </param>
              <param name="sess_cde"> The current session code </param>
-             <param name="editorUsername"> The student username of the student who is declared to be the editor of this application (retrieved from the JSON from the front end) </param>
+             <param name="editorID"> The student username of the student who is declared to be the editor of this application (retrieved from the JSON from the front end) </param>
              <param name="apartmentApplicants"> Array of JSON objects providing apartment applicants </param>
              <param name="apartmentChoices"> Array of JSON objects providing apartment hall choices </param>
              <returns>Returns the application ID number if all the queries succeeded</returns>
@@ -1955,10 +1955,10 @@
              - fourth, it removes each applicant that was stored in the database but was not in the 'newApplicantIDs' array
             
              </summary>
-             <param name="username"> The student username of the user who is attempting to save the apartment application (retrieved via authentication token) </param>
+             <param name="userID"> The student username of the user who is attempting to save the apartment application (retrieved via authentication token) </param>
              <param name="sess_cde"> The current session code </param>
              <param name="applicationID"> The application ID number of the application to be edited </param>
-             <param name="newEditorUsername"> The student username of the student who is declared to be the editor of this application (retrieved from the JSON from the front end) </param>
+             <param name="newEditorID"> The student username of the student who is declared to be the editor of this application (retrieved from the JSON from the front end) </param>
              <param name="newApartmentApplicants"> Array of JSON objects providing apartment applicants </param>
              <param name="newApartmentChoices"> Array of JSON objects providing apartment hall choices </param>
              <returns>Returns the application ID number if all the queries succeeded</returns>

--- a/Gordon360/Models/ViewModels/ApartmentApplicantViewModel.cs
+++ b/Gordon360/Models/ViewModels/ApartmentApplicantViewModel.cs
@@ -4,7 +4,6 @@
     public class ApartmentApplicantViewModel
     {
         public int ApplicationID { get; set; }
-        public string StudentID { get; set; }
         public string Username { get; set; }
         public int? Age { get; set; }
         public string Class { get; set; }

--- a/Gordon360/Models/ViewModels/ApartmentApplicantViewModel.cs
+++ b/Gordon360/Models/ViewModels/ApartmentApplicantViewModel.cs
@@ -4,6 +4,7 @@
     public class ApartmentApplicantViewModel
     {
         public int ApplicationID { get; set; }
+        public StudentProfileViewModel Profile { get; set; }
         public string StudentID { get; set; }
         public string Username { get; set; }
         public int? Age { get; set; }

--- a/Gordon360/Models/ViewModels/ApartmentApplicantViewModel.cs
+++ b/Gordon360/Models/ViewModels/ApartmentApplicantViewModel.cs
@@ -4,6 +4,7 @@
     public class ApartmentApplicantViewModel
     {
         public int ApplicationID { get; set; }
+        public string StudentID { get; set; }
         public string Username { get; set; }
         public int? Age { get; set; }
         public string Class { get; set; }

--- a/Gordon360/Models/ViewModels/ApartmentApplicationViewModel.cs
+++ b/Gordon360/Models/ViewModels/ApartmentApplicationViewModel.cs
@@ -9,6 +9,7 @@ namespace Gordon360.Models.ViewModels
         public DateTime? DateSubmitted { get; set; } // Nullable
         public DateTime DateModified { get; set; }
         public string EditorUsername { get; set; }
+        public string EditorEmail { get; set; }
         public string Gender { get; set; }
         public ApartmentApplicantViewModel[] Applicants { get; set; }
         public ApartmentChoiceViewModel[] ApartmentChoices { get; set; }

--- a/Gordon360/Services/HousingService.cs
+++ b/Gordon360/Services/HousingService.cs
@@ -135,6 +135,8 @@ namespace Gordon360.Services
         /// <returns>Returns the application ID number if all the queries succeeded</returns>
         public int SaveApplication(string username, string sess_cde, string editorUsername, ApartmentApplicantViewModel[] apartmentApplicants, ApartmentChoiceViewModel[] apartmentChoices)
         {
+            CCTEntities1 context = new CCTEntities1();
+
             IEnumerable<ApartmentAppIDViewModel> idResult = null;
 
             DateTime now = System.DateTime.Now;
@@ -152,14 +154,12 @@ namespace Gordon360.Services
             //----------------
             // Save the application editor and time
 
-            IEnumerable<AA_ApartmentApplications> newAppResult = null;
-
             // All SqlParameters must be remade before being reused in an SQL Query to prevent errors
             SqlParameter timeParam = new SqlParameter("@NOW", now);
             editorParam = new SqlParameter("@EDITOR_ID", editorUsername);
 
             // If an existing application was not found for this editor, then insert a new application entry in the database
-            newAppResult = RawSqlQuery<AA_ApartmentApplications>.query("INSERT_AA_APPLICATION @NOW, @EDITOR_ID", timeParam, editorParam); //run stored procedure
+            int newAppResult = context.Database.ExecuteSqlCommand("INSERT_AA_APPLICATION @NOW, @EDITOR_ID", timeParam, editorParam); //run stored procedure
             if (newAppResult == null)
             {
                 throw new ResourceCreationException() { ExceptionMessage = "The application could not be saved." };
@@ -194,8 +194,6 @@ namespace Gordon360.Services
 
             foreach (ApartmentApplicantViewModel applicant in apartmentApplicants)
             {
-                IEnumerable<AA_Applicants> applicantResult = null;
-
                 // All SqlParameters must be remade before being reused in an SQL Query to prevent errors
                 appIDParam = new SqlParameter("@APPLICATION_ID", applicationID);
                 idParam = new SqlParameter("@ID_NUM", applicant.StudentID);
@@ -209,7 +207,7 @@ namespace Gordon360.Services
                 }
                 sessionParam = new SqlParameter("@SESS_CDE", sess_cde);
 
-                applicantResult = RawSqlQuery<AA_Applicants>.query("INSERT_AA_APPLICANT @APPLICATION_ID, @ID_NUM, @APRT_PROGRAM, @SESS_CDE", appIDParam, idParam, programParam, sessionParam); //run stored procedure
+                int applicantResult = context.Database.ExecuteSqlCommand("INSERT_AA_APPLICANT @APPLICATION_ID, @ID_NUM, @APRT_PROGRAM, @SESS_CDE", appIDParam, idParam, programParam, sessionParam); //run stored procedure
                 if (applicantResult == null)
                 {
                     throw new ResourceCreationException() { ExceptionMessage = "Applicant with ID " + applicant.StudentID + " could not be saved." };
@@ -224,13 +222,11 @@ namespace Gordon360.Services
 
             foreach (ApartmentChoiceViewModel choice in apartmentChoices)
             {
-                IEnumerable<AA_ApartmentChoices> apartmentChoiceResult = null;
-
                 // All SqlParameters must be remade before being reused in an SQL Query to prevent errors
                 appIDParam = new SqlParameter("@APPLICATION_ID", applicationID);
                 rankingParam = new SqlParameter("@RANKING", choice.HallRank);
                 buildingCodeParam = new SqlParameter("@BLDG_CDE", choice.HallName);
-                apartmentChoiceResult = RawSqlQuery<AA_ApartmentChoices>.query("INSERT_AA_APARTMENT_CHOICE @APPLICATION_ID, @RANKING, @BLDG_CDE", appIDParam, rankingParam, buildingCodeParam); // run stored procedure
+                int apartmentChoiceResult = context.Database.ExecuteSqlCommand("INSERT_AA_APARTMENT_CHOICE @APPLICATION_ID, @RANKING, @BLDG_CDE", appIDParam, rankingParam, buildingCodeParam); // run stored procedure
                 if (apartmentChoiceResult == null)
                 {
                     throw new ResourceCreationException() { ExceptionMessage = "The apartment preference could not be saved." };
@@ -257,6 +253,8 @@ namespace Gordon360.Services
         /// <returns>Returns the application ID number if all the queries succeeded</returns>
         public int EditApplication(string username, string sess_cde, int applicationID, string newEditorUsername, ApartmentApplicantViewModel[] newApartmentApplicants, ApartmentChoiceViewModel[] newApartmentChoices)
         {
+            CCTEntities1 context = new CCTEntities1();
+
             IEnumerable<string> editorResult = null;
 
             SqlParameter appIDParam = new SqlParameter("@APPLICATION_ID", applicationID);
@@ -336,8 +334,6 @@ namespace Gordon360.Services
             // Insert new applicants that are not yet in the database
             foreach (ApartmentApplicantViewModel applicant in applicantsToAdd)
             {
-                IEnumerable<AA_Applicants> applicantResult = null;
-
                 // All SqlParameters must be remade before being reused in an SQL Query to prevent errors
                 appIDParam = new SqlParameter("@APPLICATION_ID", applicationID);
                 idParam = new SqlParameter("@ID_NUM", applicant.StudentID);
@@ -351,7 +347,7 @@ namespace Gordon360.Services
                 }
                 sessionParam = new SqlParameter("@SESS_CDE", sess_cde);
 
-                applicantResult = RawSqlQuery<AA_Applicants>.query("INSERT_AA_APPLICANT @APPLICATION_ID, @ID_NUM, @APRT_PROGRAM, @SESS_CDE", appIDParam, idParam, programParam, sessionParam); //run stored procedure
+                int applicantResult = context.Database.ExecuteSqlCommand("INSERT_AA_APPLICANT @APPLICATION_ID, @ID_NUM, @APRT_PROGRAM, @SESS_CDE", appIDParam, idParam, programParam, sessionParam); //run stored procedure
                 if (applicantResult == null)
                 {
                     throw new ResourceCreationException() { ExceptionMessage = "Applicant with ID " + applicant.StudentID + " could not be inserted." };
@@ -361,8 +357,6 @@ namespace Gordon360.Services
             // Update the info of applicants from the frontend that are already in the database
             foreach (ApartmentApplicantViewModel applicant in applicantsToUpdate)
             {
-                IEnumerable<AA_Applicants> applicantResult = null;
-
                 // All SqlParameters must be remade before being reused in an SQL Query to prevent errors
                 appIDParam = new SqlParameter("@APPLICATION_ID", applicationID);
                 idParam = new SqlParameter("@ID_NUM", applicant.StudentID);
@@ -376,7 +370,7 @@ namespace Gordon360.Services
                 }
                 sessionParam = new SqlParameter("@SESS_CDE", sess_cde);
 
-                applicantResult = RawSqlQuery<AA_Applicants>.query("UPDATE_AA_APPLICANT @APPLICATION_ID, @ID_NUM, @APRT_PROGRAM, @SESS_CDE", appIDParam, idParam, programParam, sessionParam); //run stored procedure
+                int applicantResult = context.Database.ExecuteSqlCommand("UPDATE_AA_APPLICANT @APPLICATION_ID, @ID_NUM, @APRT_PROGRAM, @SESS_CDE", appIDParam, idParam, programParam, sessionParam); //run stored procedure
                 if (applicantResult == null)
                 {
                     throw new ResourceCreationException() { ExceptionMessage = "Applicant with ID " + applicant.StudentID + " could not be updated." };
@@ -386,14 +380,12 @@ namespace Gordon360.Services
             // Remove applicants from the database that were remove from the frontend
             foreach (ApartmentApplicantViewModel applicant in applicantsToRemove)
             {
-                IEnumerable<AA_Applicants> applicantResult = null;
-
                 // All SqlParameters must be remade before being reused in an SQL Query to prevent errors
                 appIDParam = new SqlParameter("@APPLICATION_ID", applicationID);
                 idParam = new SqlParameter("@ID_NUM", applicant.StudentID);
                 sessionParam = new SqlParameter("@SESS_CDE", sess_cde);
 
-                applicantResult = RawSqlQuery<AA_Applicants>.query("DELETE_AA_APPLICANT @APPLICATION_ID, @ID_NUM, @SESS_CDE", appIDParam, idParam, sessionParam); //run stored procedure
+                int applicantResult = context.Database.ExecuteSqlCommand("DELETE_AA_APPLICANT @APPLICATION_ID, @ID_NUM, @SESS_CDE", appIDParam, idParam, sessionParam); //run stored procedure
                 if (applicantResult == null)
                 {
                     throw new ResourceNotFoundException() { ExceptionMessage = "Applicant with ID " + applicant.StudentID + " could not be removed." };
@@ -454,14 +446,12 @@ namespace Gordon360.Services
             // Insert new apartment choices that are not yet in the database
             foreach (ApartmentChoiceViewModel apartmentChoice in apartmentChoicesToAdd)
             {
-                IEnumerable<AA_ApartmentChoices> apartmentChoiceResult = null;
-
                 // All SqlParameters must be remade before being reused in an SQL Query to prevent errors
                 appIDParam = new SqlParameter("@APPLICATION_ID", applicationID);
                 rankingParam = new SqlParameter("@RANKING", apartmentChoice.HallRank);
                 buildingCodeParam = new SqlParameter("@BLDG_CDE", apartmentChoice.HallName);
 
-                apartmentChoiceResult = RawSqlQuery<AA_ApartmentChoices>.query("INSERT_AA_APARTMENT_CHOICE @APPLICATION_ID, @RANKING, @BLDG_CDE", appIDParam, rankingParam, buildingCodeParam); //run stored procedure
+                int apartmentChoiceResult = context.Database.ExecuteSqlCommand("INSERT_AA_APARTMENT_CHOICE @APPLICATION_ID, @RANKING, @BLDG_CDE", appIDParam, rankingParam, buildingCodeParam); //run stored procedure
                 if (apartmentChoiceResult == null)
                 {
                     throw new ResourceCreationException() { ExceptionMessage = "Apartment choice with ID " + applicationID + " and hall name " + apartmentChoice.HallName + " could not be inserted." };
@@ -471,14 +461,12 @@ namespace Gordon360.Services
             // Update the info of apartment choices from the frontend that are already in the database
             foreach (ApartmentChoiceViewModel apartmentChoice in apartmentChoicesToUpdate)
             {
-                IEnumerable<AA_ApartmentChoices> apartmentChoiceResult = null;
-
                 // All SqlParameters must be remade before being reused in an SQL Query to prevent errors
                 appIDParam = new SqlParameter("@APPLICATION_ID", applicationID);
                 rankingParam = new SqlParameter("@RANKING", apartmentChoice.HallRank);
                 buildingCodeParam = new SqlParameter("@BLDG_CDE", apartmentChoice.HallName);
 
-                apartmentChoiceResult = RawSqlQuery<AA_ApartmentChoices>.query("UPDATE_AA_APARTMENT_CHOICE @APPLICATION_ID, @RANKING, @BLDG_CDE", appIDParam, rankingParam, buildingCodeParam); //run stored procedure
+                int apartmentChoiceResult = context.Database.ExecuteSqlCommand("UPDATE_AA_APARTMENT_CHOICE @APPLICATION_ID, @RANKING, @BLDG_CDE", appIDParam, rankingParam, buildingCodeParam); //run stored procedure
                 if (apartmentChoiceResult == null)
                 {
                     throw new ResourceCreationException() { ExceptionMessage = "Apartment choice with ID " + applicationID + " and hall name " + apartmentChoice.HallName + " could not be updated." };
@@ -488,14 +476,12 @@ namespace Gordon360.Services
             // Remove apartment choices from the database that were removed from the frontend
             foreach (ApartmentChoiceViewModel apartmentChoice in apartmentChoicesToRemove)
             {
-                IEnumerable<AA_ApartmentChoices> apartmentChoiceResult = null;
-
                 // All SqlParameters must be remade before being reused in an SQL Query to prevent errors
                 appIDParam = new SqlParameter("@APPLICATION_ID", applicationID);
                 rankingParam = new SqlParameter("@RANKING", apartmentChoice.HallRank);
                 buildingCodeParam = new SqlParameter("@BLDG_CDE", apartmentChoice.HallName);
 
-                apartmentChoiceResult = RawSqlQuery<AA_ApartmentChoices>.query("DELETE_AA_APARTMENT_CHOICE @APPLICATION_ID, @BLDG_CDE", appIDParam, buildingCodeParam); //run stored procedure
+                int apartmentChoiceResult = context.Database.ExecuteSqlCommand("DELETE_AA_APARTMENT_CHOICE @APPLICATION_ID, @BLDG_CDE", appIDParam, buildingCodeParam); //run stored procedure
                 if (apartmentChoiceResult == null)
                 {
                     throw new ResourceNotFoundException() { ExceptionMessage = "Apartment choice with ID " + applicationID + " and hall name " + apartmentChoice.HallName + " could not be removed." };
@@ -505,8 +491,6 @@ namespace Gordon360.Services
             //--------
             // Update the date modified (and application editor if necessary)
 
-            IEnumerable<ApartmentApplicationViewModel> result = null;
-
             DateTime now = System.DateTime.Now;
 
             appIDParam = new SqlParameter("@APPLICATION_ID", applicationID);
@@ -515,7 +499,7 @@ namespace Gordon360.Services
             {
                 SqlParameter editorParam = new SqlParameter("@EDITOR_ID", username);
                 SqlParameter newEditorParam = new SqlParameter("@NEW_EDITOR_ID", newEditorUsername);
-                result = RawSqlQuery<ApartmentApplicationViewModel>.query("UPDATE_AA_APPLICATION_EDITOR @APPLICATION_ID, @EDITOR_ID, @NOW, @NEW_EDITOR_ID", appIDParam, editorParam, timeParam, newEditorParam); //run stored procedure
+                int result = context.Database.ExecuteSqlCommand("UPDATE_AA_APPLICATION_EDITOR @APPLICATION_ID, @EDITOR_ID, @NOW, @NEW_EDITOR_ID", appIDParam, editorParam, timeParam, newEditorParam); //run stored procedure
                 if (result == null)
                 {
                     throw new ResourceCreationException() { ExceptionMessage = "The application could not be updated." };
@@ -523,7 +507,7 @@ namespace Gordon360.Services
             }
             else
             {
-                result = RawSqlQuery<ApartmentApplicationViewModel>.query("UPDATE_AA_APPLICATION_DATEMODIFIED @APPLICATION_ID, @NOW", appIDParam, timeParam); //run stored procedure
+                int result = context.Database.ExecuteSqlCommand("UPDATE_AA_APPLICATION_DATEMODIFIED @APPLICATION_ID, @NOW", appIDParam, timeParam); //run stored procedure
                 if (result == null)
                 {
                     throw new ResourceCreationException() { ExceptionMessage = "The application DateModified could not be updated." };
@@ -563,7 +547,7 @@ namespace Gordon360.Services
             }
             // Only perform the update if the ID of the current user matched the 'EditorID' ID stored in the database for the requested application
 
-            IEnumerable<ApartmentApplicationViewModel> result = null;
+            CCTEntities1 context = new CCTEntities1();
 
             DateTime now = System.DateTime.Now;
 
@@ -573,7 +557,7 @@ namespace Gordon360.Services
             {
                 SqlParameter editorParam = new SqlParameter("@EDITOR_ID", username);
                 SqlParameter newEditorParam = new SqlParameter("@NEW_EDITOR_ID", newEditorUsername);
-                result = RawSqlQuery<ApartmentApplicationViewModel>.query("UPDATE_AA_APPLICATION_EDITOR @APPLICATION_ID, @EDITOR_ID, @NOW, @NEW_EDITOR_ID", appIDParam, editorParam, timeParam, newEditorParam); //run stored procedure
+                int result = context.Database.ExecuteSqlCommand("UPDATE_AA_APPLICATION_EDITOR @APPLICATION_ID, @EDITOR_ID, @NOW, @NEW_EDITOR_ID", appIDParam, editorParam, timeParam, newEditorParam); //run stored procedure
                 if (result == null)
                 {
                     throw new ResourceCreationException() { ExceptionMessage = "The application could not be updated." };
@@ -581,7 +565,7 @@ namespace Gordon360.Services
             }
             else
             {
-                result = RawSqlQuery<ApartmentApplicationViewModel>.query("UPDATE_AA_APPLICATION_DATEMODIFIED @APPLICATION_ID, @NOW", appIDParam, timeParam); //run stored procedure
+                int result = context.Database.ExecuteSqlCommand("UPDATE_AA_APPLICATION_DATEMODIFIED @APPLICATION_ID, @NOW", appIDParam, timeParam); //run stored procedure
                 if (result == null)
                 {
                     throw new ResourceCreationException() { ExceptionMessage = "The application DateModified could not be updated." };

--- a/Gordon360/Services/HousingService.cs
+++ b/Gordon360/Services/HousingService.cs
@@ -605,6 +605,7 @@ namespace Gordon360.Services
                 throw new ResourceNotFoundException() { ExceptionMessage = "The student information about the editor of this application could not be found." };
             }
             apartmentApplicationModel.EditorUsername = editorStudent.AD_Username;
+            apartmentApplicationModel.EditorEmail = editorStudent.Email;
             apartmentApplicationModel.Gender = editorStudent.Gender;
 
             // Get the applicants that match this application ID
@@ -624,6 +625,9 @@ namespace Gordon360.Services
                         ApartmentApplicantViewModel applicantModel = new ApartmentApplicantViewModel();
                         applicantModel.ApplicationID = applicationID;
 
+                        applicantModel.Profile = student;
+
+                        applicantModel.StudentID = null; // Intentionally null in this case. Do not share the ID numbers of arbitrary students with the frontend
                         applicantModel.Username = student.AD_Username;
 
                         applicantModel.Age = null; // Not yet implemented

--- a/Gordon360/Services/HousingService.cs
+++ b/Gordon360/Services/HousingService.cs
@@ -308,7 +308,7 @@ namespace Gordon360.Services
                 foreach (GET_AA_APPLICANTS_BY_APPID_Result existingApplicant in existingApplicantResult)
                 {
                     ApartmentApplicantViewModel newMatchingApplicant = null;
-                    newMatchingApplicant = newApartmentApplicants.FirstOrDefault(x => x.StudentID == existingApplicant.ID_NUM);
+                    newMatchingApplicant = newApartmentApplicants.FirstOrDefault(x => x.Username == existingApplicant.ID_NUM);
                     if (newMatchingApplicant != null)
                     {
                         // If the applicant is in both the new applicant list and the existing applicant list, then we do NOT need to add it to the database
@@ -580,7 +580,7 @@ namespace Gordon360.Services
         {
             SqlParameter appIDParam = new SqlParameter("@APPLICATION_ID", applicationID);
 
-            IEnumerable<GET_AA_APPLICATIONS_BY_ID_Result> applicationResult = RawSqlQuery<GET_AA_APPLICATIONS_BY_ID_Result>.query("GET_AA_APPLICATIONS_BY_ID @APPLICATION_ID", applicationID);
+            IEnumerable<GET_AA_APPLICATIONS_BY_ID_Result> applicationResult = RawSqlQuery<GET_AA_APPLICATIONS_BY_ID_Result>.query("GET_AA_APPLICATIONS_BY_ID @APPLICATION_ID", appIDParam);
             if (applicationResult == null || !applicationResult.Any())
             {
                 throw new ResourceNotFoundException() { ExceptionMessage = "The application could not be found." };
@@ -609,7 +609,7 @@ namespace Gordon360.Services
 
             // Get the applicants that match this application ID
             appIDParam = new SqlParameter("@APPLICATION_ID", applicationID);
-            IEnumerable<GET_AA_APPLICANTS_BY_APPID_Result> applicantsResult = RawSqlQuery<GET_AA_APPLICANTS_BY_APPID_Result>.query("GET_AA_APPLICANTS_BY_APPID @APPLICATION_ID", applicationID);
+            IEnumerable<GET_AA_APPLICANTS_BY_APPID_Result> applicantsResult = RawSqlQuery<GET_AA_APPLICANTS_BY_APPID_Result>.query("GET_AA_APPLICANTS_BY_APPID @APPLICATION_ID", appIDParam);
             if (applicantsResult != null && applicantsResult.Any())
             {
                 // Only attempt to parse the data if the collection of applicants is not empty
@@ -649,7 +649,7 @@ namespace Gordon360.Services
 
             // Get the apartment choices that match this application ID
             appIDParam = new SqlParameter("@APPLICATION_ID", applicationID);
-            IEnumerable<GET_AA_APARTMENT_CHOICES_BY_APP_ID_Result> apartmentChoicesResult = RawSqlQuery<GET_AA_APARTMENT_CHOICES_BY_APP_ID_Result>.query("GET_AA_APARTMENT_CHOICES_BY_APP_ID @APPLICATION_ID", applicationID);
+            IEnumerable<GET_AA_APARTMENT_CHOICES_BY_APP_ID_Result> apartmentChoicesResult = RawSqlQuery<GET_AA_APARTMENT_CHOICES_BY_APP_ID_Result>.query("GET_AA_APARTMENT_CHOICES_BY_APP_ID @APPLICATION_ID", appIDParam);
             if (apartmentChoicesResult != null && apartmentChoicesResult.Any())
             {
                 // Only attempt to parse the data if the collection of apartment choices is not empty

--- a/Gordon360/Services/HousingService.cs
+++ b/Gordon360/Services/HousingService.cs
@@ -104,10 +104,10 @@ namespace Gordon360.Services
         {
             IEnumerable<ApartmentAppIDViewModel> idResult = null;
 
-            SqlParameter idParam = new SqlParameter("@STUDENT_ID", username);
+            SqlParameter userParam = new SqlParameter("@STUDENT_ID", username);
             SqlParameter sessionParam = new SqlParameter("@SESS_CDE", sess_cde);
 
-            idResult = RawSqlQuery<ApartmentAppIDViewModel>.query("GET_AA_APPID_BY_STU_ID_AND_SESS @SESS_CDE, @STUDENT_ID", sessionParam, idParam); //run stored procedure
+            idResult = RawSqlQuery<ApartmentAppIDViewModel>.query("GET_AA_APPID_BY_STU_ID_AND_SESS @SESS_CDE, @STUDENT_ID", sessionParam, userParam); //run stored procedure
             if (idResult == null || !idResult.Any())
             {
                 return null;

--- a/Gordon360/Services/HousingService.cs
+++ b/Gordon360/Services/HousingService.cs
@@ -159,7 +159,7 @@ namespace Gordon360.Services
             editorParam = new SqlParameter("@EDITOR_ID", editorUsername);
 
             // If an existing application was not found for this editor, then insert a new application entry in the database
-            int newAppResult = context.Database.ExecuteSqlCommand("INSERT_AA_APPLICATION @NOW, @EDITOR_ID", timeParam, editorParam); //run stored procedure
+            int? newAppResult = context.Database.ExecuteSqlCommand("INSERT_AA_APPLICATION @NOW, @EDITOR_ID", timeParam, editorParam); //run stored procedure
             if (newAppResult == null)
             {
                 throw new ResourceCreationException() { ExceptionMessage = "The application could not be saved." };
@@ -196,7 +196,7 @@ namespace Gordon360.Services
             {
                 // All SqlParameters must be remade before being reused in an SQL Query to prevent errors
                 appIDParam = new SqlParameter("@APPLICATION_ID", applicationID);
-                idParam = new SqlParameter("@ID_NUM", applicant.StudentID);
+                idParam = new SqlParameter("@ID_NUM", applicant.Username);
                 if (applicant.OffCampusProgram != null)
                 {
                     programParam = new SqlParameter("@APRT_PROGRAM", applicant.OffCampusProgram);
@@ -207,10 +207,10 @@ namespace Gordon360.Services
                 }
                 sessionParam = new SqlParameter("@SESS_CDE", sess_cde);
 
-                int applicantResult = context.Database.ExecuteSqlCommand("INSERT_AA_APPLICANT @APPLICATION_ID, @ID_NUM, @APRT_PROGRAM, @SESS_CDE", appIDParam, idParam, programParam, sessionParam); //run stored procedure
+                int? applicantResult = context.Database.ExecuteSqlCommand("INSERT_AA_APPLICANT @APPLICATION_ID, @ID_NUM, @APRT_PROGRAM, @SESS_CDE", appIDParam, idParam, programParam, sessionParam); //run stored procedure
                 if (applicantResult == null)
                 {
-                    throw new ResourceCreationException() { ExceptionMessage = "Applicant with ID " + applicant.StudentID + " could not be saved." };
+                    throw new ResourceCreationException() { ExceptionMessage = "Applicant " + applicant.Username + " could not be saved." };
                 }
             }
 
@@ -226,7 +226,7 @@ namespace Gordon360.Services
                 appIDParam = new SqlParameter("@APPLICATION_ID", applicationID);
                 rankingParam = new SqlParameter("@RANKING", choice.HallRank);
                 buildingCodeParam = new SqlParameter("@BLDG_CDE", choice.HallName);
-                int apartmentChoiceResult = context.Database.ExecuteSqlCommand("INSERT_AA_APARTMENT_CHOICE @APPLICATION_ID, @RANKING, @BLDG_CDE", appIDParam, rankingParam, buildingCodeParam); // run stored procedure
+                int? apartmentChoiceResult = context.Database.ExecuteSqlCommand("INSERT_AA_APARTMENT_CHOICE @APPLICATION_ID, @RANKING, @BLDG_CDE", appIDParam, rankingParam, buildingCodeParam); // run stored procedure
                 if (apartmentChoiceResult == null)
                 {
                     throw new ResourceCreationException() { ExceptionMessage = "The apartment preference could not be saved." };
@@ -327,7 +327,7 @@ namespace Gordon360.Services
                 }
             }
 
-            SqlParameter idParam = null;
+            SqlParameter userParam = null;
             SqlParameter programParam = null;
             SqlParameter sessionParam = null;
 
@@ -336,7 +336,7 @@ namespace Gordon360.Services
             {
                 // All SqlParameters must be remade before being reused in an SQL Query to prevent errors
                 appIDParam = new SqlParameter("@APPLICATION_ID", applicationID);
-                idParam = new SqlParameter("@ID_NUM", applicant.StudentID);
+                userParam = new SqlParameter("@ID_NUM", applicant.Username);
                 if (applicant.OffCampusProgram != null)
                 {
                     programParam = new SqlParameter("@APRT_PROGRAM", applicant.OffCampusProgram);
@@ -347,10 +347,10 @@ namespace Gordon360.Services
                 }
                 sessionParam = new SqlParameter("@SESS_CDE", sess_cde);
 
-                int applicantResult = context.Database.ExecuteSqlCommand("INSERT_AA_APPLICANT @APPLICATION_ID, @ID_NUM, @APRT_PROGRAM, @SESS_CDE", appIDParam, idParam, programParam, sessionParam); //run stored procedure
+                int? applicantResult = context.Database.ExecuteSqlCommand("INSERT_AA_APPLICANT @APPLICATION_ID, @ID_NUM, @APRT_PROGRAM, @SESS_CDE", appIDParam, userParam, programParam, sessionParam); //run stored procedure
                 if (applicantResult == null)
                 {
-                    throw new ResourceCreationException() { ExceptionMessage = "Applicant with ID " + applicant.StudentID + " could not be inserted." };
+                    throw new ResourceCreationException() { ExceptionMessage = "Applicant " + applicant.Username + " could not be inserted." };
                 }
             }
 
@@ -359,7 +359,7 @@ namespace Gordon360.Services
             {
                 // All SqlParameters must be remade before being reused in an SQL Query to prevent errors
                 appIDParam = new SqlParameter("@APPLICATION_ID", applicationID);
-                idParam = new SqlParameter("@ID_NUM", applicant.StudentID);
+                userParam = new SqlParameter("@ID_NUM", applicant.Username);
                 if (applicant.OffCampusProgram != null)
                 {
                     programParam = new SqlParameter("@APRT_PROGRAM", applicant.OffCampusProgram);
@@ -370,10 +370,10 @@ namespace Gordon360.Services
                 }
                 sessionParam = new SqlParameter("@SESS_CDE", sess_cde);
 
-                int applicantResult = context.Database.ExecuteSqlCommand("UPDATE_AA_APPLICANT @APPLICATION_ID, @ID_NUM, @APRT_PROGRAM, @SESS_CDE", appIDParam, idParam, programParam, sessionParam); //run stored procedure
+                int? applicantResult = context.Database.ExecuteSqlCommand("UPDATE_AA_APPLICANT @APPLICATION_ID, @ID_NUM, @APRT_PROGRAM, @SESS_CDE", appIDParam, userParam, programParam, sessionParam); //run stored procedure
                 if (applicantResult == null)
                 {
-                    throw new ResourceCreationException() { ExceptionMessage = "Applicant with ID " + applicant.StudentID + " could not be updated." };
+                    throw new ResourceCreationException() { ExceptionMessage = "Applicant " + applicant.Username + " could not be updated." };
                 }
             }
 
@@ -382,13 +382,13 @@ namespace Gordon360.Services
             {
                 // All SqlParameters must be remade before being reused in an SQL Query to prevent errors
                 appIDParam = new SqlParameter("@APPLICATION_ID", applicationID);
-                idParam = new SqlParameter("@ID_NUM", applicant.StudentID);
+                userParam = new SqlParameter("@ID_NUM", applicant.Username);
                 sessionParam = new SqlParameter("@SESS_CDE", sess_cde);
 
-                int applicantResult = context.Database.ExecuteSqlCommand("DELETE_AA_APPLICANT @APPLICATION_ID, @ID_NUM, @SESS_CDE", appIDParam, idParam, sessionParam); //run stored procedure
+                int? applicantResult = context.Database.ExecuteSqlCommand("DELETE_AA_APPLICANT @APPLICATION_ID, @ID_NUM, @SESS_CDE", appIDParam, userParam, sessionParam); //run stored procedure
                 if (applicantResult == null)
                 {
-                    throw new ResourceNotFoundException() { ExceptionMessage = "Applicant with ID " + applicant.StudentID + " could not be removed." };
+                    throw new ResourceNotFoundException() { ExceptionMessage = "Applicant " + applicant.Username + " could not be removed." };
                 }
             }
 
@@ -451,7 +451,7 @@ namespace Gordon360.Services
                 rankingParam = new SqlParameter("@RANKING", apartmentChoice.HallRank);
                 buildingCodeParam = new SqlParameter("@BLDG_CDE", apartmentChoice.HallName);
 
-                int apartmentChoiceResult = context.Database.ExecuteSqlCommand("INSERT_AA_APARTMENT_CHOICE @APPLICATION_ID, @RANKING, @BLDG_CDE", appIDParam, rankingParam, buildingCodeParam); //run stored procedure
+                int? apartmentChoiceResult = context.Database.ExecuteSqlCommand("INSERT_AA_APARTMENT_CHOICE @APPLICATION_ID, @RANKING, @BLDG_CDE", appIDParam, rankingParam, buildingCodeParam); //run stored procedure
                 if (apartmentChoiceResult == null)
                 {
                     throw new ResourceCreationException() { ExceptionMessage = "Apartment choice with ID " + applicationID + " and hall name " + apartmentChoice.HallName + " could not be inserted." };
@@ -466,7 +466,7 @@ namespace Gordon360.Services
                 rankingParam = new SqlParameter("@RANKING", apartmentChoice.HallRank);
                 buildingCodeParam = new SqlParameter("@BLDG_CDE", apartmentChoice.HallName);
 
-                int apartmentChoiceResult = context.Database.ExecuteSqlCommand("UPDATE_AA_APARTMENT_CHOICE @APPLICATION_ID, @RANKING, @BLDG_CDE", appIDParam, rankingParam, buildingCodeParam); //run stored procedure
+                int? apartmentChoiceResult = context.Database.ExecuteSqlCommand("UPDATE_AA_APARTMENT_CHOICE @APPLICATION_ID, @RANKING, @BLDG_CDE", appIDParam, rankingParam, buildingCodeParam); //run stored procedure
                 if (apartmentChoiceResult == null)
                 {
                     throw new ResourceCreationException() { ExceptionMessage = "Apartment choice with ID " + applicationID + " and hall name " + apartmentChoice.HallName + " could not be updated." };
@@ -481,7 +481,7 @@ namespace Gordon360.Services
                 rankingParam = new SqlParameter("@RANKING", apartmentChoice.HallRank);
                 buildingCodeParam = new SqlParameter("@BLDG_CDE", apartmentChoice.HallName);
 
-                int apartmentChoiceResult = context.Database.ExecuteSqlCommand("DELETE_AA_APARTMENT_CHOICE @APPLICATION_ID, @BLDG_CDE", appIDParam, buildingCodeParam); //run stored procedure
+                int? apartmentChoiceResult = context.Database.ExecuteSqlCommand("DELETE_AA_APARTMENT_CHOICE @APPLICATION_ID, @BLDG_CDE", appIDParam, buildingCodeParam); //run stored procedure
                 if (apartmentChoiceResult == null)
                 {
                     throw new ResourceNotFoundException() { ExceptionMessage = "Apartment choice with ID " + applicationID + " and hall name " + apartmentChoice.HallName + " could not be removed." };
@@ -499,7 +499,7 @@ namespace Gordon360.Services
             {
                 SqlParameter editorParam = new SqlParameter("@EDITOR_ID", username);
                 SqlParameter newEditorParam = new SqlParameter("@NEW_EDITOR_ID", newEditorUsername);
-                int result = context.Database.ExecuteSqlCommand("UPDATE_AA_APPLICATION_EDITOR @APPLICATION_ID, @EDITOR_ID, @NOW, @NEW_EDITOR_ID", appIDParam, editorParam, timeParam, newEditorParam); //run stored procedure
+                int? result = context.Database.ExecuteSqlCommand("UPDATE_AA_APPLICATION_EDITOR @APPLICATION_ID, @EDITOR_ID, @NOW, @NEW_EDITOR_ID", appIDParam, editorParam, timeParam, newEditorParam); //run stored procedure
                 if (result == null)
                 {
                     throw new ResourceCreationException() { ExceptionMessage = "The application could not be updated." };
@@ -507,7 +507,7 @@ namespace Gordon360.Services
             }
             else
             {
-                int result = context.Database.ExecuteSqlCommand("UPDATE_AA_APPLICATION_DATEMODIFIED @APPLICATION_ID, @NOW", appIDParam, timeParam); //run stored procedure
+                int? result = context.Database.ExecuteSqlCommand("UPDATE_AA_APPLICATION_DATEMODIFIED @APPLICATION_ID, @NOW", appIDParam, timeParam); //run stored procedure
                 if (result == null)
                 {
                     throw new ResourceCreationException() { ExceptionMessage = "The application DateModified could not be updated." };
@@ -557,7 +557,7 @@ namespace Gordon360.Services
             {
                 SqlParameter editorParam = new SqlParameter("@EDITOR_ID", username);
                 SqlParameter newEditorParam = new SqlParameter("@NEW_EDITOR_ID", newEditorUsername);
-                int result = context.Database.ExecuteSqlCommand("UPDATE_AA_APPLICATION_EDITOR @APPLICATION_ID, @EDITOR_ID, @NOW, @NEW_EDITOR_ID", appIDParam, editorParam, timeParam, newEditorParam); //run stored procedure
+                int? result = context.Database.ExecuteSqlCommand("UPDATE_AA_APPLICATION_EDITOR @APPLICATION_ID, @EDITOR_ID, @NOW, @NEW_EDITOR_ID", appIDParam, editorParam, timeParam, newEditorParam); //run stored procedure
                 if (result == null)
                 {
                     throw new ResourceCreationException() { ExceptionMessage = "The application could not be updated." };
@@ -565,7 +565,7 @@ namespace Gordon360.Services
             }
             else
             {
-                int result = context.Database.ExecuteSqlCommand("UPDATE_AA_APPLICATION_DATEMODIFIED @APPLICATION_ID, @NOW", appIDParam, timeParam); //run stored procedure
+                int? result = context.Database.ExecuteSqlCommand("UPDATE_AA_APPLICATION_DATEMODIFIED @APPLICATION_ID, @NOW", appIDParam, timeParam); //run stored procedure
                 if (result == null)
                 {
                     throw new ResourceCreationException() { ExceptionMessage = "The application DateModified could not be updated." };
@@ -624,7 +624,6 @@ namespace Gordon360.Services
                         ApartmentApplicantViewModel applicantModel = new ApartmentApplicantViewModel();
                         applicantModel.ApplicationID = applicationID;
 
-                        applicantModel.StudentID = null; // Intentionally null in this case. Do not share the ID numbers of arbitrary students with the frontend
                         applicantModel.Username = student.AD_Username;
 
                         applicantModel.Age = null; // Not yet implemented

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -276,11 +276,11 @@ namespace Gordon360.Services
         bool AddHousingAdmin(string id);
         bool RemoveHousingAdmin(string id);
         int? GetApplicationID(string username, string sess_cde);
+        ApartmentApplicationViewModel GetApartmentApplication(int applicationID);
+        ApartmentApplicationViewModel[] GetAllApartmentApplication();
         int SaveApplication(string username, string sess_cde, string editorUsername, ApartmentApplicantViewModel[] apartmentApplicants, ApartmentChoiceViewModel[] apartmentChoices);
         int EditApplication(string username, string sess_cde, int applicationID, string newEditorUsername, ApartmentApplicantViewModel[] newApartmentApplicants, ApartmentChoiceViewModel[] newApartmentChoices);
         bool ChangeApplicationEditor(string username, int applicationID, string newEditorUsername);
-        ApartmentApplicationViewModel GetApartmentApplication(int applicationID);
-        ApartmentApplicationViewModel[] GetAllApartmentApplication();
     }
 
 }


### PR DESCRIPTION
Queries that do not need to return a result from a database table will cause an error unless mapped to a view model that is an exact match to only the variables that were changed: the view model must have no extra variable and must not be missing any of the variables affected by the query, otherwise, it causes errors. Creating view models for each slight variation of this would be needlessly messy, excessive, and unprofessional, especially since none of that data is meant to be used other than to check if the result was null.

The `RawSqlQuery<T>.query()` is the incorrect way to perform these types of SQL Queries because it uses `CCTEntities1.Database.SqlQuery<T>`, and the definition of the `RawSqlQuery<T>` class forces that the element type `T` must be a reference type or class, not a primitive type, making it problematic for any stored procedure that only returns a single value/variable.

The correct way to perform these `INSERT` and `UPDATE` queries is to use `CCTEntities1.Database.ExecuteSqlCommand`, which simply returns an `int` signifying a status code of some kind. This command/method is specifically designed for performing these types of "setter" SQL queries or commands, where you are putting something into the database or updating something and do not expect any result back in the form of values from one of the database tables/columns.

For other examples of this within the 360 project, see `ProfileService.cs`, `MyScheduleService.cs`, `SaveService.cs`, etc.