### PR TITLE
Create CI initial workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on: push
+
+jobs:
+    ci:
+        runs-on: windows-latest
+
+        steps:
+            - uses: actions/checkout@v2
+
+            - name: Setup msbuild
+              uses: microsoft/setup-msbuild@v1
+
+            - name: Setup NuGet
+              uses: NuGet/setup-nuget@v1.0.5
+
+            - name: Restore NuGet packages
+              run: nuget restore Gordon360.sln
+
+            - name: Build API
+              run: msbuild .\Gordon360\Gordon360.csproj /p:DeployOnBuild=True /p:PublishProfile=${{ github.workspace }}\gha-publish-profiles\CI.pubxml
+
+            # Uncomment to enable test builds. Works in concert with the `Deploy 360Test` Scheduled Task on 360API.gordon.edu VM
+            # - name: Upload Test Build Artifact
+            #   uses: actions/upload-artifact@v2.2.2
+            #   if: ${{ github.refs != 'refs/heads/develop' && github.refs != 'refs/heads/master' }}
+            #   with:
+            #       name: build-Test
+            #       path: ${{ github.workspace }}\Gordon360\bin\app.publish\ci
+            #       if-no-files-found: warn
+
+            - name: Upload Train Build Artifact
+              uses: actions/upload-artifact@v2.2.2
+              if: ${{ github.refs == 'refs/heads/develop' }}
+              with:
+                  name: build-Train
+                  path: ${{ github.workspace }}\Gordon360\bin\app.publish\ci
+                  if-no-files-found: error
+
+            - name: Upload Prod Build Artifact
+              uses: actions/upload-artifact@v2.2.2
+              if: ${{ github.refs == 'refs/heads/master' }}
+              with:
+                  name: build-Prod
+                  path: ${{ github.workspace }}\Gordon360\bin\app.publish\ci
+                  if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ Dive in.
 ## Table of Contents
 
 -   [Machines and Sites](#machines-and-sites)
-    -   [Deploying to the Api Site](#deploying-to-the-api-site)
-        -   [Current Case: Deploying Manually](#current-case-deploying-manually)
-        -   [Ideal Case: Continuous Deployment with GitHub Actions](#ideal-case-continuous-deployment-with-github-actions)
+-   [API Maintenance](#api-maintenance)
+    -   [Continuous Integration](#continuous-integration)
+    -   [Continuous Deployment](#continuous-deployment)
+    -   [Deploying Manually](#deploying-manually)
 -   [Caching](#caching)
 -   [Running the API locally](#running-the-api-locally)
     -   [Preliminary setup](#preliminary-setup)
@@ -57,18 +58,28 @@ Dive in.
 
 As of Spring 2021, the virtual machines CS-RDSH-01 and CS-RDSH-02 are used for developing Gordon 360. Instructions for connecting via Remote Desktop can be found in [RemoteDesktopToVM.md](RemoteDesktopToVM.md#How-to-connect-to-a-CS-RDSH-virtual-machine).
 
-### Deploying to the Api Site
+## API Maintenance
 
-The Gordon 360 API is hosted on the `360api.gordon.edu` server, which is also known as `cts-360.gordon.edu`. The built files are deployed at `F:\Sites`, under the names `360Api` and `360ApiTrain` for the master and develop branches respectively.
+### Continuous Integration
 
-#### Current Case: Deploying Manually
+The backend uses GitHub Actions for Continuous Integration. Whenever changes are pushed to GitHub, the `CI` action defined in `.github/workflows/ci.yml` will be run by GitHub Actions. This action will checkout the latest version of whatever branch was pushed to and attempt to build it. If the build fails, the action will fail and no pull request on that branch will be able to be merged until a new build succeeds. This is the minimum in Continuous Integration. Ideally, we would also have unit/integration tests that run in the `CI` action. We currently have some tests defined in the `pytest` Python format, which can be found in `Tests/ApiEndpoints`. These are difficult to use in a Continuous Integration system because they require the API-to-be-tested to be running and locally accessible to the `pytest` module.
 
-If there are problems with automatic deployment, or a specific need to revert or push manually, then this older procedure can be used.
+### Continuous Deployment
+
+The Gordon 360 API is hosted on the `360api.gordon.edu` server, which is also known as `cts-360.gordon.edu`. The built files are deployed at `F:\Sites`, under the names `360Api` and `360ApiTrain` for the `master` and `develop` branches respectively.
+
+The backend is deployed automatically using GitHub Actions. Whenever changes are pushed to the `develop` or `master` branches, the `CI` workflow will run and ensure a successful build (see above [section on Continuous Integration](#continuous-integration) for details). If the changes build successfully, the output of that build will be saved as an artifact on the workflow run - `build-Train` for `develop` and `build-Prod` for `master`.
+
+To detect and deploy successful builds, the scheduled task `Deploy 360Api[Train]` runs every 5 minutes on the API server. It calls the powershell script `Deploy360BackEnd.ps1` (found at `F:\Scripts\Deploy`), polling GitHub's API for new builds. If it detects a new build for the relevant environment (`Train` for `develop`, `Prod` for `master`), it will backup the existing API and deploy the new one. Transcripts for these deployments can be found at `F:\Scripts\Deploy\Transcripts`.
+
+### Deploying Manually
+
+If there are problems with continuous deployment, or a specific need arises to revert or push manually, then this older procedure can be used.
 
 -   Access the cts-360.gordon.edu VM (see [RemoteDesktopToVM.md](RemoteDesktopToVM.md#How-to-connect-to-a-CS-RDSH-virtual-machine) for instructions) as the cct.service user.
 -   Before you publish your new version, be sure to copy the current stable version to make a backup. To do so:
     -   Navigate in File Explorer to `F:\Sites` and copy either 360Api or 360ApiTrain, whichever you're planning to publish to.
-    -   Paste that copy in the same place (`F:\Sites`), and rename it to a backup including the date. For example, if you backed up the Train site on January 1, 2001, then the copy would be named `360ApiTrain_backup_1-01-2001`.
+    -   Paste that copy in the same place (`F:\Sites`), and rename it to a backup including the date. For example, if you backed up the Train site on January 1, 2001, then the copy would be named `360ApiTrain-backup-2001-01-01`.
 -   Open gitbash and cd to `C:\users\cct.service\code\gordon-360-api`. Make sure that you are on the branch you wish to deploy, and that it has been pulled up to date.
     **Note: if you clone a new repository on this VM, it will not have the necessary publish profiles or secrets.config. See [MakePublishProfiles.md](MakePublishProfiles.md#How-to-create-the-Publish-Profiles-to-publish-the-API-to-the-Sites) to restore the Publish Profiles.**
 -   Start Visual Studio as an administrator (right click) and open the existing project/solution file - `C:\users\cct.service\code\gordon-360-api\Gordon360.sln` (the solution file).
@@ -78,10 +89,6 @@ If there are problems with automatic deployment, or a specific need to revert or
     -   Prod -- Production ( Connects to the adminprodsql database server, and used for the real site 360.gordon.edu).
     -   If you don't see the publish profile you want (or you are automatically taken to the "Pick a Publish Target" Window) see [MakePublishProfiles.md](MakePublishProfiles.md#How-to-create-the-Publish-Profiles-to-publish-the-API-to-the-Sites) to restore the Publish Profiles.
 -   Clicking publish pushes your changes to the API for either 360ApiTrain.gordon.edu or 360Api.gordon.edu, depending on which publish profile you used.
-
-#### Ideal Case: Continuous Deployment with GitHub Actions
-
-The frontend is already configured for continuous deployment with GitHub Actions. The backend should ideally be simularly automated, but isn't yet.
 
 ## Caching
 
@@ -423,12 +430,12 @@ If you are attempting to connect the API to a database other than the ones to wh
 -   You do not need to delete any edmx files, since you are now creating the first instance of a different edmx
 -   <span id="create-connection"><!--anchor--></span>
     None of the options for data connection will fit your needs, so you will need to create a new option:
-    - Click "New Connection..."
-    - If prompted "Choose Data Source", choose "Microsoft SQL Server"
-    - For "Server name", put `admintrainsql.gordon.edu`
-    - Under "Connect to a Database", make sure "Select or enter a database name:" is selected and enter `<database name>`
-    - Go to Advanced settings, scroll to the top, and make sure "MultipleActiveResultSets" is set to True; then, scroll towards the bottom to find "Integrated Security" and make sure that is set to True
-    - Click OK to close Advanced settings, then OK again to save the data connection you have just made
+    -   Click "New Connection..."
+    -   If prompted "Choose Data Source", choose "Microsoft SQL Server"
+    -   For "Server name", put `admintrainsql.gordon.edu`
+    -   Under "Connect to a Database", make sure "Select or enter a database name:" is selected and enter `<database name>`
+    -   Go to Advanced settings, scroll to the top, and make sure "MultipleActiveResultSets" is set to True; then, scroll towards the bottom to find "Integrated Security" and make sure that is set to True
+    -   Click OK to close Advanced settings, then OK again to save the data connection you have just made
 -   Now, you can select the data connection you just made from the drop down and pick up with the above directions at 'Make sure you check "Save connection...'
 
 ## The Code

--- a/gha-publish-profiles/CI.pubxml
+++ b/gha-publish-profiles/CI.pubxml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121. 
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DeleteExistingFiles>False</DeleteExistingFiles>
+    <ExcludeApp_Data>False</ExcludeApp_Data>
+    <LaunchSiteAfterPublish>True</LaunchSiteAfterPublish>
+    <LastUsedBuildConfiguration>Release</LastUsedBuildConfiguration>
+    <LastUsedPlatform>Any CPU</LastUsedPlatform>
+    <PublishProvider>FileSystem</PublishProvider>
+    <PublishUrl>bin\app.publish\ci</PublishUrl>
+    <WebPublishMethod>FileSystem</WebPublishMethod>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
This introduces the first step in a new Continuous Integration and Continuous Deployment solution for this API. Whenever changes are pushed to GitHub, GitHub Actions will activate the CI workflow (in `.github/workflows/ci.yml`). This workflow setups the necessary tooling on the workflow runner (NuGet and msbuild), and then builds the project. It uses the publish profile `gordon-360-api/gha-publish-profiles/ci.pubxml` to build.  The workflow will fail if msbuild encounters any errors.

This is the simplest form of continuous integration. It will detect failing builds and some compile time warnings, but nothing beyond that. Ideally, proper CI would include unit and integration tests to ensure that the build is not only successful but also correct and working properly. Some tests have been written using `pytest`, which can be found in `Tests/ApiEndpoints`. One limitation with these tests is that they require the API be running locally in order to test it, which is not a simple thing to accomplish in most CI solutions, including GitHub Actions. Furthermore, many of the tests are presently broken, and even more are incredibly fragile because they test not only the correctness of the API but also the form of the data returned by the API. This means that unrelated, harmless, and normal changes to the data can break our tests without warning, and despite the API functioning properly.

The possible solutions are to invest in pytest further and fix the above flaws, or to pivot testing solutions to a more idiomatic testing platform for C# ASP.NET projects.

This pull request also adds the GitHub Actions portion of our deployment solution. Whenever changes are pushed to `develop` or `master` (which will be via pull request since those are protected branches), and the `CI` workflow successfully builds, the output of the build will be served as an artifact of the workflow. 

The other half of our Continuous Deployment solution lives on the local API server. Essentially, a powershell script is run every 5 minutes that polls GitHub's API for new builds of the `develop` and `master` branches. If it finds any that are new sine the last time it deployed, it will backup the current build and then download and deploy the new build. More details can be found in the updates to the README.