### PR TITLE
Fix Custom Error Message serialization

### DIFF
--- a/Gordon360/Exceptions/CustomExceptionFilter.cs
+++ b/Gordon360/Exceptions/CustomExceptionFilter.cs
@@ -16,45 +16,28 @@ namespace Gordon360.Exceptions.ExceptionFilters
             if (actionExecutedContext.Exception is ResourceNotFoundException)
             {
                 var exception = actionExecutedContext.Exception as ResourceNotFoundException;
-                actionExecutedContext.Response = new HttpResponseMessage()
-                {
-                    StatusCode = System.Net.HttpStatusCode.NotFound,
-                    Content = new StringContent(exception.ExceptionMessage),
-                    //ReasonPhrase = "LOL"
-                };
+                actionExecutedContext.Response = actionExecutedContext.Request.CreateErrorResponse(System.Net.HttpStatusCode.NotFound, exception.ExceptionMessage);
             }
 
             // RESOURCE CREATION CONFLICT
             else if (actionExecutedContext.Exception is ResourceCreationException)
             {
                 var exception = actionExecutedContext.Exception as ResourceCreationException;
-                actionExecutedContext.Response = new HttpResponseMessage()
-                {
-                    StatusCode = System.Net.HttpStatusCode.Conflict,
-                    Content = new StringContent(exception.ExceptionMessage)
-                };
+                actionExecutedContext.Response = actionExecutedContext.Request.CreateErrorResponse(System.Net.HttpStatusCode.Conflict, exception.ExceptionMessage);
             }
 
             // BAD INPUT
             else if( actionExecutedContext.Exception is BadInputException)
             {
                 var exception = actionExecutedContext.Exception as BadInputException;
-                actionExecutedContext.Response = new HttpResponseMessage()
-                {
-                    StatusCode = System.Net.HttpStatusCode.BadRequest,
-                    Content = new StringContent(exception.ExceptionMessage)
-                };
+                actionExecutedContext.Response = actionExecutedContext.Request.CreateErrorResponse(System.Net.HttpStatusCode.BadRequest, exception.ExceptionMessage);
             }
 
             // UNAUTHORIZED ACCESS EXCEPTION
             else if (actionExecutedContext.Exception is UnauthorizedAccessException)
             {
                 var exception = actionExecutedContext.Exception as UnauthorizedAccessException;
-                actionExecutedContext.Response = new HttpResponseMessage()
-                {
-                    StatusCode = System.Net.HttpStatusCode.Unauthorized,
-                    Content = new StringContent(exception.ExceptionMessage)
-                };
+                actionExecutedContext.Response = actionExecutedContext.Request.CreateErrorResponse(System.Net.HttpStatusCode.Unauthorized, exception.ExceptionMessage);
             }
         }
     }

--- a/Gordon360/Gordon360.csproj
+++ b/Gordon360/Gordon360.csproj
@@ -889,7 +889,7 @@
           <AutoAssignPort>True</AutoAssignPort>
           <DevelopmentServerPort>49645</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
-          <IISUrl>http://localhost:2477</IISUrl>
+          <IISUrl>http://localhost:2626</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>
           <UseCustomServer>False</UseCustomServer>
           <CustomServerUrl>


### PR DESCRIPTION
The API has its own custom Exception classes, which allow a basically arbitrary message to be returned to the front end. These Exceptions are parsed into HttpErrors by the `CustomExceptionFilter` class. However, there was in issue with the way the `HttpResponseMessage`s were being created in `CustomExceptionFilter` that was causing the response to be invalid JSON (specifically, the object properties weren't being escaped in quotes properly). This meant that when the error arrived at the front end, the custom error message (which contained important details about why the request failed) could not be parsed. The front end, when encountering this invalid JSON, would wrap 404 and 401 errors in a class with a generic message (e.g. 'Resource Not Found'), which meant that these errors could be somewhat recovered, but the resulting error object in the UI only had information from the HTTP status code - it was still missing the details encoded in the custom error message. See `parseResponse` in `src/services/user.js` and `createError` in `src/services/error.js` for more detail on this front end behavior.

I have updated the way `HttpResponseMessage`s are being initialized so that the custom error messages can be properly deserialized on the front end. This will allow us to give much more fine-grained feedback (e.g. "You already have a pending request to join this involvement" rather than "Something went wrong submitting your request to join this involvement"), as well as potentially recover from certain errors.