### PR TITLE
 added AD_username to membership route

### DIFF
--- a/Gordon360/Gordon360.csproj
+++ b/Gordon360/Gordon360.csproj
@@ -892,7 +892,7 @@
           <AutoAssignPort>True</AutoAssignPort>
           <DevelopmentServerPort>49645</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
-          <IISUrl>http://localhost:1995</IISUrl>
+          <IISUrl>http://localhost:2626</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>
           <UseCustomServer>False</UseCustomServer>
           <CustomServerUrl>

--- a/Gordon360/Gordon360.csproj
+++ b/Gordon360/Gordon360.csproj
@@ -892,7 +892,7 @@
           <AutoAssignPort>True</AutoAssignPort>
           <DevelopmentServerPort>49645</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
-          <IISUrl>http://localhost:2626</IISUrl>
+          <IISUrl>http://localhost:1995</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>
           <UseCustomServer>False</UseCustomServer>
           <CustomServerUrl>

--- a/Gordon360/Gordon360.csproj
+++ b/Gordon360/Gordon360.csproj
@@ -934,3 +934,4 @@
   <Target Name="AfterBuild">
   </Target> -->
 </Project>
+

--- a/Gordon360/Models/ViewModels/MembershipViewModel.cs
+++ b/Gordon360/Models/ViewModels/MembershipViewModel.cs
@@ -13,6 +13,7 @@ namespace Gordon360.Models.ViewModels
         public string SessionCode { get; set; }
         public string SessionDescription { get; set; }
         public int IDNumber { get; set; }
+        public string AD_Username { get; set; }
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public string Mail_Location { get; set; }

--- a/Gordon360/Services/MembershipService.cs
+++ b/Gordon360/Services/MembershipService.cs
@@ -232,6 +232,7 @@ namespace Gordon360.Services
                 trim.SessionCode = x.SessionCode.Trim();
                 trim.SessionDescription = x.SessionDescription.Trim();
                 trim.IDNumber = x.IDNumber;
+                trim.AD_Username = x.AD_Username;
                 trim.FirstName = x.FirstName.Trim();
                 trim.LastName = x.LastName.Trim();
                 trim.Mail_Location = x.Mail_Location.Trim();


### PR DESCRIPTION
Added `AD_Username` in the database.

Edited @cpabbot:
We need the `AD_Username` in order to pull member profile images. Originally, we only returned id numbers from the database and not usernames. Eventually, we should not remove id numbers from the query as well as several other fields that appear to not have any significant value (like image urls); however, this is beyond the scope of this PR so we simply added the necessary `AD_Username` field.

Note: We will have to update the query in prod as well or else this will break when we merge to prod. We should somehow note this or do this upon approval, not sure what a good process would be.