### PR TITLE
Fixed: Sometimes, the name appears twice when people type full name on quick search

### DIFF
--- a/Gordon360/ApiControllers/AccountsController.cs
+++ b/Gordon360/ApiControllers/AccountsController.cs
@@ -296,7 +296,9 @@ namespace Gordon360.ApiControllers
                 precedence++;
 
                 // Exact match in both nickname and last name
-                foreach (var match in accounts.Where(s => s.NicknameMatches(searchString) && s.LastNameMatches(secondaryString)))
+                foreach (var match in accounts
+                                        .Where(s => !allMatches.ContainsValue(s))
+                                        .Where(s => s.NicknameMatches(searchString) && s.LastNameMatches(secondaryString)))
                 {
                     string key = GenerateKey(match.FirstName, match.LastName, match.UserName, precedence);
 

--- a/Gordon360/Gordon360.csproj
+++ b/Gordon360/Gordon360.csproj
@@ -892,7 +892,7 @@
           <AutoAssignPort>True</AutoAssignPort>
           <DevelopmentServerPort>49645</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
-          <IISUrl>http://localhost:2626</IISUrl>
+          <IISUrl>http://localhost:1234</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>
           <UseCustomServer>False</UseCustomServer>
           <CustomServerUrl>

--- a/Gordon360/Gordon360.csproj
+++ b/Gordon360/Gordon360.csproj
@@ -892,7 +892,7 @@
           <AutoAssignPort>True</AutoAssignPort>
           <DevelopmentServerPort>49645</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
-          <IISUrl>http://localhost:1234</IISUrl>
+          <IISUrl>http://localhost:2626</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>
           <UseCustomServer>False</UseCustomServer>
           <CustomServerUrl>


### PR DESCRIPTION
Sometimes, the name appears twice when people type full name on quick search.
![Screen Shot 2021-06-21 at 2 42 29 PM](https://user-images.githubusercontent.com/70544403/122813920-8782dc80-d2a1-11eb-825d-c0d80060fb49.png)
![Screen Shot 2021-06-21 at 2 43 04 PM](https://user-images.githubusercontent.com/70544403/122813963-949fcb80-d2a1-11eb-9110-0793a2b7ede1.png)

Now, problem solved. The name appears only once like this...
![Screen Shot 2021-06-21 at 3 02 12 PM](https://user-images.githubusercontent.com/70544403/122814044-ad0fe600-d2a1-11eb-8f41-550aac86e29b.png)

