### PR TITLE
Removed redundancy in retrieving Clifton Strengths - PATCH

### DIFF
--- a/Gordon360/Services/ProfileService.cs
+++ b/Gordon360/Services/ProfileService.cs
@@ -125,8 +125,7 @@ namespace Gordon360.Services
         /// <returns> Clifton strengths of the given user. </returns>
         public CliftonStrengthsViewModel GetCliftonStrengths(int id)
         {
-            var strengths = _unitOfWork.CliftonStrengthsRepository.FirstOrDefault(x => x.ID_NUM == id);
-            return strengths;
+            return _unitOfWork.CliftonStrengthsRepository.FirstOrDefault(x => x.ID_NUM == id);
         }
 
         /// <summary> Gets the emergency contact information of a particular user </summary>

--- a/Gordon360/Services/ProfileService.cs
+++ b/Gordon360/Services/ProfileService.cs
@@ -126,10 +126,6 @@ namespace Gordon360.Services
         public CliftonStrengthsViewModel GetCliftonStrengths(int id)
         {
             var strengths = _unitOfWork.CliftonStrengthsRepository.FirstOrDefault(x => x.ID_NUM == id);
-            if(strengths == null)
-            {
-                return null;
-            }
             return strengths;
         }
 


### PR DESCRIPTION
#616 Patch, removing redundant null check