### PR TITLE
Profile for Usernameless Alumni

### DIFF
--- a/Gordon360/ApiControllers/MembershipsController.cs
+++ b/Gordon360/ApiControllers/MembershipsController.cs
@@ -396,7 +396,7 @@ namespace Gordon360.Controllers.Api
             }
             catch (ResourceNotFoundException)
             {
-                //just catch the exception
+                //just catch the exception (to create the profile of usernameless alumni without throwing exception)
             }
 
             if (result == null)

--- a/Gordon360/ApiControllers/MembershipsController.cs
+++ b/Gordon360/ApiControllers/MembershipsController.cs
@@ -387,8 +387,17 @@ namespace Gordon360.Controllers.Api
                 throw new BadInputException() { ExceptionMessage = errors };
             }
 
-            var id = _accountService.GetAccountByUsername(username).GordonID;
-            var result = _membershipService.GetMembershipsForStudent(id);
+            var id = "";
+            var result = Enumerable.Empty<MembershipViewModel>();
+            try
+            {
+                id = _accountService.GetAccountByUsername(username).GordonID;
+                result = _membershipService.GetMembershipsForStudent(id);
+            }
+            catch (ResourceNotFoundException)
+            {
+                //just catch the exception
+            }
 
             if (result == null)
             {

--- a/Gordon360/ApiControllers/MembershipsController.cs
+++ b/Gordon360/ApiControllers/MembershipsController.cs
@@ -396,7 +396,7 @@ namespace Gordon360.Controllers.Api
             }
             catch (ResourceNotFoundException)
             {
-                //just catch the exception (to create the profile of usernameless alumni without throwing exception)
+                NotFound();
             }
 
             if (result == null)

--- a/Gordon360/ApiControllers/ProfilesController.cs
+++ b/Gordon360/ApiControllers/ProfilesController.cs
@@ -341,10 +341,8 @@ namespace Gordon360.Controllers.Api
             }
             catch (ResourceNotFoundException)
             {
-                //just catch the exception
+                //just catch the exception (to create the profile of usernameless alumni without throwing exception)
             }
-
-            
 
             var advisors = _profileService.GetAdvisors((id == username ? username : id));
 

--- a/Gordon360/ApiControllers/ProfilesController.cs
+++ b/Gordon360/ApiControllers/ProfilesController.cs
@@ -341,7 +341,7 @@ namespace Gordon360.Controllers.Api
             }
             catch (ResourceNotFoundException)
             {
-                //just catch the exception (to create the profile of usernameless alumni without throwing exception)
+                NotFound();
             }
 
             var advisors = _profileService.GetAdvisors((id == username ? username : id));

--- a/Gordon360/ApiControllers/ProfilesController.cs
+++ b/Gordon360/ApiControllers/ProfilesController.cs
@@ -57,6 +57,7 @@ namespace Gordon360.Controllers.Api
             var student = _profileService.GetStudentProfileByUsername(username);
             var faculty = _profileService.GetFacultyStaffProfileByUsername(username);
             var alumni = _profileService.GetAlumniProfileByUsername(username);
+
             //get profile links
             var customInfo = _profileService.GetCustomUserInfo(username);
 
@@ -185,6 +186,7 @@ namespace Gordon360.Controllers.Api
             var _student = _profileService.GetStudentProfileByUsername(username);
             var _faculty = _profileService.GetFacultyStaffProfileByUsername(username);
             var _alumni = _profileService.GetAlumniProfileByUsername(username);
+                
             var _customInfo = _profileService.GetCustomUserInfo(username);
 
             object student = null;
@@ -332,7 +334,7 @@ namespace Gordon360.Controllers.Api
             var _student = _profileService.GetStudentProfileByUsername(username);
             var id = _accountService.GetAccountByUsername(username).GordonID;
 
-            var advisors = _profileService.GetAdvisors(id);
+            var advisors = _profileService.GetAdvisors((id == username ? username : id));
 
             return Ok(advisors);
 
@@ -460,8 +462,17 @@ namespace Gordon360.Controllers.Api
             var authenticatedUser = this.ActionContext.RequestContext.Principal as ClaimsPrincipal;
             var viewerName = authenticatedUser.Claims.FirstOrDefault(x => x.Type == "user_name").Value;
             var viewerType = _roleCheckingService.getCollegeRole(viewerName);
-            var id = _accountService.GetAccountByUsername(username).GordonID;
-            var photoInfo = _profileService.GetPhotoPath(id);
+            var id = "";
+            var photoInfo = new PhotoPathViewModel();
+            try
+            {
+                id = _accountService.GetAccountByUsername(username).GordonID;
+                photoInfo = _profileService.GetPhotoPath(id);
+            }
+            catch (ResourceNotFoundException)
+            {
+                photoInfo = null;
+            }
 
             var filePath = "";
             var fileName = "";

--- a/Gordon360/ApiControllers/ProfilesController.cs
+++ b/Gordon360/ApiControllers/ProfilesController.cs
@@ -331,8 +331,20 @@ namespace Gordon360.Controllers.Api
         public IHttpActionResult GetAdvisors(string username)
         {
             var authenticatedUser = this.ActionContext.RequestContext.Principal as ClaimsPrincipal;
-            var _student = _profileService.GetStudentProfileByUsername(username);
-            var id = _accountService.GetAccountByUsername(username).GordonID;
+
+            var _student = new StudentProfileViewModel();
+            var id = "";
+            try
+            {
+                _student = _profileService.GetStudentProfileByUsername(username);
+                id = _accountService.GetAccountByUsername(username).GordonID;
+            }
+            catch (ResourceNotFoundException)
+            {
+                //just catch the exception
+            }
+
+            
 
             var advisors = _profileService.GetAdvisors((id == username ? username : id));
 

--- a/Gordon360/Services/AccountService.cs
+++ b/Gordon360/Services/AccountService.cs
@@ -89,6 +89,7 @@ namespace Gordon360.Services
             }
             AccountViewModel result = query; // Implicit conversion happening here, see ViewModels.
             return result;
+
         }
     }
 

--- a/Gordon360/Services/AccountService.cs
+++ b/Gordon360/Services/AccountService.cs
@@ -89,8 +89,11 @@ namespace Gordon360.Services
             }
             AccountViewModel result = query; // Implicit conversion happening here, see ViewModels.
             return result;
-
         }
+
+
+
+        
     }
 
 }

--- a/Gordon360/Services/AccountService.cs
+++ b/Gordon360/Services/AccountService.cs
@@ -90,10 +90,6 @@ namespace Gordon360.Services
             AccountViewModel result = query; // Implicit conversion happening here, see ViewModels.
             return result;
         }
-
-
-
-        
     }
 
 }

--- a/Gordon360/Services/ProfileService.cs
+++ b/Gordon360/Services/ProfileService.cs
@@ -72,22 +72,19 @@ namespace Gordon360.Services
         /// <returns></returns>
         public IEnumerable<AdvisorViewModel> GetAdvisors(string id)
         {
-            // Create empty advisor list to fill in and return.           
-            List<AdvisorViewModel> resultList = new List<AdvisorViewModel>();
-
             var query = _unitOfWork.AccountRepository.FirstOrDefault(x => x.gordon_id == id);
             if (query == null)
             {
-                return resultList;
-                //throw new ResourceNotFoundException() { ExceptionMessage = "The account was not found." };
+                throw new ResourceNotFoundException() { ExceptionMessage = "The account was not found." };
             }
 
             var idParam = new SqlParameter("@ID", id);
             // Stored procedure returns row containing advisor1 ID, advisor2 ID, advisor3 ID 
             var idResult = RawSqlQuery<ADVISOR_SEPARATE_Result>.query("ADVISOR_SEPARATE @ID", idParam).FirstOrDefault();
 
-            
-            
+            // Create empty advisor list to fill in and return.           
+            List<AdvisorViewModel> resultList = new List<AdvisorViewModel>();
+
             // If idResult equal null, it means this user do not have advisor
             if (idResult == null)
             {
@@ -107,15 +104,15 @@ namespace Gordon360.Services
                 if (!string.IsNullOrEmpty(idResult.Advisor2))
                 {
                     resultList.Add(new AdvisorViewModel(
-                        _accountService.Get(idResult.Advisor2).FirstName, 
-                        _accountService.Get(idResult.Advisor2).LastName, 
+                        _accountService.Get(idResult.Advisor2).FirstName,
+                        _accountService.Get(idResult.Advisor2).LastName,
                         _accountService.Get(idResult.Advisor2).ADUserName));
                 }
                 if (!string.IsNullOrEmpty(idResult.Advisor3))
                 {
                     resultList.Add(new AdvisorViewModel(
-                        _accountService.Get(idResult.Advisor3).FirstName, 
-                        _accountService.Get(idResult.Advisor3).LastName, 
+                        _accountService.Get(idResult.Advisor3).FirstName,
+                        _accountService.Get(idResult.Advisor3).LastName,
                         _accountService.Get(idResult.Advisor3).ADUserName));
                 }
             }
@@ -128,7 +125,12 @@ namespace Gordon360.Services
         /// <returns> Clifton strengths of the given user. </returns>
         public CliftonStrengthsViewModel GetCliftonStrengths(int id)
         {
-            return _unitOfWork.CliftonStrengthsRepository.FirstOrDefault(x => x.ID_NUM == id);
+            var strengths = _unitOfWork.CliftonStrengthsRepository.FirstOrDefault(x => x.ID_NUM == id);
+            if (strengths == null)
+            {
+                return null;
+            }
+            return strengths;
         }
 
         /// <summary> Gets the emergency contact information of a particular user </summary>

--- a/Gordon360/Services/ProfileService.cs
+++ b/Gordon360/Services/ProfileService.cs
@@ -77,6 +77,7 @@ namespace Gordon360.Services
             var query = _unitOfWork.AccountRepository.FirstOrDefault(x => x.gordon_id == id);
             if (query == null)
             {
+                //Return an empty list if the id account does not have advisor
                 return resultList;
             }
 

--- a/Gordon360/Services/ProfileService.cs
+++ b/Gordon360/Services/ProfileService.cs
@@ -72,18 +72,21 @@ namespace Gordon360.Services
         /// <returns></returns>
         public IEnumerable<AdvisorViewModel> GetAdvisors(string id)
         {
+            // Create empty advisor list to fill in and return.           
+            List<AdvisorViewModel> resultList = new List<AdvisorViewModel>();
+
             var query = _unitOfWork.AccountRepository.FirstOrDefault(x => x.gordon_id == id);
             if (query == null)
             {
-                throw new ResourceNotFoundException() { ExceptionMessage = "The account was not found." };
+                return resultList;
+                //throw new ResourceNotFoundException() { ExceptionMessage = "The account was not found." };
             }
 
             var idParam = new SqlParameter("@ID", id);
             // Stored procedure returns row containing advisor1 ID, advisor2 ID, advisor3 ID 
             var idResult = RawSqlQuery<ADVISOR_SEPARATE_Result>.query("ADVISOR_SEPARATE @ID", idParam).FirstOrDefault();
 
-            // Create empty advisor list to fill in and return.           
-            List<AdvisorViewModel> resultList = new List<AdvisorViewModel>();
+            
             
             // If idResult equal null, it means this user do not have advisor
             if (idResult == null)
@@ -125,12 +128,7 @@ namespace Gordon360.Services
         /// <returns> Clifton strengths of the given user. </returns>
         public CliftonStrengthsViewModel GetCliftonStrengths(int id)
         {
-            var strengths = _unitOfWork.CliftonStrengthsRepository.FirstOrDefault(x => x.ID_NUM == id);
-            if(strengths == null)
-            {
-                return null;
-            }
-            return strengths;
+            return _unitOfWork.CliftonStrengthsRepository.FirstOrDefault(x => x.ID_NUM == id);
         }
 
         /// <summary> Gets the emergency contact information of a particular user </summary>

--- a/Gordon360/Services/ProfileService.cs
+++ b/Gordon360/Services/ProfileService.cs
@@ -124,16 +124,7 @@ namespace Gordon360.Services
         /// <returns> Clifton strengths of the given user. </returns>
         public CliftonStrengthsViewModel GetCliftonStrengths(int id)
         {
-<<<<<<< HEAD
-            var strengths = _unitOfWork.CliftonStrengthsRepository.FirstOrDefault(x => x.ID_NUM == id);
-            if (strengths == null)
-            {
-                return null;
-            }
-            return strengths;
-=======
             return _unitOfWork.CliftonStrengthsRepository.FirstOrDefault(x => x.ID_NUM == id);
->>>>>>> origin/develop
         }
 
         /// <summary> Gets the emergency contact information of a particular user </summary>

--- a/Gordon360/Services/ProfileService.cs
+++ b/Gordon360/Services/ProfileService.cs
@@ -72,18 +72,17 @@ namespace Gordon360.Services
         /// <returns></returns>
         public IEnumerable<AdvisorViewModel> GetAdvisors(string id)
         {
+            // Create empty advisor list to fill in and return.           
+            List<AdvisorViewModel> resultList = new List<AdvisorViewModel>();
             var query = _unitOfWork.AccountRepository.FirstOrDefault(x => x.gordon_id == id);
             if (query == null)
             {
-                throw new ResourceNotFoundException() { ExceptionMessage = "The account was not found." };
+                return resultList;
             }
 
             var idParam = new SqlParameter("@ID", id);
             // Stored procedure returns row containing advisor1 ID, advisor2 ID, advisor3 ID 
             var idResult = RawSqlQuery<ADVISOR_SEPARATE_Result>.query("ADVISOR_SEPARATE @ID", idParam).FirstOrDefault();
-
-            // Create empty advisor list to fill in and return.           
-            List<AdvisorViewModel> resultList = new List<AdvisorViewModel>();
 
             // If idResult equal null, it means this user do not have advisor
             if (idResult == null)

--- a/Gordon360/Static Classes/Names.cs
+++ b/Gordon360/Static Classes/Names.cs
@@ -113,14 +113,13 @@ namespace Gordon360.Static.Names
         //ALL_PUBLIC_ALUMNI_REQUEST returns search result to the advanced people search 
         //with encrypted id as the ad_username if their ad_username is null
         //ALL_PUBLIC_ALUMNI_REQUEST and ALL_ALUMNI_REQUEST queries work together
-        public static string ALL_PUBLIC_ALUMNI_REQUEST = "SELECT FirstName, LastName, NickName, Major1Description, Major2Description, HomeCity, HomeState, Country, Email, ShareName, PreferredClassYear, ISNULL(AD_Username, CONVERT(NVARCHAR(32),HashBytes('MD2', ID),2)) as AD_Username FROM Alumni WHERE ShareName is null OR ShareName = 'Y';";
+        public static string ALL_PUBLIC_ALUMNI_REQUEST = "SELECT FirstName, LastName, NickName, Major1Description, Major2Description, HomeCity, HomeState, Country, Email, ShareName, PreferredClassYear, ISNULL(AD_Username, CONVERT(NVARCHAR(32),HashBytes('SHA2_256', ID),2)) as AD_Username FROM Alumni WHERE ShareName is null OR ShareName = 'Y';";
 
         public static string ALL_STUDENT_REQUEST = "SELECT * from Student WHERE AD_Username is not null";
         public static string ALL_FACULTY_STAFF_REQUEST = "SELECT * from FacStaff WHERE AD_Username is not null";
-        //ALL_ALUMNI_REQUEST returns the profile information for the first match of 
-        //either real ad_username (if exists) or the encrypted id
-        //from the advanced people search to the encrypted ad_username of their profile 
-        public static string ALL_ALUMNI_REQUEST = "SELECT ID, WebUpdate, Title, FirstName, MiddleName, LastName, Suffix, MaidenName, NickName, HomeStreet1, HomeStreet2, HomeCity, HomeState, HomePostalCode, HomeCountry, HomePhone, HomeFax, HomeEmail, JobTitle, MaritalStatus, SpouseName, College, ClassYear, PreferredClassYear, Major1, Major2, ShareName, ShareAddress, Gender, GradDate, Email, grad_student, Barcode, ISNULL(AD_Username, CONVERT(NVARCHAR(32),HashBytes('MD2', ID),2)) as AD_Username, show_pic, preferred_photo, Country, Major2Description, Major1Description from Alumni";// WHERE AD_Username is not null";
+        //ALL_ALUMNI_REQUEST returns the set of all the alumni in the records
+        //Other methods query this set to find a specific alum based on AD_Username (or the encrypted id)
+        public static string ALL_ALUMNI_REQUEST = "SELECT ID, WebUpdate, Title, FirstName, MiddleName, LastName, Suffix, MaidenName, NickName, HomeStreet1, HomeStreet2, HomeCity, HomeState, HomePostalCode, HomeCountry, HomePhone, HomeFax, HomeEmail, JobTitle, MaritalStatus, SpouseName, College, ClassYear, PreferredClassYear, Major1, Major2, ShareName, ShareAddress, Gender, GradDate, Email, grad_student, Barcode, ISNULL(AD_Username, CONVERT(NVARCHAR(32),HashBytes('SHA2_256', ID),2)) as AD_Username, show_pic, preferred_photo, Country, Major2Description, Major1Description from Alumni";// WHERE AD_Username is not null";
         public static string ALL_BASIC_INFO_NOT_ALUM = "ALL_BASIC_INFO_NOT_ALUMNI";
 
         // GoStalk

--- a/Gordon360/Static Classes/Names.cs
+++ b/Gordon360/Static Classes/Names.cs
@@ -110,11 +110,17 @@ namespace Gordon360.Static.Names
     {
         public static string ALL_PUBLIC_STUDENT_REQUEST = "SELECT ISNULL(Mail_Location, '') as Mail_Location, ISNULL(BuildingDescription, '') as Hall, ISNULL(FirstName, '') as FirstName, ISNULL(LastName, '') as LastName, ISNULL(NickName, '') as NickName, ISNULL(Class, '') as Class, ISNULL(Major1Description, '') as Major1Description, ISNULL(Major2Description, '') as Major2Description, ISNULL(Major3Description, '') as Major3Description, ISNULL(Minor1Description, '') as Minor1Description, ISNULL(Minor2Description, '') as Minor2Description, ISNULL(Minor3Description, '') as Minor3Description, ISNULL(HomeCity, '') as HomeCity, ISNULL(HomeState, '') as HomeState, ISNULL(Country, '') as Country, ISNULL(KeepPrivate, '') as KeepPrivate, ISNULL(Email, '') as Email, AD_Username FROM STUDENT S WHERE AD_Username is not null FOR JSON PATH, ROOT('Students')";
         public static string ALL_PUBLIC_FACULTY_STAFF_REQUEST = "SELECT FirstName, LastName, NickName, OnCampusDepartment, BuildingDescription, HomeCity, HomeState, Country, KeepPrivate, JobTitle, Email, Type, AD_Username, Mail_Location FROM FacStaff WHERE AD_Username is not null";
-        public static string ALL_PUBLIC_ALUMNI_REQUEST = "SELECT FirstName, LastName, NickName, Major1Description, Major2Description, HomeCity, HomeState, Country, Email, ShareName, PreferredClassYear, ISNULL(AD_Username, ID) as AD_Username FROM Alumni WHERE ShareName is null OR ShareName = 'Y';";
+        //ALL_PUBLIC_ALUMNI_REQUEST returns search result to the advanced people search 
+        //with encrypted id as the ad_username if their ad_username is null
+        //ALL_PUBLIC_ALUMNI_REQUEST and ALL_ALUMNI_REQUEST queries work together
+        public static string ALL_PUBLIC_ALUMNI_REQUEST = "SELECT FirstName, LastName, NickName, Major1Description, Major2Description, HomeCity, HomeState, Country, Email, ShareName, PreferredClassYear, ISNULL(AD_Username, CONVERT(NVARCHAR(32),HashBytes('MD2', ID),2)) as AD_Username FROM Alumni WHERE ShareName is null OR ShareName = 'Y';";
 
         public static string ALL_STUDENT_REQUEST = "SELECT * from Student WHERE AD_Username is not null";
         public static string ALL_FACULTY_STAFF_REQUEST = "SELECT * from FacStaff WHERE AD_Username is not null";
-        public static string ALL_ALUMNI_REQUEST = "SELECT ID, WebUpdate, Title, FirstName, MiddleName, LastName, Suffix, MaidenName, NickName, HomeStreet1, HomeStreet2, HomeCity, HomeState, HomePostalCode, HomeCountry, HomePhone, HomeFax, HomeEmail, JobTitle, MaritalStatus, SpouseName, College, ClassYear, PreferredClassYear, Major1, Major2, ShareName, ShareAddress, Gender, GradDate, Email, grad_student, Barcode, ISNULL(AD_Username, ID) as AD_Username, show_pic, preferred_photo, Country, Major2Description, Major1Description from Alumni";// WHERE AD_Username is not null";
+        //ALL_ALUMNI_REQUEST returns the profile information for the first match of 
+        //either real ad_username (if exists) or the encrypted id
+        //from the advanced people search to the encrypted ad_username of their profile 
+        public static string ALL_ALUMNI_REQUEST = "SELECT ID, WebUpdate, Title, FirstName, MiddleName, LastName, Suffix, MaidenName, NickName, HomeStreet1, HomeStreet2, HomeCity, HomeState, HomePostalCode, HomeCountry, HomePhone, HomeFax, HomeEmail, JobTitle, MaritalStatus, SpouseName, College, ClassYear, PreferredClassYear, Major1, Major2, ShareName, ShareAddress, Gender, GradDate, Email, grad_student, Barcode, ISNULL(AD_Username, CONVERT(NVARCHAR(32),HashBytes('MD2', ID),2)) as AD_Username, show_pic, preferred_photo, Country, Major2Description, Major1Description from Alumni";// WHERE AD_Username is not null";
         public static string ALL_BASIC_INFO_NOT_ALUM = "ALL_BASIC_INFO_NOT_ALUMNI";
 
         // GoStalk

--- a/Gordon360/Static Classes/Names.cs
+++ b/Gordon360/Static Classes/Names.cs
@@ -110,11 +110,11 @@ namespace Gordon360.Static.Names
     {
         public static string ALL_PUBLIC_STUDENT_REQUEST = "SELECT ISNULL(Mail_Location, '') as Mail_Location, ISNULL(BuildingDescription, '') as Hall, ISNULL(FirstName, '') as FirstName, ISNULL(LastName, '') as LastName, ISNULL(NickName, '') as NickName, ISNULL(Class, '') as Class, ISNULL(Major1Description, '') as Major1Description, ISNULL(Major2Description, '') as Major2Description, ISNULL(Major3Description, '') as Major3Description, ISNULL(Minor1Description, '') as Minor1Description, ISNULL(Minor2Description, '') as Minor2Description, ISNULL(Minor3Description, '') as Minor3Description, ISNULL(HomeCity, '') as HomeCity, ISNULL(HomeState, '') as HomeState, ISNULL(Country, '') as Country, ISNULL(KeepPrivate, '') as KeepPrivate, ISNULL(Email, '') as Email, AD_Username FROM STUDENT S WHERE AD_Username is not null FOR JSON PATH, ROOT('Students')";
         public static string ALL_PUBLIC_FACULTY_STAFF_REQUEST = "SELECT FirstName, LastName, NickName, OnCampusDepartment, BuildingDescription, HomeCity, HomeState, Country, KeepPrivate, JobTitle, Email, Type, AD_Username, Mail_Location FROM FacStaff WHERE AD_Username is not null";
-        public static string ALL_PUBLIC_ALUMNI_REQUEST = "SELECT FirstName, LastName, NickName, Major1Description, Major2Description, HomeCity, HomeState, Country, Email, ShareName, PreferredClassYear, AD_Username FROM Alumni WHERE ShareName is null OR ShareName = 'Y';";
+        public static string ALL_PUBLIC_ALUMNI_REQUEST = "SELECT FirstName, LastName, NickName, Major1Description, Major2Description, HomeCity, HomeState, Country, Email, ShareName, PreferredClassYear, ISNULL(AD_Username, ID) as AD_Username FROM Alumni WHERE ShareName is null OR ShareName = 'Y';";
 
         public static string ALL_STUDENT_REQUEST = "SELECT * from Student WHERE AD_Username is not null";
         public static string ALL_FACULTY_STAFF_REQUEST = "SELECT * from FacStaff WHERE AD_Username is not null";
-        public static string ALL_ALUMNI_REQUEST = "SELECT * from Alumni WHERE AD_Username is not null";
+        public static string ALL_ALUMNI_REQUEST = "SELECT ID, WebUpdate, Title, FirstName, MiddleName, LastName, Suffix, MaidenName, NickName, HomeStreet1, HomeStreet2, HomeCity, HomeState, HomePostalCode, HomeCountry, HomePhone, HomeFax, HomeEmail, JobTitle, MaritalStatus, SpouseName, College, ClassYear, PreferredClassYear, Major1, Major2, ShareName, ShareAddress, Gender, GradDate, Email, grad_student, Barcode, ISNULL(AD_Username, ID) as AD_Username, show_pic, preferred_photo, Country, Major2Description, Major1Description from Alumni";// WHERE AD_Username is not null";
         public static string ALL_BASIC_INFO_NOT_ALUM = "ALL_BASIC_INFO_NOT_ALUMNI";
 
         // GoStalk

--- a/README.md
+++ b/README.md
@@ -814,7 +814,7 @@ What is it? Resource that represents users' profiles.
 
 Differences from GoSite:
 
--   Only displaying city and country as home address. (When the viewer is a student. Police, super admin, faculty and staff should still see all the information for home address)
+-   Only displaying city and country as home address. (When the viewer is a student, Police, super admin, alumni, faculty and staff should still see all the information for home address)
 -   Displaying minors.
 -   On campus was changed to display more general information rather than completely getting rid of it like GoSite does now. (Shows on/off campus)
 

--- a/README.md
+++ b/README.md
@@ -814,7 +814,7 @@ What is it? Resource that represents users' profiles.
 
 Differences from GoSite:
 
--   Only displaying city and country as home address. (When the viewer is a student, Police, super admin, alumni, faculty and staff should still see all the information for home address)
+-   Only displaying city and country as home address. (When the viewer is a student or alumni. Police, super admin, faculty, and staff should still see all the information for home address)
 -   Displaying minors.
 -   On campus was changed to display more general information rather than completely getting rid of it like GoSite does now. (Shows on/off campus)
 


### PR DESCRIPTION
This PR creates profiles for usernameless alumni.

Minor change:
- Replace AD_Username with the encrypted ID if AD_Username is null
- Catch the throwing NoResourceFoundException and return a null (or anything that makes profiles load)