### PR TITLE
Clarify API notation for use with Postman

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ Here is a breakdown of the project folder:
 
 ## API Endpoints
 
-Notation: In the API endpoint descriptions below, parameter values are indicated by a leading ":".  The ":" is not present in the URL, just the value.  Also, a trailing "/" is required after the last parameter value (even though it is not shown below).
+Notation: In the API endpoint descriptions below, some parameter values are indicated by a leading ":".  The ":" is not present in the URL, just the value.  Also, a trailing "/" is required after the last parameter value (even though it is not shown below).
 
 _Note:_ The shell script `get-route-list.sh` is run with `bash get-route-list.sh` from a linux shell or git-bash. It provides a list of the API routes that appear in the ApiController files.
 

--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ Here is a breakdown of the project folder:
 
 ## API Endpoints
 
-Notation: In the API endpoint descriptions below, some parameter values are indicated by a leading ":".  The ":" is not present in the URL, just the value.  Also, a trailing "/" is required after the last parameter value (even though it is not shown below).
+Notation: In the API endpoint descriptions below, some parameter values are indicated by a leading ":" (though convention is to surround the parameter with {curly-brackets}).  The ":" is not present in the URL, just the value.  Also, a trailing "/" is required after the last parameter value if the parameter includes a special character like a period (e.g. `360.studenttest` necessitates trailing slash).
 
 _Note:_ The shell script `get-route-list.sh` is run with `bash get-route-list.sh` from a linux shell or git-bash. It provides a list of the API routes that appear in the ApiController files.
 

--- a/README.md
+++ b/README.md
@@ -493,6 +493,8 @@ Here is a breakdown of the project folder:
 
 ## API Endpoints
 
+Notation: In the API endpoint descriptions below, parameter values are indicated by a leading ":".  The ":" is not present in the URL, just the value.  Also, a trailing "/" is required after the last parameter value (even though it is not shown below).
+
 _Note:_ The shell script `get-route-list.sh` is run with `bash get-route-list.sh` from a linux shell or git-bash. It provides a list of the API routes that appear in the ApiController files.
 
 ### Accounts
@@ -1074,7 +1076,7 @@ To manually test the API, use an API development/testing app like [Postman](http
 
     -   Use the clipboard to make of copy of the _access-token_ value (do not include the double quotes, just copy the long string of characters between the quotes)
     -   Click on the "+" tab near the top of the window to open a new request frame
-    -   Leave "GET" as the request type and enter in an appropriate API URL (e.g. `http://localhost:5555/api/memberships/activity/AJG`
+    -   Leave "GET" as the request type and enter in an appropriate API URL (e.g. `http://localhost:5555/api/memberships/activity/AJG`, or `http://localhost:5555/api/profiles/360.studenttest/`).  Note that a trailing slash is needed after the last parameter value.
     -   Just below the URL, click on "Headers" and enter the following key/value pairs replacing _access-token_ with the token string you copied:
 
         | Key             | Value                               |


### PR DESCRIPTION
Explain that :parameter means a value to replace (so the ":" doesn't appear in the URL), and that a trailing slash is then required.