### PR TITLE
Added school-role checking in emergency contact in API

### DIFF
--- a/Gordon360/ApiControllers/ProfilesController.cs
+++ b/Gordon360/ApiControllers/ProfilesController.cs
@@ -373,8 +373,15 @@ namespace Gordon360.Controllers.Api
         [StateYourBusiness(operation = Operation.READ_ONE, resource = Resource.PROFILE)]
         public IHttpActionResult GetEmergencyContact(string username)
         {
-            var emrg = _profileService.GetEmergencyContact(username);
-
+            var authenticatedUser = this.ActionContext.RequestContext.Principal as ClaimsPrincipal;
+            var viewerName = authenticatedUser.Claims.FirstOrDefault(x => x.Type == "user_name").Value;
+            var viewerType = _roleCheckingService.getCollegeRole(viewerName);
+            
+            var emrg = Enumerable.Empty<EmergencyContactViewModel>();
+            if (viewerType == Position.POLICE)
+            {
+                emrg = _profileService.GetEmergencyContact(username);
+            }
             return Ok(emrg);
         }
 

--- a/Gordon360/ApiControllers/ProfilesController.cs
+++ b/Gordon360/ApiControllers/ProfilesController.cs
@@ -370,7 +370,7 @@ namespace Gordon360.Controllers.Api
         /// <returns> Emergency contact information of the given user. </returns>
         [HttpGet]
         [Route("emergency-contact/{username}")]
-        [StateYourBusiness(operation = Operation.READ_ONE, resource = Resource.PROFILE)]
+        [StateYourBusiness(operation = Operation.READ_ONE, resource = Resource.EMERGENCY_CONTACT)]
         public IHttpActionResult GetEmergencyContact(string username)
         {
             var authenticatedUser = this.ActionContext.RequestContext.Principal as ClaimsPrincipal;

--- a/Gordon360/ApiControllers/ProfilesController.cs
+++ b/Gordon360/ApiControllers/ProfilesController.cs
@@ -373,12 +373,19 @@ namespace Gordon360.Controllers.Api
         [StateYourBusiness(operation = Operation.READ_ONE, resource = Resource.EMERGENCY_CONTACT)]
         public IHttpActionResult GetEmergencyContact(string username)
         {
-            var authenticatedUser = this.ActionContext.RequestContext.Principal as ClaimsPrincipal;
-            var viewerName = authenticatedUser.Claims.FirstOrDefault(x => x.Type == "user_name").Value;
-            var viewerType = _roleCheckingService.getCollegeRole(viewerName);
+            try
+            {
+                var emrg = _profileService.GetEmergencyContact(username);
+                return Ok(emrg);
+            }
+            catch (System.Exception e)
+            {
+                System.Diagnostics.Debug.WriteLine(e.Message);
+                Request.CreateErrorResponse(HttpStatusCode.InternalServerError, "There was an error getting the emergency contact.");
+                return NotFound();
+            }
             
-            var emrg = _profileService.GetEmergencyContact(username);
-            return Ok(emrg);
+            
         }
 
         /// <summary>Get the profile image of currently logged in user</summary>

--- a/Gordon360/ApiControllers/ProfilesController.cs
+++ b/Gordon360/ApiControllers/ProfilesController.cs
@@ -377,11 +377,7 @@ namespace Gordon360.Controllers.Api
             var viewerName = authenticatedUser.Claims.FirstOrDefault(x => x.Type == "user_name").Value;
             var viewerType = _roleCheckingService.getCollegeRole(viewerName);
             
-            var emrg = Enumerable.Empty<EmergencyContactViewModel>();
-            if (viewerType == Position.POLICE)
-            {
-                emrg = _profileService.GetEmergencyContact(username);
-            }
+            var emrg = _profileService.GetEmergencyContact(username);
             return Ok(emrg);
         }
 

--- a/Gordon360/AuthorizationFilters/StateYourBusiness.cs
+++ b/Gordon360/AuthorizationFilters/StateYourBusiness.cs
@@ -146,6 +146,10 @@ namespace Gordon360.AuthorizationFilters
             {
                 case Resource.PROFILE:
                     return true;
+                case Resource.EMERGENCY_CONTACT:
+                    if (user_position == Position.POLICE)
+                        return true;
+                    return false;
                 case Resource.MEMBERSHIP:
                     return true;
                 case Resource.MEMBERSHIP_REQUEST:

--- a/Gordon360/Static Classes/Names.cs
+++ b/Gordon360/Static Classes/Names.cs
@@ -4,6 +4,7 @@ namespace Gordon360.Static.Names
 {
     public static class Resource
     {
+        public const string EMERGENCY_CONTACT = "A new emergency contact resource";
         public const string PROFILE = "A new profile resource";
         public const string MEMBERSHIP_REQUEST = "A Membership Request Resource";
         public const string MEMBERSHIP = "A Membership Resource";


### PR DESCRIPTION
This PR only returns emergency contact information if the account belongs to the police, else it returns an empty list.