### PR TITLE
Accept common town abbreviations in advanced people search

### DIFF
--- a/Gordon360/ApiControllers/AccountsController.cs
+++ b/Gordon360/ApiControllers/AccountsController.cs
@@ -472,6 +472,20 @@ namespace Gordon360.ApiControllers
             {
                 hometownSearchParam = "";
             }
+            // Accept common town abbreviations in advanced people search
+            // East = E, West = W, South = S, North = N
+            else if (
+              hometownSearchParam.StartsWith("e ") ||
+              hometownSearchParam.StartsWith("w ") ||
+              hometownSearchParam.StartsWith("s ") ||
+              hometownSearchParam.StartsWith("n ")
+              )
+            {
+                hometownSearchParam = hometownSearchParam.Replace("e ", "east ");
+                hometownSearchParam = hometownSearchParam.Replace("w ", "west ");
+                hometownSearchParam = hometownSearchParam.Replace("s ", "south ");
+                hometownSearchParam = hometownSearchParam.Replace("n ", "north ");
+            }
             if (majorSearchParam == "C\u266F")
             {
                 majorSearchParam = "";

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -43,6 +43,9 @@
         </member>
         <member name="M:Gordon360.ApiControllers.AccountsController.AdvancedPeopleSearch(System.Boolean,System.String,System.String,System.String,System.String,System.String,System.String,System.String,System.String,System.String,System.String,System.String)">
             <summary>
+            Deprecated route uses new route below with two leading parameters for
+            including students and facStaff.
+            
             Return a list of accounts matching some or all of the search parameters
             We are searching through all the info of a user, then narrowing it down to get only what we want
             </summary>

--- a/Gordon360/Gordon360.csproj
+++ b/Gordon360/Gordon360.csproj
@@ -894,16 +894,7 @@
     <VisualStudio>
       <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
         <WebProjectProperties>
-          <UseIIS>True</UseIIS>
-          <AutoAssignPort>True</AutoAssignPort>
-          <DevelopmentServerPort>49645</DevelopmentServerPort>
-          <DevelopmentServerVPath>/</DevelopmentServerVPath>
-          <IISUrl>http://localhost:5555</IISUrl>
-          <NTLMAuthentication>False</NTLMAuthentication>
-          <UseCustomServer>False</UseCustomServer>
-          <CustomServerUrl>
-          </CustomServerUrl>
-          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+          <SaveServerSettingsInUserFile>True</SaveServerSettingsInUserFile>
           <servers defaultServer="">
             <server name="SelfHostServer" exePath="" cmdArgs="" url="http://localhost:49645/" workingDir="" />
           </servers>


### PR DESCRIPTION
Links to #622.

Accept common town abbreviations in advanced people search.
For example, "N Andover" => "North Andover".

![Screen Shot 2021-07-07 at 2 27 32 PM](https://user-images.githubusercontent.com/70544403/124815002-adacab80-df34-11eb-8b83-aed593ebb273.png)

Before:
![Screen Shot 2021-07-07 at 3 02 49 PM](https://user-images.githubusercontent.com/70544403/124814966-a08fbc80-df34-11eb-9922-0f84ab1bea5f.png)

After:
![124815266-13009c80-df35-11eb-8903-13a93ea25112](https://user-images.githubusercontent.com/70544403/124817396-c10d4600-df37-11eb-891f-44fe4a7e237a.png)

I did not try backward since there is only one data on DB.
![Screen Shot 2021-07-07 at 2 26 35 PM](https://user-images.githubusercontent.com/70544403/124814908-91a90a00-df34-11eb-9364-9f7cb4652dcc.png)
![Screen Shot 2021-07-07 at 3 01 08 PM](https://user-images.githubusercontent.com/70544403/124814916-9372cd80-df34-11eb-8031-282c666b3f2a.png)
