### PR TITLE
(S21) Added current term on homepage

### DIFF
--- a/Gordon360/ApiControllers/SessionsController.cs
+++ b/Gordon360/ApiControllers/SessionsController.cs
@@ -111,7 +111,7 @@ namespace Gordon360.Controllers.Api
         }
 
         /// <summary>
-        /// Gets the first day in the current session
+        /// Gets the last day in the current session
         /// </summary>
         /// <returns></returns>
         [HttpGet]

--- a/Gordon360/ApiControllers/SessionsController.cs
+++ b/Gordon360/ApiControllers/SessionsController.cs
@@ -91,8 +91,45 @@ namespace Gordon360.Controllers.Api
 
             return Ok(currentSession);
         }
+
         /// <summary>
-        /// Gets the days left in the current semester
+        /// Gets the first day in the current session
+        /// </summary>
+        /// <returns></returns>
+        [HttpGet]
+        [Route("firstDay")]
+        //Public Route
+        public IHttpActionResult GetFirstDayinSemester()
+        {
+            var firstDay = Helpers.GetFirstDay();
+            if (firstDay == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(firstDay);
+        }
+
+        /// <summary>
+        /// Gets the first day in the current session
+        /// </summary>
+        /// <returns></returns>
+        [HttpGet]
+        [Route("lastDay")]
+        //Public Route
+        public IHttpActionResult GetLastDayinSemester()
+        {
+            var lastDay = Helpers.GetLastDay();
+            if (lastDay == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(lastDay);
+        }
+
+        /// <summary>
+        /// Gets the days left in the current session
         /// </summary>
         /// <returns></returns>
         [HttpGet]

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -846,9 +846,21 @@
             </summary>
             <returns></returns>
         </member>
+        <member name="M:Gordon360.Controllers.Api.SessionsController.GetFirstDayinSemester">
+            <summary>
+            Gets the first day in the current session
+            </summary>
+            <returns></returns>
+        </member>
+        <member name="M:Gordon360.Controllers.Api.SessionsController.GetLastDayinSemester">
+            <summary>
+            Gets the first day in the current session
+            </summary>
+            <returns></returns>
+        </member>
         <member name="M:Gordon360.Controllers.Api.SessionsController.GetDaysLeftinSemester">
             <summary>
-            Gets the days left in the current semester
+            Gets the days left in the current session
             </summary>
             <returns></returns>
         </member>

--- a/Gordon360/Static Classes/Helpers.cs
+++ b/Gordon360/Static Classes/Helpers.cs
@@ -175,7 +175,23 @@ namespace Gordon360.Static.Methods
             return result; ;
         }
 
-        // Return the days left in the semester, and the total days in the semester
+        // Return the first day in the current session
+        public static String GetFirstDay()
+        {
+            DateTime firstDayRaw = GetCurrentSession().SessionBeginDate.Value;
+            String firstDay = firstDayRaw.ToString("MM/dd/yyyy");
+            return firstDay;
+        }
+
+        // Return the last day in the current session
+        public static String GetLastDay()
+        {
+            DateTime lastDayRaw = GetCurrentSession().SessionEndDate.Value;
+            String lastDay = lastDayRaw.ToString("MM/dd/yyyy");
+            return lastDay;
+        }
+
+        // Return the days left in the semester, and the total days in the current session
         public static double[] GetDaysLeft()
         {
             // The end of the current session

--- a/README.md
+++ b/README.md
@@ -791,8 +791,12 @@ Who has access? Everyone.
 `api/sessions/:id` Get the session with session code `id`.
 
 `api/sessions/current` Get the current session.
+	
+`api/sessions/firstDay` Get the Gets the first day in the current session.
+	
+`api/sessions/lastDay` Get the Gets the last day in the current session.
 
-`api/sessions/daysLeft` Get the days left in the semester and the total days in the semester
+`api/sessions/daysLeft` Get the days left in the semester and the total days in the current session.
 
 ### Participation Definitions
 


### PR DESCRIPTION
Relate to 360-gordon-ui issue number https://github.com/gordon-cs/gordon-360-ui/pull/1258 and https://github.com/gordon-cs/gordon-360-ui/pull/1256.
FYI, I forgot to change s21_town_abbreviations branch to a new branch.
That is why I am on the wrong branch.