### PR TITLE
change quick people search sql code in api

### DIFF
--- a/Gordon360/ApiControllers/AccountsController.cs
+++ b/Gordon360/ApiControllers/AccountsController.cs
@@ -98,7 +98,7 @@ namespace Gordon360.ApiControllers
             var viewerName = authenticatedUser.Claims.FirstOrDefault(x => x.Type == "user_name").Value;
             var viewerType = _roleCheckingService.getCollegeRole(viewerName);
 
-            var accounts = viewerType == Position.STUDENT ? Data.AllBasicInfoWithoutAlumni : Data.AllBasicInfo;
+            var accounts = Data.AllBasicInfoWithoutAlumni;
 
             int precedence = 0;
 
@@ -286,7 +286,7 @@ namespace Gordon360.ApiControllers
             };
 
             // Create accounts viewmodel to search
-            var accounts = viewerType == Position.STUDENT ? Data.AllBasicInfoWithoutAlumni : Data.AllBasicInfo;
+            var accounts = Data.AllBasicInfoWithoutAlumni;
 
             if (!string.IsNullOrEmpty(searchString) && !string.IsNullOrEmpty(secondaryString))
             {

--- a/Gordon360/Static Classes/Names.cs
+++ b/Gordon360/Static Classes/Names.cs
@@ -121,8 +121,17 @@ namespace Gordon360.Static.Names
         //ALL_ALUMNI_REQUEST returns the set of all the alumni in the records
         //Other methods query this set to find a specific alum based on AD_Username (or the encrypted id)
         public static string ALL_ALUMNI_REQUEST = "SELECT ID, WebUpdate, Title, FirstName, MiddleName, LastName, Suffix, MaidenName, NickName, HomeStreet1, HomeStreet2, HomeCity, HomeState, HomePostalCode, HomeCountry, HomePhone, HomeFax, HomeEmail, JobTitle, MaritalStatus, SpouseName, College, ClassYear, PreferredClassYear, Major1, Major2, ShareName, ShareAddress, Gender, GradDate, Email, grad_student, Barcode, ISNULL(AD_Username, CONVERT(NVARCHAR(32),HashBytes('SHA2_256', ID),2)) as AD_Username, show_pic, preferred_photo, Country, Major2Description, Major1Description from Alumni";// WHERE AD_Username is not null";
-        public static string ALL_BASIC_INFO_NOT_ALUM = "ALL_BASIC_INFO_NOT_ALUMNI";
-
+        public static string ALL_BASIC_INFO_NOT_ALUM = 
+            "select DISTINCT A.firstname as Firstname, A.lastname as Lastname, " +
+            "COALESCE(B.NickName, C.Nickname) as Nickname, " +
+            "COALESCE(B.MaidenName, C.MaidenName) as MaidenName, A.AD_Username as Username, " +
+            "CONCAT(A.firstname, A.lastname, A.AD_Username) as ConcatonatedInfo " +
+            "from ACCOUNT as A left join FacStaff as B on A.AD_Username = B.AD_Username " +
+            "left join Student as C on A.AD_Username = C.AD_Username " +
+            "where isnull(A.AD_Username, '') != '' " +
+            "and(isnull(B.AD_Username, '') != '' " +
+            "or isnull(C.AD_Username, '') !='')";
+            
         // GoStalk
         public static string ALL_MAJORS = "SELECT DISTINCT MajorDescription FROM Majors ORDER BY MajorDescription ASC";
         public static string ALL_MINORS = "SELECT DISTINCT Minor1Description FROM Student WHERE Minor1Description is not null";


### PR DESCRIPTION
This PR changes the sql code of ALL_BASIC_INFO_NOT_ALUMNI which affects the quick people search in API.
We also decided to remove alumni from the quick people search.