### PR TITLE
Make profile of alumni with sharename null accessible by faculty accounts

### DIFF
--- a/Gordon360/Models/ViewModels/PublicAlumniProfileViewModel.cs
+++ b/Gordon360/Models/ViewModels/PublicAlumniProfileViewModel.cs
@@ -72,7 +72,7 @@ namespace Gordon360.Models.ViewModels
                 Major1Description = alu.Major1Description ?? "",
                 Major2Description = alu.Major2Description ?? ""
             };
-            if (!vm.ShareName.Contains("Y"))
+            if (vm.ShareName.Contains("N") || vm.ShareName.Contains("n"))
             {
                 return null;
             }


### PR DESCRIPTION
This PR solves an issue caused by the Public Alumni View Model.

Since many alumni have Sharename = null, we cannot access their profiles even though they show up in the people search. So, simply returning a profile for the alumni with Sharename = null will solve this issue once for all.