### PR TITLE
Added user-agent to client header in HTTP request sent to 25Live

### DIFF
--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -854,7 +854,7 @@
         </member>
         <member name="M:Gordon360.Controllers.Api.SessionsController.GetLastDayinSemester">
             <summary>
-            Gets the first day in the current session
+            Gets the last day in the current session
             </summary>
             <returns></returns>
         </member>

--- a/Gordon360/Static Classes/Helpers.cs
+++ b/Gordon360/Static Classes/Helpers.cs
@@ -220,14 +220,14 @@ namespace Gordon360.Static.Methods
             // Send the request and parse 
             using (WebClient client = new WebClient())
             {
+                // Necessary to prevent HTTP error 429 from 25Live
+                client.Headers.Add("user-agent", "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.2; .NET CLR 1.0.3705;)");
                 MemoryStream stream = null;
                 // Commit contents of the request to temporary memory
                 try
                 {
-                    Uri request = new Uri(requestUrl);
-                    // Use an Async method to make sure we have completed the download 
-                    // We don't want to try and pull partial data!
-                    var data = client.DownloadData(request);
+                    // Get XML data as byte array and convet to memory stream
+                    var data = client.DownloadData(requestUrl);
                     stream = new MemoryStream(data);
                 }
                 // catch any errors thrown


### PR DESCRIPTION
Around the end of June 2021 our HTTP request to 25Live stopped working with an HTTP 429 Too Many Requests error.  According to [this page](https://sharepoint.stackexchange.com/questions/282238/system-net-webexception-the-remote-server-returned-an-error-429) this problem can be caused by the user agent not being set. The fix in this PR follows the example in the [Microsoft WebClient docs](https://docs.microsoft.com/en-us/dotnet/api/system.net.webclient?view=net-5.0) to set the user agent.
