### PR TITLE
Split up Multi-Occurrence Events

### DIFF
--- a/Gordon360/ApiControllers/EventController.cs
+++ b/Gordon360/ApiControllers/EventController.cs
@@ -23,7 +23,7 @@ namespace Gordon360.ApiControllers
 
         [Authorize]
         [HttpGet]
-        [Route("chapel/{term}")]
+        [Route("attended/{term}")]
         public IHttpActionResult GetEventsByTerm(string term)
         {
             //get token data from context, username is the username of current logged in person
@@ -59,11 +59,11 @@ namespace Gordon360.ApiControllers
         /// <returns></returns>
         [Authorize]
         [HttpGet]
-        [Route("25Live/All")]
+        [Route("")]
         public IHttpActionResult GetAllEvents()
         {
 
-            if (!ModelState.IsValid )
+            if (!ModelState.IsValid)
             {
                 string errors = "";
                 foreach (var modelstate in ModelState.Values)
@@ -91,7 +91,7 @@ namespace Gordon360.ApiControllers
 
         [Authorize]
         [HttpGet]
-        [Route("25Live/CLAW")]
+        [Route("claw")]
         public IHttpActionResult GetAllChapelEvents()
         {
 
@@ -123,7 +123,7 @@ namespace Gordon360.ApiControllers
         }
 
         [HttpGet]
-        [Route("25Live/Public")]
+        [Route("public")]
         public IHttpActionResult GetAllPublicEvents()
         {
             if (!ModelState.IsValid)
@@ -142,6 +142,138 @@ namespace Gordon360.ApiControllers
             }
 
             var result = _eventService.GetPublicEvents();
+
+            if (result == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(result);
+        }
+
+
+
+        [Authorize]
+        [HttpGet]
+        [Route("chapel/{term}")]
+        public IHttpActionResult DEPRECATED_GetEventsByTerm(string term)
+        {
+            //get token data from context, username is the username of current logged in person
+            var authenticatedUser = ActionContext.RequestContext.Principal as ClaimsPrincipal;
+            var user_name = authenticatedUser.Claims.FirstOrDefault(x => x.Type == "user_name").Value;
+            if (!ModelState.IsValid || string.IsNullOrWhiteSpace(user_name) || string.IsNullOrWhiteSpace(term))
+            {
+                string errors = "";
+                foreach (var modelstate in ModelState.Values)
+                {
+                    foreach (var error in modelstate.Errors)
+                    {
+                        errors += "|" + error.ErrorMessage + "|" + error.Exception;
+                    }
+
+                }
+                throw new BadInputException() { ExceptionMessage = errors };
+            }
+
+            var result = _eventService.DEPRECATED_GetEventsForStudentByTerm(user_name, term);
+
+            if (result == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// This makes use of our cached request to 25Live, which stores AllEvents
+        /// </summary>
+        /// <returns></returns>
+        [Authorize]
+        [HttpGet]
+        [Route("25Live/All")]
+        public IHttpActionResult DEPRECATED_GetAllEvents()
+        {
+
+            if (!ModelState.IsValid )
+            {
+                string errors = "";
+                foreach (var modelstate in ModelState.Values)
+                {
+                    foreach (var error in modelstate.Errors)
+                    {
+                        errors += "|" + error.ErrorMessage + "|" + error.Exception;
+                    }
+
+                }
+
+                throw new BadInputException() { ExceptionMessage = errors };
+            }
+
+            var result = _eventService.DEPRECATED_GetAllEvents();
+
+            if (result == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(result);
+
+        }
+
+        [Authorize]
+        [HttpGet]
+        [Route("25Live/CLAW")]
+        public IHttpActionResult DEPRECATED_GetAllChapelEvents()
+        {
+
+            if (!ModelState.IsValid)
+            {
+                string errors = "";
+                foreach (var modelstate in ModelState.Values)
+                {
+                    foreach (var error in modelstate.Errors)
+                    {
+                        errors += "|" + error.ErrorMessage + "|" + error.Exception;
+                    }
+
+                }
+
+                throw new BadInputException() { ExceptionMessage = errors };
+            }
+
+            var result = _eventService.DEPRECATED_GetCLAWEvents();
+
+
+            if (result == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(result);
+
+        }
+
+        [HttpGet]
+        [Route("25Live/Public")]
+        public IHttpActionResult DEPRECATED_GetAllPublicEvents()
+        {
+            if (!ModelState.IsValid)
+            {
+                string errors = "";
+                foreach (var modelstate in ModelState.Values)
+                {
+                    foreach (var error in modelstate.Errors)
+                    {
+                        errors += "|" + error.ErrorMessage + "|" + error.Exception;
+                    }
+
+                }
+
+                throw new BadInputException() { ExceptionMessage = errors };
+            }
+
+            var result = _eventService.DEPRECATED_GetPublicEvents();
 
             if (result == null)
             {

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -927,6 +927,12 @@
             </summary>
             <returns></returns>
         </member>
+        <member name="M:Gordon360.ApiControllers.EventController.DEPRECATED_GetAllEvents">
+            <summary>
+            This makes use of our cached request to 25Live, which stores AllEvents
+            </summary>
+            <returns></returns>
+        </member>
         <member name="M:Gordon360.ApiControllers.JobsController.GetJobs(System.DateTime,System.DateTime)">
             <summary>
             Get a user's active jobs
@@ -1094,6 +1100,11 @@
             <summary>Delete an existing booking item</summary>
             <param name="rideID">The identifier for the booking to be deleted</param>
             <remarks>Calls the server to make a call and remove the given booking from the database</remarks>
+        </member>
+        <member name="M:Gordon360.Models.ViewModels.DEPRECATED_EventViewModel.#ctor(Gordon360.Models.ViewModels.DEPRECATED_EventViewModel,Gordon360.Models.ViewModels.EventOccurence)">
+            <summary>
+            Initializes a new custom instance of the <see cref="T:Gordon360.Models.ViewModels.DEPRECATED_EventViewModel"/> class.
+            </summary>
         </member>
         <member name="F:Gordon360.Repositories.GenericRepository`1._context">
             <summary>
@@ -1624,6 +1635,27 @@
             <returns>All CLAW Events</returns>
         </member>
         <member name="M:Gordon360.Services.EventService.GetEventsForStudentByTerm(System.String,System.String)">
+            <summary>
+            Returns all attended events for a student in a specific term
+            </summary>
+            <param name="user_name"> The student's ID</param>
+            <param name="term"> The current term</param>
+            <returns></returns>
+        </member>
+        <!-- Badly formed XML comment ignored for member "M:Gordon360.Services.EventService.DEPRECATED_GetAllEvents" -->
+        <member name="M:Gordon360.Services.EventService.DEPRECATED_GetPublicEvents">
+            <summary>
+            Select only events that are marked for Public promotion
+            </summary>
+            <returns>All Public Events</returns>
+        </member>
+        <member name="M:Gordon360.Services.EventService.DEPRECATED_GetCLAWEvents">
+            <summary>
+            Select only events that are Approved to give CLAW credit
+            </summary>
+            <returns>All CLAW Events</returns>
+        </member>
+        <member name="M:Gordon360.Services.EventService.DEPRECATED_GetEventsForStudentByTerm(System.String,System.String)">
             <summary>
             Returns all attended events for a student in a specific term
             </summary>

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -1607,6 +1607,7 @@
         <member name="M:Gordon360.Services.EventService.GetAllEvents">
             <summary>
             Access the memory stream created by the cached task and parse it into events
+            Splits events with multiple repeated occurrences into individual records for each occurrence
             </summary>
             <returns>All events for the current academic year.</returns>
         </member>

--- a/Gordon360/Gordon360.csproj
+++ b/Gordon360/Gordon360.csproj
@@ -582,6 +582,8 @@
       <DependentUpon>CCT_DB_Models.tt</DependentUpon>
     </Compile>
     <Compile Include="Models\ViewModels\AcademicCheckInViewModel.cs" />
+    <Compile Include="Models\ViewModels\DEPRECATED_AttendedEventViewModel.cs" />
+    <Compile Include="Models\ViewModels\DEPRECATED_EventViewModel.cs" />
     <Compile Include="Models\ViewModels\EmergencyContactViewModel.cs" />
     <Compile Include="Models\ViewModels\MailboxViewModel.cs" />
     <Compile Include="Models\ViewModels\MessageSearchViewModel.cs" />

--- a/Gordon360/Models/ViewModels/AttendedEventViewModel.cs
+++ b/Gordon360/Models/ViewModels/AttendedEventViewModel.cs
@@ -13,7 +13,9 @@ namespace Gordon360.Models.ViewModels
         public string Event_Title { get; set; }
         public string Description { get; set; }
         public string Organization { get; set; }
-        public List<EventOccurence> Occurrences { get; set; }
+        public string StartDate { get; set; }
+        public string EndDate { get; set; }
+        public string Location { get; set; }
 
         // We're gonna take an eventviewmodel (info from 25Live) and a Chapeleventviewmodel (info form our database) 
         // then mash 'em together
@@ -31,7 +33,9 @@ namespace Gordon360.Models.ViewModels
                 Event_Title = a.Event_Title ?? "";
                 Description = a.Description ?? "";
                 Organization = a.Organization ?? "";
-                Occurrences = a.Occurrences ?? null;
+                StartDate = a.StartDate ?? "";
+                EndDate = a.EndDate ?? "";
+                Location = a.Location ?? "";
 
             }
             // If it's null, fill it with empty strings so we don't crash
@@ -41,7 +45,9 @@ namespace Gordon360.Models.ViewModels
                 Event_Title = "";
                 Description =  "";
                 Organization =  "";
-                Occurrences = null;
+                StartDate = "";
+                EndDate = "";
+                Location = "";
             }
  
         }

--- a/Gordon360/Models/ViewModels/DEPRECATED_AttendedEventViewModel.cs
+++ b/Gordon360/Models/ViewModels/DEPRECATED_AttendedEventViewModel.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Gordon360.Models.ViewModels
+{
+    public class DEPRECATED_AttendedEventViewModel
+    {
+        public string LiveID { get; set; }
+        public DateTime? CHDate { get; set; }
+        public string CHTermCD { get; set; }
+        public int? Required { get; set; }
+        public string Event_Name { get; set; }
+        public string Event_Title { get; set; }
+        public string Description { get; set; }
+        public string Organization { get; set; }
+        public List<EventOccurence> Occurrences { get; set; }
+
+        // We're gonna take an eventviewmodel (info from 25Live) and a Chapeleventviewmodel (info form our database) 
+        // then mash 'em together
+        public DEPRECATED_AttendedEventViewModel(DEPRECATED_EventViewModel a, ChapelEventViewModel b)
+        {
+            // First the EventViewModel
+            LiveID = b.LiveID;
+            CHDate = b.CHDate.Value.Add(b.CHTime.Value.TimeOfDay);
+            CHTermCD = b.CHTermCD.Trim();
+            Required = b.Required;
+            // Then the CHapelEventViewModel
+            if (a != null)
+            {
+                Event_Name = a.Event_Name ?? "";
+                Event_Title = a.Event_Title ?? "";
+                Description = a.Description ?? "";
+                Organization = a.Organization ?? "";
+                Occurrences = a.Occurrences ?? null;
+
+            }
+            // If it's null, fill it with empty strings so we don't crash
+            else
+            {
+                Event_Name = "";
+                Event_Title = "";
+                Description = "";
+                Organization = "";
+                Occurrences = null;
+            }
+
+        }
+    }
+
+
+}

--- a/Gordon360/Models/ViewModels/DEPRECATED_EventViewModel.cs
+++ b/Gordon360/Models/ViewModels/DEPRECATED_EventViewModel.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Xml.Linq;
+using System.Linq;
+
+
+namespace Gordon360.Models.ViewModels
+{
+
+    public class DEPRECATED_EventViewModel
+    {
+        // Class element declarations
+        public string Event_ID { get; set; }
+        public string Event_Name { get; set; }
+        public string Event_Title { get; set; }
+        public string Event_Type_Name { get; set; }
+        public bool HasCLAWCredit { get; set; }
+        public bool IsPublic { get; set; }
+        public string Description { get; set; }
+        public List<EventOccurence> Occurrences { get; set; }
+        public string Organization { get; set; }
+
+        // Set the namespace for X Paths
+        private readonly XNamespace r25 = "http://www.collegenet.com/r25";
+
+        // This view model contains pieces of info pulled from a JSon array which is pulled from 25Live, using a pre-defined function
+        public DEPRECATED_EventViewModel(XElement a)
+        {
+            Event_ID = a.Element(r25 + "event_id")?.Value;
+            Event_Name = a.Element(r25 + "event_name")?.Value;
+            Event_Title = a.Element(r25 + "event_title")?.Value;
+            Event_Type_Name = a.Element(r25 + "event_type_name")?.Value;
+            Description = a.Elements(r25 + "event_text")?.FirstOrDefault(t => t.Element(r25 + "text_type_id")?.Value == "1")?.Element(r25 + "text")?.Value;
+            Organization = a.Element(r25 + "organization")?.Element(r25 + "organization_name")?.Value;
+            HasCLAWCredit = a.Elements(r25 + "category")?.Any(c => c.Element(r25 + "category_id")?.Value == "85") ?? false;
+            IsPublic = a.Elements(r25 + "requirement")?.Any(r => r.Element(r25 + "requirement_id")?.Value == "3") ?? false;
+
+            Occurrences = a.Element(r25 + "profile")?.Descendants(r25 + "reservation").Select(o => new EventOccurence
+            {
+                StartDate = o.Element(r25 + "event_start_dt")?.Value,
+                EndDate = o.Element(r25 + "event_end_dt")?.Value,
+                Location = o.Element(r25 + "space_reservation")?.Element(r25 + "space")?.Element(r25 + "formal_name")?.Value
+            }).ToList();
+        }
+
+        /// <summary>
+        /// Initializes a new custom instance of the <see cref="DEPRECATED_EventViewModel"/> class.
+        /// </summary>
+        public DEPRECATED_EventViewModel(DEPRECATED_EventViewModel baseEvent, EventOccurence occurrence)
+        {
+            this.Event_ID = $"{baseEvent.Event_ID}_{occurrence.GetHashCode()}";
+            this.Event_Name = baseEvent.Event_Name;
+            this.Event_Title = baseEvent.Event_Title;
+            this.Event_Type_Name = baseEvent.Event_Type_Name;
+            this.Description = baseEvent.Description;
+            this.Organization = baseEvent.Organization;
+            this.IsPublic = baseEvent.IsPublic;
+            this.HasCLAWCredit = baseEvent.HasCLAWCredit;
+            this.Occurrences = new List<EventOccurence> { occurrence };
+        }
+    }
+
+
+    public class EventOccurence
+    {
+        public string StartDate { get; set; }
+        public string EndDate { get; set; }
+        public string Location { get; set; }
+    }
+
+}

--- a/Gordon360/Models/ViewModels/EventViewModel.cs
+++ b/Gordon360/Models/ViewModels/EventViewModel.cs
@@ -42,6 +42,10 @@ namespace Gordon360.Models.ViewModels
                 Location = o.Element(r25 + "space_reservation")?.Element(r25 + "space")?.Element(r25 + "formal_name")?.Value
             }).ToList();
         }
+
+        /// <summary>
+        /// Initializes a new custom instance of the <see cref="EventViewModel"/> class.
+        /// </summary>
         public EventViewModel(string Event_ID,string Event_Name,string Event_Title,string Event_Type_Name,string Description,string Organization,bool IsPublic,bool HasClawCredit,List<EventOccurence> Occurrences)
         {
             this.Event_ID = Event_ID;

--- a/Gordon360/Models/ViewModels/EventViewModel.cs
+++ b/Gordon360/Models/ViewModels/EventViewModel.cs
@@ -42,7 +42,20 @@ namespace Gordon360.Models.ViewModels
                 Location = o.Element(r25 + "space_reservation")?.Element(r25 + "space")?.Element(r25 + "formal_name")?.Value
             }).ToList();
         }
+        public EventViewModel(string Event_ID,string Event_Name,string Event_Title,string Event_Type_Name,string Description,string Organization,bool IsPublic,bool HasClawCredit,List<EventOccurence> Occurrences)
+        {
+            this.Event_ID = Event_ID;
+            this.Event_Name = Event_Name;
+            this.Event_Title = Event_Title;
+            this.Event_Type_Name = Event_Type_Name;
+            this.Description = Description;
+            this.Organization = Organization;
+            this.IsPublic = IsPublic;
+            this.HasCLAWCredit = HasCLAWCredit;
+            this.Occurrences = Occurrences;
+        }
     }
+
 
     public class EventOccurence
     {

--- a/Gordon360/Models/ViewModels/EventViewModel.cs
+++ b/Gordon360/Models/ViewModels/EventViewModel.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Xml.Linq;
+﻿using System.Xml.Linq;
 using System.Linq;
 
 
@@ -9,7 +7,6 @@ namespace Gordon360.Models.ViewModels
 
     public class EventViewModel
     {
-        // Class element declarations
         public string Event_ID { get; set; }
         public string Event_Name { get; set; }
         public string Event_Title { get; set; }
@@ -17,55 +14,30 @@ namespace Gordon360.Models.ViewModels
         public bool HasCLAWCredit { get; set; }
         public bool IsPublic { get; set; }
         public string Description { get; set; }
-        public List<EventOccurence> Occurrences { get; set; }
-        public string Organization { get; set; }
-
-        // Set the namespace for X Paths
-        private readonly XNamespace r25 = "http://www.collegenet.com/r25";
-
-        // This view model contains pieces of info pulled from a JSon array which is pulled from 25Live, using a pre-defined function
-        public EventViewModel(XElement a)
-        {
-            Event_ID = a.Element(r25 + "event_id")?.Value;
-            Event_Name = a.Element(r25 + "event_name")?.Value;
-            Event_Title = a.Element(r25 + "event_title")?.Value;
-            Event_Type_Name = a.Element(r25 + "event_type_name")?.Value;
-            Description = a.Elements(r25 + "event_text")?.FirstOrDefault(t => t.Element(r25 + "text_type_id")?.Value == "1")?.Element(r25 + "text")?.Value;
-            Organization = a.Element(r25 + "organization")?.Element(r25 + "organization_name")?.Value;
-            HasCLAWCredit = a.Elements(r25 + "category")?.Any(c => c.Element(r25 + "category_id")?.Value == "85") ?? false;
-            IsPublic = a.Elements(r25 + "requirement")?.Any(r => r.Element(r25 + "requirement_id")?.Value == "3") ?? false;
-
-            Occurrences = a.Element(r25 + "profile")?.Descendants(r25 + "reservation").Select(o => new EventOccurence
-            {
-                StartDate = o.Element(r25 + "event_start_dt")?.Value,
-                EndDate = o.Element(r25 + "event_end_dt")?.Value,
-                Location = o.Element(r25 + "space_reservation")?.Element(r25 + "space")?.Element(r25 + "formal_name")?.Value
-            }).ToList();
-        }
-
-        /// <summary>
-        /// Initializes a new custom instance of the <see cref="EventViewModel"/> class.
-        /// </summary>
-        public EventViewModel(string Event_ID,string Event_Name,string Event_Title,string Event_Type_Name,string Description,string Organization,bool IsPublic,bool HasClawCredit,List<EventOccurence> Occurrences)
-        {
-            this.Event_ID = Event_ID;
-            this.Event_Name = Event_Name;
-            this.Event_Title = Event_Title;
-            this.Event_Type_Name = Event_Type_Name;
-            this.Description = Description;
-            this.Organization = Organization;
-            this.IsPublic = IsPublic;
-            this.HasCLAWCredit = HasCLAWCredit;
-            this.Occurrences = Occurrences;
-        }
-    }
-
-
-    public class EventOccurence
-    {
         public string StartDate { get; set; }
         public string EndDate { get; set; }
         public string Location { get; set; }
+        public string Organization { get; set; }
+
+        // Set the namespace for X Paths
+        public static readonly XNamespace r25 = "http://www.collegenet.com/r25";
+
+        // This view model contains pieces of info pulled from a JSon array which is pulled from 25Live, using a pre-defined function
+        public EventViewModel(XElement eventDetails, XElement occurrenceDetails)
+        {
+            Event_ID = eventDetails.Element(r25 + "event_id")?.Value;
+            Event_Name = eventDetails.Element(r25 + "event_name")?.Value;
+            Event_Title = eventDetails.Element(r25 + "event_title")?.Value;
+            Event_Type_Name = eventDetails.Element(r25 + "event_type_name")?.Value;
+            Description = eventDetails.Elements(r25 + "event_text")?.FirstOrDefault(t => t.Element(r25 + "text_type_id")?.Value == "1")?.Element(r25 + "text")?.Value;
+            Organization = eventDetails.Element(r25 + "organization")?.Element(r25 + "organization_name")?.Value;
+            HasCLAWCredit = eventDetails.Elements(r25 + "category")?.Any(c => c.Element(r25 + "category_id")?.Value == "85") ?? false;
+            IsPublic = eventDetails.Elements(r25 + "requirement")?.Any(r => r.Element(r25 + "requirement_id")?.Value == "3") ?? false;
+            StartDate = occurrenceDetails.Element(r25 + "event_start_dt")?.Value;
+            EndDate = occurrenceDetails.Element(r25 + "event_end_dt")?.Value;
+            Location = occurrenceDetails.Element(r25 + "space_reservation")?.Element(r25 + "space")?.Element(r25 + "formal_name")?.Value;
+        }
+
     }
 
 }

--- a/Gordon360/Services/EventService.cs
+++ b/Gordon360/Services/EventService.cs
@@ -35,21 +35,18 @@ namespace Gordon360.Services
 
         /// <summary>
         /// Access the memory stream created by the cached task and parse it into events
+        /// Splits events with multiple repeated occurrences into individual records for each occurrence
         /// </summary>
         /// <returns>All events for the current academic year.</returns>
         public IEnumerable<EventViewModel> GetAllEvents()
         {
             var events = Data.AllEvents.Descendants(r25 + "event").Select(e => new EventViewModel(e));
-
             var multiple = events.Where(e => e.Occurrences.Count > 1);
-
             events = events.Where(e => e.Occurrences.Count == 1);
-
-            EventViewModel[] splitEvents = new EventViewModel[multiple.Select((e) => e.Occurrences.Count).Aggregate((last,current) => last + current)];
+            List<EventViewModel> splitEvents = new List<EventViewModel>();// (multiple.Select((e) => e.Occurrences.Count).Aggregate((last,current) => last + current)];
 
             int count = 0;
             int occurrenceIndex = 0;
-
             foreach (EventViewModel e in multiple)
             {
                 occurrenceIndex = 0;
@@ -57,13 +54,9 @@ namespace Gordon360.Services
                 {
                     List<EventOccurence> oneOccurrence = new List<EventOccurence>(1);
                     oneOccurrence.Add(e.Occurrences[occurrenceIndex++]);
-
-                    splitEvents[count++] = new EventViewModel(e.Event_ID + "_" + occurrenceIndex.ToString(),e.Event_Name,e.Event_Title,e.Event_Type_Name,e.Description,e.Organization,e.IsPublic,e.HasCLAWCredit,oneOccurrence);
+                    splitEvents.Add(new EventViewModel(e.Event_ID + "_" + occurrenceIndex.ToString(),e.Event_Name,e.Event_Title,e.Event_Type_Name,e.Description,e.Organization,e.IsPublic,e.HasCLAWCredit,oneOccurrence));
                 }
             }
-
-
-
             return events.Concat(splitEvents);
         }
 

--- a/Gordon360/Services/EventService.cs
+++ b/Gordon360/Services/EventService.cs
@@ -10,7 +10,6 @@ using Gordon360.Static.Data;
 using System.Xml.Linq;
 using System;
 
-
 // <summary>
 // We use this service to pull data from 25Live as well as parsing it
 // The data is retrieved from the cache maintained by Startup.cs
@@ -41,19 +40,28 @@ namespace Gordon360.Services
         public IEnumerable<EventViewModel> GetAllEvents()
         {
             var events = Data.AllEvents.Descendants(r25 + "event").Select(e => new EventViewModel(e));
+            
+            // Split events into thise with multiple occurrences and those with one
             var multiple = events.Where(e => e.Occurrences.Count > 1);
             events = events.Where(e => e.Occurrences.Count == 1);
-            List<EventViewModel> splitEvents = new List<EventViewModel>();// (multiple.Select((e) => e.Occurrences.Count).Aggregate((last,current) => last + current)];
-
+            
+            // Initialize loop variables
             int count = 0;
             int occurrenceIndex = 0;
+            List<EventViewModel> splitEvents = new List<EventViewModel>();
+            
+            // Loop over multiple-occurrence events
             foreach (EventViewModel e in multiple)
             {
                 occurrenceIndex = 0;
+                
+                // Loop over occurrences in one event
                 foreach (EventOccurence o in e.Occurrences)
                 {
                     List<EventOccurence> oneOccurrence = new List<EventOccurence>(1);
                     oneOccurrence.Add(e.Occurrences[occurrenceIndex++]);
+                    
+                    // Create a new event with information from the occurrence
                     splitEvents.Add(new EventViewModel(e.Event_ID + "_" + occurrenceIndex.ToString(),e.Event_Name,e.Event_Title,e.Event_Type_Name,e.Description,e.Organization,e.IsPublic,e.HasCLAWCredit,oneOccurrence));
                 }
             }
@@ -77,7 +85,6 @@ namespace Gordon360.Services
         {
             return GetAllEvents().Where(e => e.HasCLAWCredit);
         }
-
 
         /// <summary>
         /// Returns all attended events for a student in a specific term

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -40,6 +40,10 @@ namespace Gordon360.Services
         IEnumerable<EventViewModel> GetAllEvents();
         IEnumerable<EventViewModel> GetPublicEvents();
         IEnumerable<EventViewModel> GetCLAWEvents();
+        IEnumerable<DEPRECATED_AttendedEventViewModel> DEPRECATED_GetEventsForStudentByTerm(string id, string term);
+        IEnumerable<DEPRECATED_EventViewModel> DEPRECATED_GetAllEvents();
+        IEnumerable<DEPRECATED_EventViewModel> DEPRECATED_GetPublicEvents();
+        IEnumerable<DEPRECATED_EventViewModel> DEPRECATED_GetCLAWEvents();
     }
 
     public interface IDiningService


### PR DESCRIPTION
For years, the events page has been unable to process events that have repeated occurrences properly. It has only shown the first occurrence of the event and has disappeared when the event time is passed. This should not be the case since the events are still happening every week (or however frequent).

This API change takes the event records with multiple occurrences, loops over those event occurrences, and creates a new event record for each of them. It then merges them in with the non-multiple-occurrence events and returns them to the controller as well as other event functions.