### PR TITLE
Retrieve mailbox combos based on box number, not mailbox id

### DIFF
--- a/Gordon360/Services/ProfileService.cs
+++ b/Gordon360/Services/ProfileService.cs
@@ -71,21 +71,21 @@ namespace Gordon360.Services
         /// </summary>
         /// <param name="username">The current user's username</param>
         /// <returns>MailboxViewModel with the combination</returns>
-        public MailboxViewModel GetMailboxCombination(string username)
+        public string GetMailboxCombination(string username)
         {
             var mailboxNumber = 
                 Data.StudentData
                 .FirstOrDefault(x => x.AD_Username.ToLower() == username.ToLower())
                 .Mail_Location;
 
-            MailboxViewModel info = new MailboxViewModel();
+            var combo = _unitOfWork.MailboxRepository.FirstOrDefault(m => m.BoxNo == mailboxNumber).Combination;
 
-            if (mailboxNumber != null)
+            if (combo == null)
             {
-                info = _unitOfWork.MailboxRepository.GetById(mailboxNumber) ?? new Mailboxes();
+                throw new ResourceNotFoundException() { ExceptionMessage = "A combination was not found for the specified mailbox number." };
             }
 
-            return info;
+            return combo;
         }
 
         /// <summary>

--- a/Gordon360/Services/ProfileService.cs
+++ b/Gordon360/Services/ProfileService.cs
@@ -71,14 +71,14 @@ namespace Gordon360.Services
         /// </summary>
         /// <param name="username">The current user's username</param>
         /// <returns>MailboxViewModel with the combination</returns>
-        public string GetMailboxCombination(string username)
+        public MailboxViewModel GetMailboxCombination(string username)
         {
             var mailboxNumber = 
                 Data.StudentData
                 .FirstOrDefault(x => x.AD_Username.ToLower() == username.ToLower())
                 .Mail_Location;
 
-            var combo = _unitOfWork.MailboxRepository.FirstOrDefault(m => m.BoxNo == mailboxNumber).Combination;
+            MailboxViewModel combo = _unitOfWork.MailboxRepository.FirstOrDefault(m => m.BoxNo == mailboxNumber);
 
             if (combo == null)
             {

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -21,7 +21,7 @@ namespace Gordon360.Services
         StudentProfileViewModel GetStudentProfileByUsername(string username);
         FacultyStaffProfileViewModel GetFacultyStaffProfileByUsername(string username);
         AlumniProfileViewModel GetAlumniProfileByUsername(string username);
-        string GetMailboxCombination(string username);
+        MailboxViewModel GetMailboxCombination(string username);
         IEnumerable<AdvisorViewModel> GetAdvisors(string id);
         CliftonStrengthsViewModel GetCliftonStrengths(int id);
         IEnumerable<EmergencyContact> GetEmergencyContact(string username);

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -21,7 +21,7 @@ namespace Gordon360.Services
         StudentProfileViewModel GetStudentProfileByUsername(string username);
         FacultyStaffProfileViewModel GetFacultyStaffProfileByUsername(string username);
         AlumniProfileViewModel GetAlumniProfileByUsername(string username);
-        MailboxViewModel GetMailboxCombination(string username);
+        string GetMailboxCombination(string username);
         IEnumerable<AdvisorViewModel> GetAdvisors(string id);
         CliftonStrengthsViewModel GetCliftonStrengths(int id);
         IEnumerable<EmergencyContact> GetEmergencyContact(string username);


### PR DESCRIPTION
In theory, boxNo and boxId are nearly identical. However, there were errors based on the keys automatically defined by Entity Framework for the mailboxes view.