### PR TITLE
Add Endpoint for Person Type

### DIFF
--- a/Gordon360/ApiControllers/ProfilesController.cs
+++ b/Gordon360/ApiControllers/ProfilesController.cs
@@ -173,38 +173,13 @@ namespace Gordon360.Controllers.Api
             var alumni = _profileService.GetAlumniProfileByUsername(username);
 
 
-            // merge the person's info if this person is in multiple tables and return result 
-            if (student != null)
-            {
-                if (faculty != null)
-                {
-                    if (alumni != null)
-                    {
-                        return Ok("stualufac");
-                    }
-                    return Ok("stufac");
-                }
-                else if (alumni != null)
-                {
-                    return Ok("stualu");
-                }
-                return Ok("stu");
-            }
-            else if (faculty != null)
-            {
-                if (alumni != null)
-                {
-                    return Ok("alufac");
-                }
-                return Ok("fac");
-            }
-            else if (alumni != null)
-            {
-                return Ok("alu");
-            }
-            else
-            {
+            var stualufac =  (student != null ? "stu" : "")
+                + (alumni != null ? "alu" : "")
+                + (faculty != null ? "fac" : "");
+            if (stualufac == "") {
                 return NotFound();
+            } else {
+                return Ok(stualufac);
             }
         }
 

--- a/Gordon360/ApiControllers/ProfilesController.cs
+++ b/Gordon360/ApiControllers/ProfilesController.cs
@@ -157,6 +157,57 @@ namespace Gordon360.Controllers.Api
                 return NotFound();
             }
         }
+
+        /// <summary>Get person type of currently logged in user</summary>
+        /// <returns></returns>
+        [HttpGet]
+        [Route("persontype")]
+        public IHttpActionResult GetPersonType()
+        {
+            //get token data from context, username is the username of current logged in person
+            var authenticatedUser = this.ActionContext.RequestContext.Principal as ClaimsPrincipal;
+            var username = authenticatedUser.Claims.FirstOrDefault(x => x.Type == "user_name").Value;
+            // search username in cached data
+            var student = _profileService.GetStudentProfileByUsername(username);
+            var faculty = _profileService.GetFacultyStaffProfileByUsername(username);
+            var alumni = _profileService.GetAlumniProfileByUsername(username);
+
+
+            // merge the person's info if this person is in multiple tables and return result 
+            if (student != null)
+            {
+                if (faculty != null)
+                {
+                    if (alumni != null)
+                    {
+                        return Ok("stualufac");
+                    }
+                    return Ok("stufac");
+                }
+                else if (alumni != null)
+                {
+                    return Ok("stualu");
+                }
+                return Ok("stu");
+            }
+            else if (faculty != null)
+            {
+                if (alumni != null)
+                {
+                    return Ok("alufac");
+                }
+                return Ok("fac");
+            }
+            else if (alumni != null)
+            {
+                return Ok("alu");
+            }
+            else
+            {
+                return NotFound();
+            }
+        }
+
         /// <summary>Get public profile info for a user</summary>
         /// <param name="username">username of the profile info</param>
         /// <returns></returns>

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -337,6 +337,10 @@
             <summary>Get profile info of currently logged in user</summary>
             <returns></returns>
         </member>
+        <member name="M:Gordon360.Controllers.Api.ProfilesController.GetPersonType">
+            <summary>Get person type of currently logged in user</summary>
+            <returns></returns>
+        </member>
         <member name="M:Gordon360.Controllers.Api.ProfilesController.GetUserProfile(System.String)">
             <summary>Get public profile info for a user</summary>
             <param name="username">username of the profile info</param>


### PR DESCRIPTION
In the UI, in order to get the currently logged-in user's person type, you need to request their entire profile. This coupling is inefficient and collects a lot of unneeded data.

This pull request adds an endpoint (/profiles/persontype) that allows the UI to get just the person type.