### PR TITLE
Limit which FacStaff can view student schedules

### DIFF
--- a/Gordon360/ApiControllers/ScheduleController.cs
+++ b/Gordon360/ApiControllers/ScheduleController.cs
@@ -130,7 +130,10 @@ namespace Gordon360.Controllers.Api
                         }
                         break;
                     case Position.FACSTAFF:
-                        scheduleResult = _scheduleService.GetScheduleStudent(id);
+                        if (_scheduleService.CanReadStudentSchedules(viewerName))
+                        {
+                            scheduleResult = _scheduleService.GetScheduleStudent(id);
+                        }
                         break;
                 }
             }
@@ -154,6 +157,20 @@ namespace Gordon360.Controllers.Api
             }
 
             return Ok(result);
+        }
+
+        /// <summary>
+        /// Get whether the currently logged-in user can read student schedules
+        /// </summary>
+        /// <returns>Whether they can read student schedules</returns>
+        [HttpGet]
+        [Route("canreadstudent")]
+        public IHttpActionResult GetCanReadStudentSchedules()
+        {
+            var authenticatedUser = this.ActionContext.RequestContext.Principal as ClaimsPrincipal;
+            var username = authenticatedUser.Claims.FirstOrDefault(x => x.Type == "user_name").Value;
+
+            return Ok(_scheduleService.CanReadStudentSchedules(username));
         }
     }
 }

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -430,6 +430,12 @@
             </summary>
             <returns>A IEnumerable of schedule objects</returns>
         </member>
+        <member name="M:Gordon360.Controllers.Api.ScheduleController.GetCanReadStudentSchedules">
+            <summary>
+            Get whether the currently logged-in user can read student schedules
+            </summary>
+            <returns>Whether they can read student schedules</returns>
+        </member>
         <member name="T:Gordon360.Controllers.Api.VersionController">
             <summary>
             Get the short git SHA-1 and build date for the backend
@@ -1667,7 +1673,7 @@
             <summary>
             Helper class to execute Sql statements.
             </summary>
-            <typeparam name="T">The class to which the result will be bound</typeparam>
+            <typeparam name="T">The type to which the result will be bound</typeparam>
         </member>
         <member name="M:Gordon360.Services.ComplexQueries.RawSqlQuery`1.query(System.String,System.Object[])">
             <summary>
@@ -2106,6 +2112,13 @@
             </summary>
             <param name="id">The id of the instructor</param>
             <returns>StudentScheduleViewModel if found, null if not found</returns>
+        </member>
+        <member name="M:Gordon360.Services.ScheduleService.CanReadStudentSchedules(System.String)">
+            <summary>
+            Determine whether the specified user can read student schedules, based on the logic in the stored procedure
+            </summary>
+            <param name="username">The username to determine it for</param>
+            <returns>Whether the specified user can read student schedules</returns>
         </member>
         <member name="M:Gordon360.Services.StudentEmploymentService.GetEmployment(System.String)">
             <summary>

--- a/Gordon360/Services/ComplexQueries/RawSqlQuery.cs
+++ b/Gordon360/Services/ComplexQueries/RawSqlQuery.cs
@@ -9,8 +9,8 @@ namespace Gordon360.Services.ComplexQueries
     /// <summary>
     /// Helper class to execute Sql statements.
     /// </summary>
-    /// <typeparam name="T">The class to which the result will be bound</typeparam>
-    public static class RawSqlQuery<T> where T: class
+    /// <typeparam name="T">The type to which the result will be bound</typeparam>
+    public static class RawSqlQuery<T>
     {
         /// <summary>
         /// Execute the sql query

--- a/Gordon360/Services/ScheduleService.cs
+++ b/Gordon360/Services/ScheduleService.cs
@@ -40,22 +40,12 @@ namespace Gordon360.Services
                 throw new ResourceNotFoundException() { ExceptionMessage = "The Schedule was not found." };
             }
 
-
             var currentSessionCode = Helpers.GetCurrentSession().SessionCode;
-
-            // This is a test code for 2019 Summer. Next time you see this, delete this part
-            if (currentSessionCode == "201905" && id != "999999097")
-            {
-                currentSessionCode = "201909";
-            }
-
-
 
             var idInt = Int32.Parse(id);
             var idParam = new SqlParameter("@stu_num", idInt);
             var sessParam = new SqlParameter("@sess_cde", currentSessionCode);
             var result = RawSqlQuery<ScheduleViewModel>.query("STUDENT_COURSES_BY_ID_NUM_AND_SESS_CDE @stu_num, @sess_cde", idParam, sessParam);
-            //var result = RawSqlQuery<ScheduleViewModel>.query("SELECT STUDENT_ID as ID_NUM, CRS_CDE, CRS_TITLE, BLDG_CDE, ROOM_CDE, MONDAY_CDE, TUESDAY_CDE, WEDNESDAY_CDE, THURSDAY_CDE, FRIDAY_CDE, BEGIN_TIME, END_TIME FROM TmsEPrd.dbo.GORD_CCT_COURSES WHERE yr_cde = 18 and trm_cde = 'SP' and Student_ID = 50153273");
             if (result == null)
             {
                 return null;
@@ -97,6 +87,18 @@ namespace Gordon360.Services
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Determine whether the specified user can read student schedules, based on the logic in the stored procedure
+        /// </summary>
+        /// <param name="username">The username to determine it for</param>
+        /// <returns>Whether the specified user can read student schedules</returns>
+        public bool CanReadStudentSchedules(string username)
+        {
+            var usernameParam = new SqlParameter("@username", username);
+
+            return RawSqlQuery<int>.query("CAN_READ_STUDENT_SCHEDULES @username", usernameParam).FirstOrDefault() == 1;
         }
     }
 }

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -231,6 +231,7 @@ namespace Gordon360.Services
     {
         IEnumerable<ScheduleViewModel> GetScheduleStudent(string id);
         IEnumerable<ScheduleViewModel> GetScheduleFaculty(string id);
+        bool CanReadStudentSchedules(string username);
     }
 
     public interface IScheduleControlService


### PR DESCRIPTION
Only Faculty members and a select subset of Staff should be allowed to view student schedules. A New DB stored procedure has been created that authorizes only those people, `CAN_READ_STUDENT_SCHEDULES`. This PR uses the new stored procedure to enforce that limitation on  the `ScheduleController.Get(username)` route.

It also adds a service method and route for determining whether a user can read student schedules (limited to faculty and staff-advisors based on AD groups). That way, the front-end knows whether to try and display such info.