### PR TITLE
Refactored: emailService code with membershipService code

### DIFF
--- a/Gordon360/Models/ViewModels/EmailViewModel.cs
+++ b/Gordon360/Models/ViewModels/EmailViewModel.cs
@@ -10,5 +10,6 @@ namespace Gordon360.Models.ViewModels
         public string FirstName { get; set; }  
         public string LastName { get; set; }
         public string Email { get; set; }
+        public string Description = "";
     }
 }


### PR DESCRIPTION
This is a draft so far because the API is still not working.  cannot do any testing to ensure the code works correctly, but I think it should work in theory.

This PR is intended to add:

- custom description or default description (title) next to advisors' and leaders' full names in the involvement profile by returning the description value using EmailViewModel.