### PR TITLE
Make wellness notes SYMPTOMATIC when reporting symptoms

### DIFF
--- a/Gordon360/Services/WellnessService.cs
+++ b/Gordon360/Services/WellnessService.cs
@@ -83,7 +83,7 @@ namespace Gordon360.Services
                 Created = now,
                 Expires = ExpirationDate(now),
                 CreatedBy = "360.WellnessCheck",
-                Notes = status == WellnessStatusColor.YELLOW ? $"STATUS: {status};" : null,
+                Notes = status == WellnessStatusColor.YELLOW ? $"STATUS: Symptomatic;" : null,
                 Emailed = null
             };
 

--- a/Gordon360/Services/WellnessService.cs
+++ b/Gordon360/Services/WellnessService.cs
@@ -83,6 +83,7 @@ namespace Gordon360.Services
                 Created = now,
                 Expires = ExpirationDate(now),
                 CreatedBy = "360.WellnessCheck",
+                Notes = status == WellnessStatusColor.YELLOW ? $"STATUS: {status};" : null,
                 Emailed = null
             };
 


### PR DESCRIPTION
Per CTS Ticket #144036, the Covid-19 Team requests that when someone reports symptoms (i.e. posts a YELLOW status) to 360, they should appear as SYMPTOMATIC on our reporting services. This is accomplished via a special syntax in the notes field: "STATUS: `[Some special status]`;", in this case "STATUS: SYMPTOMATIC;". This will cause them to appear in our reporting systems as Symptomatic rather than just Yellow.