### PR TITLE
Add StatusDescription to wellness statuses.

### DIFF
--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -1948,9 +1948,9 @@
         </member>
         <member name="M:Gordon360.Services.ProfileService.GetBirthdate(System.String)">
             <summary>
-            get the current user's birthday
+            get a user's birthday
             </summary>
-            <param name="username">The current user's username</param>
+            <param name="username">The username of the person to get the birthdate of</param>
             <returns>Date the user's date of birth</returns>
         </member>
         <member name="M:Gordon360.Services.ProfileService.GetAdvisors(System.String)">

--- a/Gordon360/Models/ViewModels/WellnessViewModel.cs
+++ b/Gordon360/Models/ViewModels/WellnessViewModel.cs
@@ -12,5 +12,7 @@ namespace Gordon360.Models.ViewModels
         public DateTime Created { get; set; }
 
         public bool IsValid { get; set; }
+
+        public string StatusDescription {  get; set; }
     }
 }

--- a/Gordon360/Services/WellnessService.cs
+++ b/Gordon360/Services/WellnessService.cs
@@ -54,7 +54,8 @@ namespace Gordon360.Services
                 {
                     Status = ((WellnessStatusColor)result.HealthStatusID).ToString(),
                     Created = result.Created,
-                    IsValid = result.Expires == null || DateTime.Now < result.Expires
+                    IsValid = result.Expires == null || DateTime.Now < result.Expires,
+                    StatusDescription = result.Notes?.StartsWith("STATUS: ") ?? false ? result.Notes.Substring(8, result.Notes.IndexOf(";") - 8) : null
                 };
             }
         }


### PR DESCRIPTION
Wellness statuses can have a custom StatusDescription in their notes, which takes the form of `Status: [StatusDescription; Some other notes`.

The notes field is used by health administrators to manage people's wellness, and it should generally not be shown to users. However, when there is a custom status description nested between `STATUS: ` and `;`, that should be shown to the user as it explains why they are in their current color status (e.g. "Missing testing form" or "Symptomatic").

This PR adds a `StatusDescription` field property to the `WellnessViewModel` that exposes the custom status description if it exists.