### PR TITLE
Make 360.studenttest college role 'Student'

### DIFF
--- a/Gordon360/AuthorizationServer/TokenIssuer.cs
+++ b/Gordon360/AuthorizationServer/TokenIssuer.cs
@@ -105,7 +105,7 @@ namespace Gordon360.AuthorizationServer
                         {
                             collegeRole = Position.READONLY;
                         }
-                        else if(distinguishedName.Contains("OU=Students"))
+                        else if(distinguishedName.Contains("OU=Students") || username.ToLower() == "360.studenttest")
                         {
                             collegeRole = Position.STUDENT;
                         }


### PR DESCRIPTION
360.studenttest has historically defaulted to the college role of Faculty/Staff because it is not in the Students OU in Active Directory. This commit updates the Token Issuer to make an exception for specifically 360.studenttest so that it is marked as a student type.

Note that college_role is distinct from PersonType. While PersonType is based on data in the database, college_role is unique to 360 and decided at login and stored in the authentication token. It is rarely used on the front end, but is used extensively in the API.