### PR TITLE
Use Windows 2019 for .NET Framework 4.6.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
     ci:
-        runs-on: windows-latest
+        runs-on: windows-2019
 
         steps:
             - uses: actions/checkout@v2


### PR DESCRIPTION
Our CI has been using the `windows-latest` build in GitHub Actions. GitHub recently switched their actions runners from Windows 2019 to Windows 2022, and Visual Studio 2022. In the process, they somehow made it impossible to install .NET Framework. 4.6.1 on the runner. Using windows-2019 is the recommended temporary work-around. In the long-term, we should update to .NET 6