### PR TITLE
Fix Age calculation in Housing points distribution.

### DIFF
--- a/Gordon360/Models/ViewModels/ApartmentApplicantViewModel.cs
+++ b/Gordon360/Models/ViewModels/ApartmentApplicantViewModel.cs
@@ -24,7 +24,8 @@ namespace Gordon360.Models.ViewModels
                 if (BirthDate.HasValue)
                 {
                     DateTime nextSemester = new DateTime(DateTime.Today.Year, 9, 1); //The next semester is fall of the current year, since apartment applications are only in the spring
-                    return nextSemester.Year - BirthDate.Value.Year; // This age is meant to be approximate, so no need for leap-year compensation or an exact 'nextSemester' date
+                    var age = nextSemester.Year - BirthDate.Value.Year; // This age is meant to be approximate, so no need for leap-year compensation or an exact 'nextSemester' date
+                    return (BirthDate.Value.Date > nextSemester.AddYears(-age)) ? age - 1 : age; // If birth date is after the start of next semester, they are one year younger.
                 }
                 else { return null; }
             }


### PR DESCRIPTION
The Age calculation in the ApartmentApplicantViewModel was incorrect. Age was calculated as `currentYear - birthYear`, which works part of the time. For example, someone born in 2000 would be 22 in 2022, so 2022-2000 makes intuitive sense. However, that formula assumes that a person's age is constant throughout the year, but the typical Western reckoning of age is that you become a year older on your birthday. Thus, until your birthday, you are still the same age as the previous year.

Since Apartment Applicant age is reckoned relative to the beginning of the fall semester following the application period (i.e. approximately September 1st of the same year), the above formula would not work for anyone who turns 23 the year that they apply if their birthday is after September 1st.

The solution is to simply check whether their birthday is later than September 1st and reduce their calculated age by 1 if so.