### PR TITLE
Save banners with correct image URL instead of local file path

### DIFF
--- a/Gordon360/ApiControllers/ContentManagementController.cs
+++ b/Gordon360/ApiControllers/ContentManagementController.cs
@@ -71,7 +71,8 @@ namespace Gordon360.Controllers.Api
         [StateYourBusiness(operation = Operation.ADD, resource = Resource.SLIDER)]
         public IHttpActionResult PostBannerSlide(BannerSlidePostViewModel slide)
         {
-            var result = _contentManagementService.AddBannerSlide(slide);
+            var serverURL = Url.Content("~/");
+            var result = _contentManagementService.AddBannerSlide(slide, serverURL);
             if (result == null)
             {
                 return NotFound();

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -1733,7 +1733,7 @@
             </summary>
             <returns>An IEnumerable of the slides in the database</returns>
         </member>
-        <member name="M:Gordon360.Services.ContentManagementService.AddBannerSlide(Gordon360.Models.ViewModels.BannerSlidePostViewModel)">
+        <member name="M:Gordon360.Services.ContentManagementService.AddBannerSlide(Gordon360.Models.ViewModels.BannerSlidePostViewModel,System.String)">
             <summary>
             Inserts a banner slide in the database and uploads the image to the local slider folder
             </summary>

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -268,7 +268,7 @@ namespace Gordon360.Services
     {
         IEnumerable<SliderViewModel> DEPRECATED_GetSliderContent();
         IEnumerable<Slider_Images> GetBannerSlides();
-        Slider_Images AddBannerSlide(BannerSlidePostViewModel slide);
+        Slider_Images AddBannerSlide(BannerSlidePostViewModel slide, string serverURL);
         Slider_Images DeleteBannerSlide(int slideID);
     }
 


### PR DESCRIPTION
When a banner is submitted to the API, it is stored in the API's local file path and the URL that it can be fetched from is stored in the database. However, we were storing the local filepath (e.g. `F:\\Sites\\360apitrain.gordon.edu\\browseable\\slider\\image.jpeg`) in the database instead of the web URL that the file can be retrieved from via HTTP (e.g `https://360apitrain.gordon.edu/browseable/slider/image.jpeg`).

Thus when the banners were loaded on the frontend, the browser would try to get the image from the local files instead of the web, which didn't work (both because the image didn't exist in the local file system and because browsers aren't allowed to access the local file system by default).

Now, we properly store the URL of the image in the database after uploading it to the local filesystem of the API.