### PR TITLE
Allow alumni to login, fix authentication issues

### DIFF
--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -1738,6 +1738,10 @@
             Inserts a banner slide in the database and uploads the image to the local slider folder
             </summary>
             <param name="slide">The slide to add</param>
+            <param name="serverURL">The url of the server that the image is being posted to.
+            This is needed to save the image path into the database. The URL is different depending on where the API is running.
+            The URL is trivial to access from the controller, but not available from within the service, so it has to be passed in.
+            </param>
             <returns>The inserted slide</returns>
         </member>
         <member name="M:Gordon360.Services.ContentManagementService.DeleteBannerSlide(System.Int32)">

--- a/Gordon360/Static Classes/Names.cs
+++ b/Gordon360/Static Classes/Names.cs
@@ -70,6 +70,7 @@ namespace Gordon360.Static.Names
         public const string SUPERADMIN = "god";      // TODO: change in database to something more reverent
         public const string POLICE = "gordon police";
         public const string READONLY = "readonly";
+        public const string DEFAULT = "default";
     }
 
     public static class Activity_Roles


### PR DESCRIPTION
Previously, alumni have not been able to login. This was not an intentional design choice, but rather a bug relating to the organization of our Active Directory instance. While all student and facstaff accounts exist within the Gordon College organizational unit in AD, the Alumni OU does not. It is a sibling to the Gordon College OU. Our LDAP Authentication searched within the Gordon College OU for accounts, so it never found Alumni accounts.

This change addresses that issue by searching the entire Gordon domain for accounts. This has an unfortunate side effect that any user account within the gordon domain will be able to authenticate. However, because we require logged-in users to have a valid Gordon ID and profile info, this will exclude most accounts that we don't want using 360.

Furthermore, I have restructured how the `college_role` identity claim is assigned. This was because the alumni role was never assigned. Now, anyone in the `Alumni` OU will receive the alumni role.

Previously, `college_role` defaulted to FacStaff if no other special case was hit. That is very insecure. Instead, it now defaults to the `default` college_role, which is brand new and has no privileges at all. Since we use `college_role` for authorization in the API, this will prevent accounts from accessing data they shouldn't be able to.