### PR TITLE
Read allowed origins from config for CORS

### DIFF
--- a/Gordon360/Program.cs
+++ b/Gordon360/Program.cs
@@ -25,9 +25,10 @@ builder.Services.AddControllers(options =>
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
-builder.Services.AddCors(p => p.AddPolicy(name: "localhost", builder =>
+string corsPolicy = "360UI";
+builder.Services.AddCors(p => p.AddPolicy(name: corsPolicy, corsBuilder =>
 {
-    builder.WithOrigins("http://localhost:3000").AllowAnyMethod().AllowAnyHeader();
+    corsBuilder.WithOrigins(builder.Configuration.GetValue<string>("AllowedOrigin")).AllowAnyMethod().AllowAnyHeader();
 }));
 
 builder.Services.AddDbContext<CCTContext>(options =>
@@ -58,7 +59,7 @@ app.UseRouting();
 app.UseAuthentication();
 app.UseAuthorization();
 
-app.UseCors("localhost");
+app.UseCors(corsPolicy);
 
 app.MapControllers();
 

--- a/Gordon360/appsettings.json
+++ b/Gordon360/appsettings.json
@@ -1,17 +1,21 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
-    }
-  },
   "AllowedHosts": "localhost;360.gordon.edu",
+  "AllowedOrigin":  "<Default>",
   "AzureAd": {
     "Instance": "<Default>",
     "ClientId": "<Default>",
     "TenantId": "<Default>",
     "Audience": "<Default>"
+  },
+  "BonAppetit": {
+    "IssuerID": "<Default>",
+    "ApplicationID": "<Default>",
+    "Secret": "<Default>"
+  },
+  "ConnectionStrings": {
+    "CCT": "<Default>",
+    "MyGordon": "<Default>",
+    "StudentTimesheets": "<Default>"
   },
   "DEFAULT_ACTIVITY_IMAGE_PATH": "<Default>",
   "DEFAULT_PROFILE_IMAGE_PATH": "<Default>",
@@ -19,14 +23,12 @@
   "DEFAULT_IMAGE_PATH": "<Default>",
   "DEFAULT_ID_SUBMISSION_PATH": "<Default>",
   "DATABASE_IMAGE_PATH": "<Default>",
-  "ConnectionStrings": {
-    "CCT": "<Default>",
-    "MyGordon": "<Default>",
-    "StudentTimesheets": "<Default>"
-  },
-  "BonAppetit": {
-    "IssuerID": "<Default>",
-    "ApplicationID": "<Default>",
-    "Secret":  "<Default>"
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
   }
+
 }


### PR DESCRIPTION
Allowed origins was hard-coded in our CORS settings to `http://localhost:3000`. This is problematic because we don't want the deployed APIs to accept cross-origin requests from a user's `localhost` (to mitigate certain kinds of cross-site scripting attacks). Furthermore, the origins we do want to allow via CORS depend on the deployment environment, hence they are now read from configuration files. The structure of the configuration files has been updated to contain this value, and also put in alphabetical order.