### PR TITLE
Ignore Secrets.config File by Adding to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -270,3 +270,4 @@ paket-files/
 
 # Environment Specific app settings
 appsettings.*.json
+secrets.config


### PR DESCRIPTION
The file is going to continue to be tracked in developer's repositories if we do not add it to the .gitignore file.

We obviously do not want our private secrets to be uploaded to the public repo.