### PR TITLE
Refactor AuthGroup to enum and unify namespace

### DIFF
--- a/Gordon360/Authorization/AuthGroup.cs
+++ b/Gordon360/Authorization/AuthGroup.cs
@@ -1,0 +1,34 @@
+﻿namespace Gordon360.Authorization
+{
+    public enum AuthGroup
+    {
+        Advisors,
+        Alumni,
+        FacStaff,
+        Faculty,
+        HousingAdmin,
+        NewsAdmin,
+        Police,
+        SiteAdmin,
+        Staff,
+        Student
+    }
+
+    public static class AuthGroupEnum
+    {
+        public static AuthGroup? FromString(string groupName) => groupName switch
+        {
+            "360-Advisors-SG" => AuthGroup.Advisors,
+            "360-Alumni-SG" => AuthGroup.Alumni,
+            "360-FacStaff-SG" => AuthGroup.FacStaff,
+            "360-Faculty-SG" => AuthGroup.Faculty,
+            "360-HousingAdmin-SG" => AuthGroup.HousingAdmin,
+            "360-NewsAdmin-SG" => AuthGroup.NewsAdmin,
+            "360-Police-SG" => AuthGroup.Police,
+            "360-SiteAdmin-SG" => AuthGroup.SiteAdmin,
+            "360-Staff-SG" => AuthGroup.Staff,
+            "360-Student-SG" => AuthGroup.Student,
+            _ => null
+        };
+    }
+}

--- a/Gordon360/Authorization/AuthUtils.cs
+++ b/Gordon360/Authorization/AuthUtils.cs
@@ -1,11 +1,9 @@
-﻿using Gordon360.Static.Names;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.DirectoryServices.AccountManagement;
 using System.Linq;
 using System.Security.Claims;
 
-namespace Gordon360.Utilities
+namespace Gordon360.Authorization
 {
     public class AuthUtils
     {
@@ -21,29 +19,33 @@ namespace Gordon360.Utilities
             return User.FindFirstValue(ClaimTypes.Upn).Split("@")[0];
         }
 
-        public static IEnumerable<string> GetGroups(ClaimsPrincipal User)
+        public static IEnumerable<AuthGroup> GetGroups(ClaimsPrincipal User)
         {
-            return User.Claims.Where(x => x.Type == "groups").Select(g => g.Value);
+            return User.Claims
+                .Where(x => x.Type == "groups")
+                .Select(g => AuthGroupEnum.FromString(g.Value))
+                .OfType<AuthGroup>();
         }
 
         public static bool UserIsInGroup(ClaimsPrincipal User, AuthGroup group)
         {
-            return GetGroups(User).Contains(group.Name);
+            return GetGroups(User).Contains(group);
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "Program only runs on Windows")]
-        public static IEnumerable<string> GetGroups(string userName)
+        public static IEnumerable<AuthGroup> GetGroups(string userName)
         {
             UserPrincipal user = UserPrincipal.FindByIdentity(Context, userName);
 
             if (user == null)
             {
-                return Enumerable.Empty<string>();
+                return Enumerable.Empty<AuthGroup>();
             }
 
             return user.GetAuthorizationGroups()
-                .Where(g => g is GroupPrincipal)
-                .Select(g => g.SamAccountName);
+                               .Where(g => g is GroupPrincipal)
+                               .Select(g => AuthGroupEnum.FromString(g.SamAccountName))
+                               .OfType<AuthGroup>();
         }
     }
 }

--- a/Gordon360/Authorization/StateYourBusiness.cs
+++ b/Gordon360/Authorization/StateYourBusiness.cs
@@ -13,7 +13,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace Gordon360.AuthorizationFilters
+namespace Gordon360.Authorization
 {
     /* Authorization Filter.
      * It is actually an action filter masquerading as an authorization filter. This is because I need access to the 
@@ -42,7 +42,7 @@ namespace Gordon360.AuthorizationFilters
         private MyGordonContext _MyGordonContext;
 
         // User position at the college and their id.
-        private IEnumerable<string> user_groups { get; set; }
+        private IEnumerable<AuthGroup> user_groups { get; set; }
         private string user_id { get; set; }
         private string user_name { get; set; }
 
@@ -59,7 +59,7 @@ namespace Gordon360.AuthorizationFilters
             user_groups = AuthUtils.GetGroups(authenticatedUser);
             user_id = new AccountService(_CCTContext).GetAccountByUsername(user_name).GordonID;
 
-            if (user_groups.Contains(AuthGroup.SiteAdmin.Name))
+            if (user_groups.Contains(AuthGroup.SiteAdmin))
             {
                 await next();
                 return;
@@ -97,7 +97,7 @@ namespace Gordon360.AuthorizationFilters
         private async Task<bool> CanDenyAllowAsync(string resource)
         {
             // User is admin
-            if (user_groups.Contains(AuthGroup.SiteAdmin.Name))
+            if (user_groups.Contains(AuthGroup.SiteAdmin))
                 return true;
 
             switch (resource)
@@ -129,7 +129,7 @@ namespace Gordon360.AuthorizationFilters
         private async Task<bool> CanReadOneAsync(string resource)
         {
             // User is admin
-            if (user_groups.Contains(AuthGroup.SiteAdmin.Name))
+            if (user_groups.Contains(AuthGroup.SiteAdmin))
                 return true;
 
             switch (resource)
@@ -137,7 +137,7 @@ namespace Gordon360.AuthorizationFilters
                 case Resource.PROFILE:
                     return true;
                 case Resource.EMERGENCY_CONTACT:
-                    if (user_groups.Contains(AuthGroup.Police.Name))
+                    if (user_groups.Contains(AuthGroup.Police))
                         return true;
                     else
                     {
@@ -186,8 +186,8 @@ namespace Gordon360.AuthorizationFilters
                             return true;
 
                         // faculty and police can access student account information
-                        if (user_groups.Contains(AuthGroup.FacStaff.Name)
-                            || user_groups.Contains(AuthGroup.Police.Name))
+                        if (user_groups.Contains(AuthGroup.FacStaff)
+                            || user_groups.Contains(AuthGroup.Police))
                             return true;
 
                         return false;
@@ -215,7 +215,7 @@ namespace Gordon360.AuthorizationFilters
         private async Task<bool> CanReadPartialAsync(string resource)
         {
             // User is admin
-            if (user_groups.Contains(AuthGroup.SiteAdmin.Name))
+            if (user_groups.Contains(AuthGroup.SiteAdmin))
                 return true;
 
             switch (resource)
@@ -315,45 +315,45 @@ namespace Gordon360.AuthorizationFilters
             {
                 case Resource.MEMBERSHIP:
                     // User is admin
-                    if (user_groups.Contains(AuthGroup.SiteAdmin.Name))
+                    if (user_groups.Contains(AuthGroup.SiteAdmin))
                         return true;
                     else
                         return false;
                 case Resource.ChapelEvent:
                     // User is admin
-                    if (user_groups.Contains(AuthGroup.SiteAdmin.Name))
+                    if (user_groups.Contains(AuthGroup.SiteAdmin))
                         return true;
                     else
                         return false;
                 case Resource.EVENTS_BY_STUDENT_ID:
                     // User is admin
-                    if (user_groups.Contains(AuthGroup.SiteAdmin.Name))
+                    if (user_groups.Contains(AuthGroup.SiteAdmin))
                         return true;
                     else
                         return false;
 
                 case Resource.MEMBERSHIP_REQUEST:
                     // User is admin
-                    if (user_groups.Contains(AuthGroup.SiteAdmin.Name))
+                    if (user_groups.Contains(AuthGroup.SiteAdmin))
                         return true;
                     else
                         return false;
                 case Resource.STUDENT:
                     // User is admin
-                    if (user_groups.Contains(AuthGroup.SiteAdmin.Name))
+                    if (user_groups.Contains(AuthGroup.SiteAdmin))
                         return true;
                     else
                         return false; // See reasons for this in CanReadOne(). No one (except for super admin) should be able to access student records through
                                       // our API.
                 case Resource.ADVISOR:
                     // User is admin
-                    if (user_groups.Contains(AuthGroup.SiteAdmin.Name))
+                    if (user_groups.Contains(AuthGroup.SiteAdmin))
                         return true;
                     else
                         return false;
                 case Resource.GROUP_ADMIN:
                     // User is site-wide admin
-                    if (user_groups.Contains(AuthGroup.SiteAdmin.Name))
+                    if (user_groups.Contains(AuthGroup.SiteAdmin))
                         return true;
                     else
                         return false;
@@ -365,7 +365,7 @@ namespace Gordon360.AuthorizationFilters
                     {
                         // Only the housing admin and super admin can read all of the received applications.
                         // Super admin has unrestricted access by default, so no need to check.
-                        if (user_groups.Contains(AuthGroup.HousingAdmin.Name))
+                        if (user_groups.Contains(AuthGroup.HousingAdmin))
                         {
                             return true;
                         }
@@ -395,7 +395,7 @@ namespace Gordon360.AuthorizationFilters
             {
                 case Resource.SHIFT:
                     {
-                        if (user_groups.Contains(AuthGroup.Student.Name))
+                        if (user_groups.Contains(AuthGroup.Student))
                             return true;
                         return false;
                     }
@@ -403,7 +403,7 @@ namespace Gordon360.AuthorizationFilters
                 case Resource.MEMBERSHIP:
                     {
                         // User is admin
-                        if (user_groups.Contains(AuthGroup.SiteAdmin.Name))
+                        if (user_groups.Contains(AuthGroup.SiteAdmin))
                             return true;
                         var membershipToConsider = (MEMBERSHIP)context.ActionArguments["membership"];
                         // A membership can always be added if it is of type "GUEST"
@@ -423,7 +423,7 @@ namespace Gordon360.AuthorizationFilters
                 case Resource.MEMBERSHIP_REQUEST:
                     {
                         // User is admin
-                        if (user_groups.Contains(AuthGroup.SiteAdmin.Name))
+                        if (user_groups.Contains(AuthGroup.SiteAdmin))
                             return true;
                         var membershipRequestToConsider = (REQUEST)context.ActionArguments["membershipRequest"];
                         // A membership request belonging to the currently logged in student
@@ -437,7 +437,7 @@ namespace Gordon360.AuthorizationFilters
                     return false; // No one should be able to add students through this API
                 case Resource.ADVISOR:
                     // User is admin
-                    if (user_groups.Contains(AuthGroup.SiteAdmin.Name))
+                    if (user_groups.Contains(AuthGroup.SiteAdmin))
                         return true;
                     else
                         return false; // Only super admin can add Advisors through this API
@@ -447,7 +447,7 @@ namespace Gordon360.AuthorizationFilters
                 case Resource.HOUSING:
                     {
                         // The user must be a student and not a member of an existing application
-                        if (user_groups.Contains(AuthGroup.Student.Name))
+                        if (user_groups.Contains(AuthGroup.Student))
                         {
                             var sess_cde = Helpers.GetCurrentSession(_CCTContext);
                             var housingService = new HousingService(_CCTContext);
@@ -475,14 +475,14 @@ namespace Gordon360.AuthorizationFilters
             {
                 case Resource.SHIFT:
                     {
-                        if (user_groups.Contains(AuthGroup.Student.Name))
+                        if (user_groups.Contains(AuthGroup.Student))
                             return true;
                         return false;
                     }
                 case Resource.MEMBERSHIP:
                     {
                         // User is admin
-                        if (user_groups.Contains(AuthGroup.SiteAdmin.Name))
+                        if (user_groups.Contains(AuthGroup.SiteAdmin))
                             return true;
                         var membershipToConsider = (MEMBERSHIP)context.ActionArguments["membership"];
                         var activityCode = membershipToConsider.ACT_CDE;
@@ -523,7 +523,7 @@ namespace Gordon360.AuthorizationFilters
                 case Resource.MEMBERSHIP_PRIVACY:
                     {
                         // User is admin
-                        if (user_groups.Contains(AuthGroup.SiteAdmin.Name))
+                        if (user_groups.Contains(AuthGroup.SiteAdmin))
                             return true;
                         var membershipService = new MembershipService(_CCTContext);
                         var membershipID = (int)context.ActionArguments["id"];
@@ -548,11 +548,11 @@ namespace Gordon360.AuthorizationFilters
                         // The housing admins can update the application information (i.e. probation, offcampus program, etc.)
                         // If the user is a student, then the user must be on an application and be an editor to update the application
                         HousingService housingService = new HousingService(_CCTContext);
-                        if (user_groups.Contains(AuthGroup.HousingAdmin.Name))
+                        if (user_groups.Contains(AuthGroup.HousingAdmin))
                         {
                             return true;
                         }
-                        else if (user_groups.Contains(AuthGroup.Student.Name))
+                        else if (user_groups.Contains(AuthGroup.Student))
                         {
                             var sess_cde = Helpers.GetCurrentSession(_CCTContext);
                             int? applicationID = housingService.GetApplicationID(user_name, sess_cde);
@@ -571,7 +571,7 @@ namespace Gordon360.AuthorizationFilters
                 case Resource.ADVISOR:
                     {
                         // User is admin
-                        if (user_groups.Contains(AuthGroup.SiteAdmin.Name))
+                        if (user_groups.Contains(AuthGroup.SiteAdmin))
                             return true;
 
                         var membershipService = new MembershipService(_CCTContext);
@@ -587,7 +587,7 @@ namespace Gordon360.AuthorizationFilters
                 case Resource.PROFILE:
                     {
                         // User is admin
-                        if (user_groups.Contains(AuthGroup.SiteAdmin.Name))
+                        if (user_groups.Contains(AuthGroup.SiteAdmin))
                             return true;
 
                         var username = (string)context.ActionArguments["username"];
@@ -598,7 +598,7 @@ namespace Gordon360.AuthorizationFilters
                 case Resource.ACTIVITY_INFO:
                     {
                         // User is admin
-                        if (user_groups.Contains(AuthGroup.SiteAdmin.Name))
+                        if (user_groups.Contains(AuthGroup.SiteAdmin))
                             return true;
                         var activityCode = (string)context.ActionArguments["id"];
                         var membershipService = new MembershipService(_CCTContext);
@@ -613,7 +613,7 @@ namespace Gordon360.AuthorizationFilters
                 case Resource.ACTIVITY_STATUS:
                     {
                         // User is admin
-                        if (user_groups.Contains(AuthGroup.SiteAdmin.Name))
+                        if (user_groups.Contains(AuthGroup.SiteAdmin))
                             return true;
                         var activityCode = (string)context.ActionArguments["id"];
                         var sessionCode = (string)context.ActionArguments["sess_cde"];
@@ -650,7 +650,7 @@ namespace Gordon360.AuthorizationFilters
                     if (approved == null || approved == true)
                         return false;
                     // can update if user is admin
-                    if (user_groups.Contains(AuthGroup.SiteAdmin.Name))
+                    if (user_groups.Contains(AuthGroup.SiteAdmin))
                         return true;
                     // can update if user is news item author
                     string newsAuthor = newsItem.ADUN;
@@ -665,13 +665,13 @@ namespace Gordon360.AuthorizationFilters
             switch (resource)
             {
                 case Resource.SHIFT:
-                    if (user_groups.Contains(AuthGroup.Student.Name))
+                    if (user_groups.Contains(AuthGroup.Student))
                         return true;
                     return false;
                 case Resource.MEMBERSHIP:
                     {
                         // User is admin
-                        if (user_groups.Contains(AuthGroup.SiteAdmin.Name))
+                        if (user_groups.Contains(AuthGroup.SiteAdmin))
                             return true;
                         var membershipService = new MembershipService(_CCTContext);
                         var membershipID = (int)context.ActionArguments["id"];
@@ -691,7 +691,7 @@ namespace Gordon360.AuthorizationFilters
                 case Resource.MEMBERSHIP_REQUEST:
                     {
                         // User is admin
-                        if (user_groups.Contains(AuthGroup.SiteAdmin.Name))
+                        if (user_groups.Contains(AuthGroup.SiteAdmin))
                             return true;
                         // membershipRequest = mr
                         var mrService = new MembershipRequestService(_CCTContext);
@@ -718,11 +718,11 @@ namespace Gordon360.AuthorizationFilters
                         // The housing admins can update the application information (i.e. probation, offcampus program, etc.)
                         // If the user is a student, then the user must be on an application and be an editor to update the application
                         HousingService housingService = new HousingService(_CCTContext);
-                        if (user_groups.Contains(AuthGroup.HousingAdmin.Name))
+                        if (user_groups.Contains(AuthGroup.HousingAdmin))
                         {
                             return true;
                         }
-                        else if (user_groups.Contains(AuthGroup.Student.Name))
+                        else if (user_groups.Contains(AuthGroup.Student))
                         {
                             var sess_cde = Helpers.GetCurrentSession(_CCTContext);
                             int? applicationID = housingService.GetApplicationID(user_name, sess_cde);
@@ -760,7 +760,7 @@ namespace Gordon360.AuthorizationFilters
                             return false;
                         }
                         // user is admin
-                        if (user_groups.Contains(AuthGroup.SiteAdmin.Name))
+                        if (user_groups.Contains(AuthGroup.SiteAdmin))
                             return true;
                         // user is news item author
                         string newsAuthor = newsItem.ADUN;
@@ -770,7 +770,7 @@ namespace Gordon360.AuthorizationFilters
                     }
                 case Resource.SLIDER:
                     {
-                        if (user_groups.Contains(AuthGroup.SiteAdmin.Name))
+                        if (user_groups.Contains(AuthGroup.SiteAdmin))
                             return true;
                         return false;
                     }

--- a/Gordon360/Controllers/AcademicCheckInController.cs
+++ b/Gordon360/Controllers/AcademicCheckInController.cs
@@ -1,8 +1,8 @@
+using Gordon360.Authorization;
 using Gordon360.Exceptions;
 using Gordon360.Models.CCT.Context;
 using Gordon360.Models.ViewModels;
 using Gordon360.Services;
-using Gordon360.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Linq;

--- a/Gordon360/Controllers/AccountsController.cs
+++ b/Gordon360/Controllers/AccountsController.cs
@@ -1,9 +1,8 @@
-using Gordon360.AuthorizationFilters;
+using Gordon360.Authorization;
 using Gordon360.Models.CCT.Context;
 using Gordon360.Models.ViewModels;
 using Gordon360.Services;
 using Gordon360.Static.Names;
-using Gordon360.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using System.Linq;
@@ -170,7 +169,7 @@ namespace Gordon360.Controllers
             var viewerGroups = AuthUtils.GetGroups(User);
 
             // Only students and FacStaff can search students
-            if (accountTypes.Contains("student") && !(viewerGroups.Contains(AuthGroup.Student.Name) || viewerGroups.Contains(AuthGroup.FacStaff.Name)))
+            if (accountTypes.Contains("student") && !(viewerGroups.Contains(AuthGroup.Student) || viewerGroups.Contains(AuthGroup.FacStaff)))
             {
                 accountTypes.Remove("student");
             }

--- a/Gordon360/Controllers/ActivitiesController.cs
+++ b/Gordon360/Controllers/ActivitiesController.cs
@@ -1,4 +1,4 @@
-﻿using Gordon360.AuthorizationFilters;
+﻿using Gordon360.Authorization;
 using Gordon360.Models.CCT;
 using Gordon360.Models.CCT.Context;
 using Gordon360.Models.ViewModels;

--- a/Gordon360/Controllers/AdminsController.cs
+++ b/Gordon360/Controllers/AdminsController.cs
@@ -1,4 +1,4 @@
-﻿using Gordon360.AuthorizationFilters;
+﻿using Gordon360.Authorization;
 using Gordon360.Models.CCT.Context;
 using Gordon360.Models.CCT;
 using Gordon360.Services;

--- a/Gordon360/Controllers/ContentManagementController.cs
+++ b/Gordon360/Controllers/ContentManagementController.cs
@@ -1,4 +1,4 @@
-﻿using Gordon360.AuthorizationFilters;
+﻿using Gordon360.Authorization;
 using Gordon360.Models.CCT.Context;
 using Gordon360.Models.CCT;
 using Gordon360.Models.ViewModels;

--- a/Gordon360/Controllers/DiningController.cs
+++ b/Gordon360/Controllers/DiningController.cs
@@ -1,7 +1,7 @@
-﻿using Gordon360.Models.CCT.Context;
+﻿using Gordon360.Authorization;
+using Gordon360.Models.CCT.Context;
 using Gordon360.Services;
 using Gordon360.Static.Methods;
-using Gordon360.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using System.Threading.Tasks;

--- a/Gordon360/Controllers/EmailsController.cs
+++ b/Gordon360/Controllers/EmailsController.cs
@@ -1,4 +1,4 @@
-﻿using Gordon360.AuthorizationFilters;
+﻿using Gordon360.Authorization;
 using Gordon360.Models.CCT.Context;
 using Gordon360.Models.ViewModels;
 using Gordon360.Services;

--- a/Gordon360/Controllers/EventsController.cs
+++ b/Gordon360/Controllers/EventsController.cs
@@ -1,7 +1,7 @@
-﻿using Gordon360.Models.CCT.Context;
+﻿using Gordon360.Authorization;
+using Gordon360.Models.CCT.Context;
 using Gordon360.Models.ViewModels;
 using Gordon360.Services;
-using Gordon360.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Memory;

--- a/Gordon360/Controllers/HousingController.cs
+++ b/Gordon360/Controllers/HousingController.cs
@@ -1,11 +1,10 @@
-using Gordon360.AuthorizationFilters;
+using Gordon360.Authorization;
 using Gordon360.Models.CCT;
 using Gordon360.Models.CCT.Context;
 using Gordon360.Models.ViewModels;
 using Gordon360.Services;
 using Gordon360.Static.Methods;
 using Gordon360.Static.Names;
-using Gordon360.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Security.Claims;

--- a/Gordon360/Controllers/JobsController.cs
+++ b/Gordon360/Controllers/JobsController.cs
@@ -1,11 +1,10 @@
-﻿using Gordon360.AuthorizationFilters;
+﻿using Gordon360.Authorization;
 using Gordon360.Exceptions;
 using Gordon360.Models.CCT.Context;
 using Gordon360.Models.StudentTimesheets.Context;
 using Gordon360.Models.ViewModels;
 using Gordon360.Services;
 using Gordon360.Static.Names;
-using Gordon360.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Collections.Generic;

--- a/Gordon360/Controllers/LogController.cs
+++ b/Gordon360/Controllers/LogController.cs
@@ -1,4 +1,4 @@
-﻿using Gordon360.AuthorizationFilters;
+﻿using Gordon360.Authorization;
 using Gordon360.Models.CCT.Context;
 using Gordon360.Exceptions;
 using Gordon360.Models.CCT;

--- a/Gordon360/Controllers/MembershipsController.cs
+++ b/Gordon360/Controllers/MembershipsController.cs
@@ -222,7 +222,7 @@ namespace Gordon360.Controllers
             var viewerGroups = AuthUtils.GetGroups(User);
 
             if (viewerGroups.Contains(AuthGroup.SiteAdmin) || viewerGroups.Contains(AuthGroup.Police))              //super admin and gordon police reads all
-                return base.Ok(result);
+                return Ok(result);
             else
             {
                 List<MembershipViewModel> list = new List<MembershipViewModel>();
@@ -242,7 +242,7 @@ namespace Gordon360.Controllers
                         }
                     }
                 }
-                return base.Ok(list);
+                return Ok(list);
             }
         }
 

--- a/Gordon360/Controllers/MembershipsController.cs
+++ b/Gordon360/Controllers/MembershipsController.cs
@@ -1,10 +1,9 @@
-﻿using Gordon360.AuthorizationFilters;
-using Gordon360.Models.CCT.Context;
+﻿using Gordon360.Authorization;
 using Gordon360.Models.CCT;
+using Gordon360.Models.CCT.Context;
 using Gordon360.Models.ViewModels;
 using Gordon360.Services;
 using Gordon360.Static.Names;
-using Gordon360.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using System.Linq;
@@ -222,8 +221,8 @@ namespace Gordon360.Controllers
             var authenticatedUserUsername = AuthUtils.GetUsername(User);
             var viewerGroups = AuthUtils.GetGroups(User);
 
-            if (viewerGroups.Contains(AuthGroup.SiteAdmin.Name) || viewerGroups.Contains(AuthGroup.Police.Name))              //super admin and gordon police reads all
-                return Ok(result);
+            if (viewerGroups.Contains(AuthGroup.SiteAdmin) || viewerGroups.Contains(AuthGroup.Police))              //super admin and gordon police reads all
+                return base.Ok(result);
             else
             {
                 List<MembershipViewModel> list = new List<MembershipViewModel>();
@@ -243,7 +242,7 @@ namespace Gordon360.Controllers
                         }
                     }
                 }
-                return Ok(list);
+                return base.Ok(list);
             }
         }
 

--- a/Gordon360/Controllers/MyScheduleController.cs
+++ b/Gordon360/Controllers/MyScheduleController.cs
@@ -1,11 +1,11 @@
 ﻿using Gordon360.Models.CCT.Context;
 using Gordon360.Models.CCT;
 using Gordon360.Services;
-using Gordon360.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using Gordon360.Authorization;
 
 namespace Gordon360.Controllers
 {

--- a/Gordon360/Controllers/NewsController.cs
+++ b/Gordon360/Controllers/NewsController.cs
@@ -1,4 +1,4 @@
-﻿using Gordon360.AuthorizationFilters;
+﻿using Gordon360.Authorization;
 using Gordon360.Models.CCT.Context;
 using Gordon360.Models.MyGordon.Context;
 using Gordon360.Models.MyGordon;

--- a/Gordon360/Controllers/ProfilesController.cs
+++ b/Gordon360/Controllers/ProfilesController.cs
@@ -240,7 +240,7 @@ namespace Gordon360.Controllers
                     result.Add("pref", await GetProfileImageOrDefault(preferredImagePath));
                 }
                 result.Add("def", await GetProfileImageOrDefault(defaultImagePath));
-                return base.Ok(result);
+                return Ok(result);
 
             }
             else
@@ -261,11 +261,11 @@ namespace Gordon360.Controllers
                 {
                     result.Add("def", await ImageUtils.DownloadImageFromURL(_config["DEFAULT_PROFILE_IMAGE_PATH"]));
                 }
-                return base.Ok(result);
+                return Ok(result);
             }
             else
             {
-                return base.Ok();
+                return Ok();
             }
         }
 

--- a/Gordon360/Controllers/ProfilesController.cs
+++ b/Gordon360/Controllers/ProfilesController.cs
@@ -1,6 +1,6 @@
-﻿using Gordon360.AuthorizationFilters;
-using Gordon360.Models.CCT.Context;
+﻿using Gordon360.Authorization;
 using Gordon360.Models.CCT;
+using Gordon360.Models.CCT.Context;
 using Gordon360.Models.ViewModels;
 using Gordon360.Services;
 using Gordon360.Static.Names;
@@ -72,19 +72,19 @@ namespace Gordon360.Controllers
             object? faculty = null;
             object? alumni = null;
 
-            if (viewerGroups.Contains(AuthGroup.SiteAdmin.Name) || viewerGroups.Contains(AuthGroup.Police.Name))
+            if (viewerGroups.Contains(AuthGroup.SiteAdmin) || viewerGroups.Contains(AuthGroup.Police))
             {
                 student = _student;
                 faculty = _faculty;
                 alumni = _alumni;
             }
-            else if (viewerGroups.Contains(AuthGroup.FacStaff.Name))
+            else if (viewerGroups.Contains(AuthGroup.FacStaff))
             {
                 student = _student;
                 faculty = _faculty == null ? null : (PublicFacultyStaffProfileViewModel)_faculty;
                 alumni = _alumni == null ? null : (PublicAlumniProfileViewModel)_alumni;
             }
-            else if (viewerGroups.Contains(AuthGroup.Student.Name))
+            else if (viewerGroups.Contains(AuthGroup.Student))
             {
                 student = _student == null ? null : (PublicStudentProfileViewModel)_student;
                 faculty = _faculty == null ? null : (PublicFacultyStaffProfileViewModel)_faculty;
@@ -233,18 +233,18 @@ namespace Gordon360.Controllers
             var defaultImagePath = _config["DEFAULT_IMAGE_PATH"] + photoInfo.Img_Name;
 
             var viewerGroups = AuthUtils.GetGroups(User);
-            if (viewerGroups.Contains(AuthGroup.FacStaff.Name))
+            if (viewerGroups.Contains(AuthGroup.FacStaff))
             {
                 if (preferredImagePath is not null && System.IO.File.Exists(preferredImagePath))
                 {
                     result.Add("pref", await GetProfileImageOrDefault(preferredImagePath));
                 }
                 result.Add("def", await GetProfileImageOrDefault(defaultImagePath));
-                return Ok(result);
+                return base.Ok(result);
 
             }
             else
-            if (viewerGroups.Contains(AuthGroup.Student.Name))
+            if (viewerGroups.Contains(AuthGroup.Student))
             {
                 if (_accountService.GetAccountByUsername(username).show_pic == 1)
                 {
@@ -261,11 +261,11 @@ namespace Gordon360.Controllers
                 {
                     result.Add("def", await ImageUtils.DownloadImageFromURL(_config["DEFAULT_PROFILE_IMAGE_PATH"]));
                 }
-                return Ok(result);
+                return base.Ok(result);
             }
             else
             {
-                return Ok();
+                return base.Ok();
             }
         }
 

--- a/Gordon360/Controllers/RequestsController.cs
+++ b/Gordon360/Controllers/RequestsController.cs
@@ -1,10 +1,9 @@
-﻿using Gordon360.AuthorizationFilters;
+﻿using Gordon360.Authorization;
 using Gordon360.Models.CCT.Context;
 using Gordon360.Models.CCT;
 using Gordon360.Models.ViewModels;
 using Gordon360.Services;
 using Gordon360.Static.Names;
-using Gordon360.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/Gordon360/Controllers/ScheduleControlController.cs
+++ b/Gordon360/Controllers/ScheduleControlController.cs
@@ -1,6 +1,6 @@
-﻿using Gordon360.Models.CCT.Context;
+﻿using Gordon360.Authorization;
+using Gordon360.Models.CCT.Context;
 using Gordon360.Services;
-using Gordon360.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json.Linq;
 using System;

--- a/Gordon360/Controllers/ScheduleController.cs
+++ b/Gordon360/Controllers/ScheduleController.cs
@@ -1,8 +1,7 @@
-﻿using Gordon360.Models.CCT.Context;
+﻿using Gordon360.Authorization;
+using Gordon360.Models.CCT.Context;
 using Gordon360.Models.ViewModels;
 using Gordon360.Services;
-using Gordon360.Static.Names;
-using Gordon360.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
@@ -37,7 +36,7 @@ namespace Gordon360.Controllers
             var authenticatedUserUsername = AuthUtils.GetUsername(User);
             var groups = AuthUtils.GetGroups(User);
 
-            if (groups.Contains(AuthGroup.Student.Name))
+            if (groups.Contains(AuthGroup.Student))
             {
                 var result = _scheduleService.GetScheduleStudentAsync(authenticatedUserUsername);
                 if (result == null)
@@ -47,7 +46,7 @@ namespace Gordon360.Controllers
                 return Ok(result);
             }
 
-            else if (groups.Contains(AuthGroup.FacStaff.Name))
+            else if (groups.Contains(AuthGroup.FacStaff))
             {
                 var result = _scheduleService.GetScheduleFacultyAsync(authenticatedUserUsername);
                 if (result == null)
@@ -78,25 +77,25 @@ namespace Gordon360.Controllers
             var scheduleControl = _context.Schedule_Control.Find(id);
 
             IEnumerable<ScheduleViewModel>? scheduleResult = null;
-            if (groups.Contains(AuthGroup.Student.Name))
+            if (groups.Contains(AuthGroup.Student))
             {
                 int schedulePrivacy = scheduleControl?.IsSchedulePrivate ?? 1;
 
-                if (viewerGroups.Contains(AuthGroup.Police.Name) || viewerGroups.Contains(AuthGroup.SiteAdmin.Name))
+                if (viewerGroups.Contains(AuthGroup.Police) || viewerGroups.Contains(AuthGroup.SiteAdmin))
                 {
                     scheduleResult = await _scheduleService.GetScheduleStudentAsync(id);
                 }
-                else if (viewerGroups.Contains(AuthGroup.Student.Name) && schedulePrivacy == 0)
+                else if (viewerGroups.Contains(AuthGroup.Student) && schedulePrivacy == 0)
                 {
 
                     scheduleResult = await _scheduleService.GetScheduleStudentAsync(id);
                 }
-                else if (viewerGroups.Contains(AuthGroup.Advisors.Name))
+                else if (viewerGroups.Contains(AuthGroup.Advisors))
                 {
                     scheduleResult = await _scheduleService.GetScheduleStudentAsync(id);
                 }
             }
-            else if (groups.Contains(AuthGroup.FacStaff.Name))
+            else if (groups.Contains(AuthGroup.FacStaff))
             {
                 scheduleResult = await _scheduleService.GetScheduleFacultyAsync(id);
             }
@@ -124,7 +123,7 @@ namespace Gordon360.Controllers
         public async Task<ActionResult<bool>> GetCanReadStudentSchedules()
         {
             var groups = AuthUtils.GetGroups(User);
-            return groups.Contains(AuthGroup.Advisors.Name);
+            return groups.Contains(AuthGroup.Advisors);
         }
     }
 }

--- a/Gordon360/Controllers/StudentEmploymentController.cs
+++ b/Gordon360/Controllers/StudentEmploymentController.cs
@@ -1,7 +1,7 @@
+using Gordon360.Authorization;
 using Gordon360.Models.CCT.Context;
 using Gordon360.Models.ViewModels;
 using Gordon360.Services;
-using Gordon360.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
 

--- a/Gordon360/Controllers/VictoryPromiseController.cs
+++ b/Gordon360/Controllers/VictoryPromiseController.cs
@@ -1,7 +1,7 @@
-﻿using Gordon360.Models.CCT.Context;
+﻿using Gordon360.Authorization;
+using Gordon360.Models.CCT.Context;
 using Gordon360.Models.ViewModels;
 using Gordon360.Services;
-using Gordon360.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/Gordon360/Controllers/WellnessController.cs
+++ b/Gordon360/Controllers/WellnessController.cs
@@ -2,8 +2,8 @@
 using Gordon360.Models.CCT;
 using Gordon360.Models.ViewModels;
 using Gordon360.Services;
-using Gordon360.Utilities;
 using Microsoft.AspNetCore.Mvc;
+using Gordon360.Authorization;
 
 namespace Gordon360.Controllers
 {

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -4,6 +4,13 @@
         <name>Gordon360</name>
     </assembly>
     <members>
+        <member name="M:Gordon360.Authorization.AuthUtils.GetUsername(System.Security.Claims.ClaimsPrincipal)">
+            <summary>
+            Get the username of the authenticated user
+            </summary>
+            <param name="User">The ClaimsPrincipal representing the user's authentication claims</param>
+            <returns>Username of the authenticated user</returns>
+        </member>
         <member name="M:Gordon360.Controllers.Api.AcademicCheckInController.PutEmergencyContactAsync(Gordon360.Models.ViewModels.EmergencyContactViewModel)">
             <summary>Set emergency contacts for student</summary>
             <param name="data"> The contact data to be stored </param>
@@ -2068,13 +2075,6 @@
             Helper method that gets the current session we are in.
             </summary>
             <returns>The session code of the current session</returns>
-        </member>
-        <member name="M:Gordon360.Utilities.AuthUtils.GetUsername(System.Security.Claims.ClaimsPrincipal)">
-            <summary>
-            Get the username of the authenticated user
-            </summary>
-            <param name="User">The ClaimsPrincipal representing the user's authentication claims</param>
-            <returns>Username of the authenticated user</returns>
         </member>
         <member name="M:Gordon360.Utilities.ImageUtils.DeleteImage(System.String)">
             <summary>

--- a/Gordon360/Services/AccountService.cs
+++ b/Gordon360/Services/AccountService.cs
@@ -1,4 +1,4 @@
-﻿using Gordon360.AuthorizationFilters;
+﻿using Gordon360.Authorization;
 using Gordon360.Models.CCT.Context;
 using Gordon360.Exceptions;
 using Gordon360.Models.CCT;

--- a/Gordon360/Static Classes/Names.cs
+++ b/Gordon360/Static Classes/Names.cs
@@ -1,40 +1,5 @@
 ﻿namespace Gordon360.Static.Names
 {
-    public class AuthGroup
-    {
-        static AuthGroup()
-        {
-            Advisors = new AuthGroup("360-Advisors-SG");
-            Alumni = new AuthGroup("360-Alumni-SG");
-            FacStaff = new AuthGroup("360-FacStaff-SG");
-            Faculty = new AuthGroup("360-Faculty-SG");
-            HousingAdmin = new AuthGroup("360-HousingAdmin-SG");
-            NewsAdmin = new AuthGroup("360-NewsAdmin-SG");
-            Police = new AuthGroup("360-Police-SG");
-            SiteAdmin = new AuthGroup("360-SiteAdmin-SG");
-            Staff = new AuthGroup("360-Staff-SG");
-            Student = new AuthGroup("360-Student-SG");
-        }
-
-        private AuthGroup(string name)
-        {
-            Name = name;
-        }
-
-        public static AuthGroup Advisors { get; }
-        public static AuthGroup Alumni { get; }
-        public static AuthGroup FacStaff { get; }
-        public static AuthGroup Faculty { get; }
-        public static AuthGroup HousingAdmin { get; }
-        public static AuthGroup NewsAdmin { get; }
-        public static AuthGroup Police { get; }
-        public static AuthGroup SiteAdmin { get; }
-        public static AuthGroup Staff { get; }
-        public static AuthGroup Student { get; }
-
-        public string Name { get; }
-    }
-
     public static class Resource
     {
         public const string EMERGENCY_CONTACT = "A new emergency contact resource";


### PR DESCRIPTION
AuthGroup is now a proper enum, and is mapped from Claims using the AuthGroupEnum.FromString method.

I also reorganized our authorization logic to live in the Authorization namespace for clarity.