### PR TITLE
Fix involvement update

### DIFF
--- a/Gordon360/Authorization/StateYourBusiness.cs
+++ b/Gordon360/Authorization/StateYourBusiness.cs
@@ -622,7 +622,7 @@ namespace Gordon360.Authorization
                         var isGroupAdmin = (await membershipService.GetGroupAdminMembershipsForActivityAsync(activityCode)).Any(x => x.IDNumber.ToString() == user_id);
                         if (isGroupAdmin)
                         {
-                            var activityService = new ActivityService(_CCTContext);
+                            var activityService = context.HttpContext.RequestServices.GetRequiredService<IActivityService>();
                             // If an activity is currently open, then a group admin has the ability to close it
                             if (activityService.IsOpen(activityCode, sessionCode))
                             {

--- a/Gordon360/Controllers/ActivitiesController.cs
+++ b/Gordon360/Controllers/ActivitiesController.cs
@@ -18,10 +18,10 @@ namespace Gordon360.Controllers
         private readonly IActivityService _activityService;
         private readonly CCTContext _context;
 
-        public ActivitiesController(CCTContext context)
+        public ActivitiesController(CCTContext context, IActivityService activityService)
         {
             _context = context;
-            _activityService = new ActivityService(context);
+            _activityService = activityService;
         }
 
         [HttpGet]

--- a/Gordon360/Controllers/ActivitiesController.cs
+++ b/Gordon360/Controllers/ActivitiesController.cs
@@ -202,15 +202,15 @@ namespace Gordon360.Controllers
 
         /// <summary>
         /// </summary>
-        /// <param name="id"></param>
-        /// <param name="activity"></param>
+        /// <param name="activity_code">The code of the activity to update</param>
+        /// <param name="involvement">The updated involvement details</param>
         /// <returns></returns>
         [HttpPut]
-        [Route("{id}")]
+        [Route("{activity_code}")]
         [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.ACTIVITY_INFO)]
-        public ActionResult<ACT_INFO> Put(string id, ACT_INFO activity)
+        public ActionResult<ACT_INFO> Put(string activity_code, InvolvementUpdateViewModel involvement)
         {
-            var result = _activityService.Update(id, activity);
+            var result = _activityService.Update(activity_code, involvement);
 
             if (result == null)
             {

--- a/Gordon360/Controllers/ActivitiesController.cs
+++ b/Gordon360/Controllers/ActivitiesController.cs
@@ -208,7 +208,7 @@ namespace Gordon360.Controllers
         [HttpPut]
         [Route("{activity_code}")]
         [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.ACTIVITY_INFO)]
-        public ActionResult<ACT_INFO> Put(string activity_code, InvolvementUpdateViewModel involvement)
+        public ActionResult<ActivityInfoViewModel> Put(string activity_code, InvolvementUpdateViewModel involvement)
         {
             var result = _activityService.Update(activity_code, involvement);
 
@@ -217,7 +217,7 @@ namespace Gordon360.Controllers
                 return NotFound();
             }
 
-            return Ok(result);
+            return Ok((ActivityInfoViewModel)result);
         }
 
         [HttpPut]

--- a/Gordon360/Controllers/MembershipsController.cs
+++ b/Gordon360/Controllers/MembershipsController.cs
@@ -17,10 +17,10 @@ namespace Gordon360.Controllers
         private readonly IMembershipService _membershipService;
         private readonly IActivityService _activityService;
 
-        public MembershipsController(CCTContext context)
+        public MembershipsController(CCTContext context, IActivityService activityService)
         {
             _membershipService = new MembershipService(context);
-            _activityService = new ActivityService(context);
+            _activityService = activityService;
         }
 
         /// <summary>

--- a/Gordon360/Controllers/ProfilesController.cs
+++ b/Gordon360/Controllers/ProfilesController.cs
@@ -296,8 +296,7 @@ namespace Gordon360.Controllers
 
             var filePath = Path.Combine(_config["PREFERRED_IMAGE_PATH"], fileName);
 
-            using var stream = System.IO.File.Create(filePath);
-            await image.CopyToAsync(stream);
+            ImageUtils.UploadImageAsync(filePath, image);
 
             await _profileService.UpdateProfileImageAsync(username, _config["DATABASE_IMAGE_PATH"], fileName);
 

--- a/Gordon360/Controllers/ProfilesController.cs
+++ b/Gordon360/Controllers/ProfilesController.cs
@@ -287,11 +287,14 @@ namespace Gordon360.Controllers
             var (extension, _) = ImageUtils.GetImageFormat(image);
             var fileName = $"{account.Barcode}.{extension}";
 
-            // If the new photo won't overwrite the old one, delete the old photo.
-            var oldPath = Path.Combine(pathInfo.Pref_Img_Path, pathInfo.Pref_Img_Name);
-            if (pathInfo.Pref_Img_Name != fileName && System.IO.File.Exists(oldPath))
+            // If there is an old photo that won't get overwritten, delete the old photo
+            if (pathInfo.Pref_Img_Name is string oldName
+                && oldName != fileName
+                && pathInfo.Pref_Img_Path is string oldPath
+                && Path.Combine(oldPath, oldName) is string oldFile
+                && System.IO.File.Exists(oldFile))
             {
-                System.IO.File.Delete(oldPath);
+                System.IO.File.Delete(oldFile);
             }
 
             var filePath = Path.Combine(_config["PREFERRED_IMAGE_PATH"], fileName);

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -169,11 +169,11 @@
             <param name="id">The id of the user who is group admin</param>
             <returns></returns>
         </member>
-        <member name="M:Gordon360.Controllers.ActivitiesController.Put(System.String,Gordon360.Models.CCT.ACT_INFO)">
+        <member name="M:Gordon360.Controllers.ActivitiesController.Put(System.String,Gordon360.Models.ViewModels.InvolvementUpdateViewModel)">
             <summary>
             </summary>
-            <param name="id"></param>
-            <param name="activity"></param>
+            <param name="activity_code">The code of the activity to update</param>
+            <param name="involvement">The updated involvement details</param>
             <returns></returns>
         </member>
         <member name="M:Gordon360.Controllers.ActivitiesController.PostImageAsync(System.String)">
@@ -1156,11 +1156,11 @@
             <param name="sess_cde">The session we want to get the closed activities for</param>
             <returns>The collection of activity codes for open activities</returns>
         </member>
-        <member name="M:Gordon360.Services.ActivityService.Update(System.String,Gordon360.Models.CCT.ACT_INFO)">
+        <member name="M:Gordon360.Services.ActivityService.Update(System.String,Gordon360.Models.ViewModels.InvolvementUpdateViewModel)">
             <summary>
             Updates the Activity Info 
             </summary>
-            <param name="activity">The activity info resource with the updated information</param>
+            <param name="involvement">The activity info resource with the updated information</param>
             <param name="activityCode">The id of the activity info to be updated</param>
             <returns>The updated activity info resource</returns>
         </member>

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -176,11 +176,12 @@
             <param name="involvement">The updated involvement details</param>
             <returns></returns>
         </member>
-        <member name="M:Gordon360.Controllers.ActivitiesController.PostImageAsync(System.String)">
+        <member name="M:Gordon360.Controllers.ActivitiesController.PostImageAsync(System.String,Microsoft.AspNetCore.Http.IFormFile)">
             <summary>
             Set an image for the activity
             </summary>
-            <param name="id">The activity Code</param>
+            <param name="involvement_code">The activity code</param>
+            <param name="image">The image file</param>
             <returns></returns>
         </member>
         <member name="M:Gordon360.Controllers.ActivitiesController.ResetImage(System.String)">
@@ -1178,12 +1179,13 @@
             <param name="activityCode">The activity code for the activity that will be closed</param>
             <param name="sess_cde">The session code for the session where the activity is being closed</param>
         </member>
-        <member name="M:Gordon360.Services.ActivityService.UpdateActivityImage(System.String,System.String)">
+        <member name="M:Gordon360.Services.ActivityService.UpdateActivityImageAsync(Gordon360.Models.CCT.ACT_INFO,Microsoft.AspNetCore.Http.IFormFile)">
             <summary>
-            Sets the path for the activity image.
+            Updates the image for the spcefied involvement
             </summary>
-            <param name="activityCode">The activity code</param>
-            <param name="path"></param>
+            <param name="involvement">The involvement to update the image of</param>
+            <param name="image">The new image</param>
+            <returns>The involvement with the updated image path</returns>
         </member>
         <member name="M:Gordon360.Services.ActivityService.ResetActivityImage(System.String)">
             <summary>
@@ -2121,6 +2123,17 @@
             <param name="imagePath">The path to which the image belongs</param>
             <param name="imageData">The base64 image data to be stored</param>
             <param name="format">The format to save the image as. Defaults to Jpeg</param>
+        </member>
+        <member name="M:Gordon360.Utilities.ImageUtils.UploadImageAsync(System.String,Microsoft.AspNetCore.Http.IFormFile)">
+            <summary>
+            Uploads image from HTTP FormFile
+            </summary>
+            <remarks>
+            Takes image data and writes it to an image file. Note that if the target path
+            already has a file, the method will overwrite it (which gives no errors)
+            </remarks>
+            <param name="imagePath">The path to which the image belongs</param>
+            <param name="imageData">The image data to be stored</param>
         </member>
         <member name="M:Gordon360.Utilities.ImageUtils.GetBase64ImageDataFromPath(System.String)">
             <summary>

--- a/Gordon360/Models/ViewModels/InvolvementUpdateViewModel.cs
+++ b/Gordon360/Models/ViewModels/InvolvementUpdateViewModel.cs
@@ -1,0 +1,9 @@
+﻿namespace Gordon360.Models.ViewModels
+{
+    public record InvolvementUpdateViewModel
+    {
+        public string Description { get; init; }
+        public string JoinInfo { get; init; }
+        public string Url { get; init; }
+    }
+}

--- a/Gordon360/Program.cs
+++ b/Gordon360/Program.cs
@@ -41,6 +41,7 @@ builder.Services.AddDbContext<CCTContext>(options =>
 );
 
 builder.Services.AddScoped<IAccountService, AccountService>();
+builder.Services.AddScoped<IActivityService, ActivityService>();
 builder.Services.AddScoped<IProfileService, ProfileService>();
 builder.Services.AddScoped<IAddressesService, AddressesService>();
 

--- a/Gordon360/Services/ActivityService.cs
+++ b/Gordon360/Services/ActivityService.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 
 namespace Gordon360.Services
 {
@@ -17,10 +18,12 @@ namespace Gordon360.Services
     public class ActivityService : IActivityService
     {
         private readonly CCTContext _context;
+        private readonly IConfiguration _config;
 
-        public ActivityService(CCTContext context)
+        public ActivityService(CCTContext context, IConfiguration config)
         {
             _context = context;
+            _config = config;
         }
         /// <summary>
         /// Fetches a single activity record whose id matches the id provided as an argument
@@ -232,8 +235,6 @@ namespace Gordon360.Services
                 throw new ResourceNotFoundException() { ExceptionMessage = "The Activity Info was not found." };
             }
 
-            ValidateActivityInfo(activity);
-
             // One can only update certain fields within a membrship
             original.ACT_BLURB = involvement.Description;
             original.ACT_URL = involvement.Url;
@@ -242,7 +243,6 @@ namespace Gordon360.Services
             _context.SaveChanges();
 
             return original;
-
         }
 
         /// <summary>
@@ -321,21 +321,8 @@ namespace Gordon360.Services
                 throw new ResourceNotFoundException() { ExceptionMessage = "The Activity Info was not found." };
             }
 
-            /* @TODO: fix images
-            original.ACT_IMG_PATH = System.Web.Configuration.WebConfigurationManager.AppSettings["DEFAULT_ACTIVITY_IMAGE_PATH"];
-            */
+            original.ACT_IMG_PATH = _config["DEFAULT_ACTIVITY_IMAGE_PATH"];
             _context.SaveChanges();
-        }
-        // Helper method to validate an activity info post. Throws an exception that gets caught later if something is not valid.
-        // Returns true if all is well. The return value is not really used though. This could be of type void.
-        private bool ValidateActivityInfo(ACT_INFO activity)
-        {
-            var activityExists = _context.ACT_INFO.Where(x => x.ACT_CDE == activity.ACT_CDE).Count() > 0;
-            if (!activityExists)
-                throw new ResourceNotFoundException() { ExceptionMessage = "The Activity was not found." };
-
-            return true;
-
         }
 
         /// <summary>

--- a/Gordon360/Services/ActivityService.cs
+++ b/Gordon360/Services/ActivityService.cs
@@ -220,10 +220,10 @@ namespace Gordon360.Services
         /// <summary>
         /// Updates the Activity Info 
         /// </summary>
-        /// <param name="activity">The activity info resource with the updated information</param>
+        /// <param name="involvement">The activity info resource with the updated information</param>
         /// <param name="activityCode">The id of the activity info to be updated</param>
         /// <returns>The updated activity info resource</returns>
-        public ACT_INFO Update(string activityCode, ACT_INFO activity)
+        public ACT_INFO Update(string activityCode, InvolvementUpdateViewModel involvement)
         {
             var original = _context.ACT_INFO.Find(activityCode);
 
@@ -235,9 +235,9 @@ namespace Gordon360.Services
             ValidateActivityInfo(activity);
 
             // One can only update certain fields within a membrship
-            original.ACT_BLURB = activity.ACT_BLURB;
-            original.ACT_URL = activity.ACT_URL;
-            original.ACT_JOIN_INFO = activity.ACT_JOIN_INFO;
+            original.ACT_BLURB = involvement.Description;
+            original.ACT_URL = involvement.Url;
+            original.ACT_JOIN_INFO = involvement.JoinInfo;
 
             _context.SaveChanges();
 

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -1,6 +1,7 @@
 ﻿using Gordon360.Models.CCT;
 using Gordon360.Models.MyGordon;
 using Gordon360.Models.ViewModels;
+using Microsoft.AspNetCore.Http;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -112,7 +113,7 @@ namespace Gordon360.Services
         ACT_INFO Update(string activityCode, InvolvementUpdateViewModel activity);
         void CloseOutActivityForSession(string activityCode, string sess_cde);
         void OpenActivityForSession(string activityCode, string sess_cde);
-        void UpdateActivityImage(string activityCode, string path);
+        Task<ACT_INFO> UpdateActivityImageAsync(ACT_INFO involvement, IFormFile image);
         void ResetActivityImage(string activityCode);
         void TogglePrivacy(string activityCode, bool isPrivate);
     }

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -109,7 +109,7 @@ namespace Gordon360.Services
         IEnumerable<string> GetOpenActivities(string sess_cde, int gordonID);
         IEnumerable<string> GetClosedActivities(string sess_cde);
         IEnumerable<string> GetClosedActivities(string sess_cde, int gordonID);
-        ACT_INFO Update(string activityCode, ACT_INFO activity);
+        ACT_INFO Update(string activityCode, InvolvementUpdateViewModel activity);
         void CloseOutActivityForSession(string activityCode, string sess_cde);
         void OpenActivityForSession(string activityCode, string sess_cde);
         void UpdateActivityImage(string activityCode, string path);

--- a/Gordon360/Utilities/ImageUtils.cs
+++ b/Gordon360/Utilities/ImageUtils.cs
@@ -91,6 +91,26 @@ namespace Gordon360.Utilities
             }
         }
 
+        /// <summary>
+        /// Uploads image from HTTP FormFile
+        /// </summary>
+        /// <remarks>
+        /// Takes image data and writes it to an image file. Note that if the target path
+        /// already has a file, the method will overwrite it (which gives no errors)
+        /// </remarks>
+        /// <param name="imagePath">The path to which the image belongs</param>
+        /// <param name="imageData">The image data to be stored</param>
+        public async static void UploadImageAsync(string imagePath, IFormFile imageData)
+        {
+            if (Path.GetDirectoryName(imagePath) is string path && !Directory.Exists(path))
+            {
+                Directory.CreateDirectory(path);
+            }
+
+            using var stream = File.Create(imagePath);
+            await imageData.CopyToAsync(stream);
+        }
+
         public static async Task<string> DownloadImageFromURL(string url)
         {
             using var httpClient = new HttpClient();

--- a/Gordon360/Utilities/ImageUtils.cs
+++ b/Gordon360/Utilities/ImageUtils.cs
@@ -22,7 +22,7 @@ namespace Gordon360.Utilities
             {
                 File.Delete(imagePath);
             }
-            catch (System.Exception e)
+            catch (Exception e)
             {
                 //If there wasn't an image there, the only reason
                 //was that no image was associated with the news item,
@@ -39,14 +39,14 @@ namespace Gordon360.Utilities
         /// <returns>The base64 data of the image</returns>
         public static string RetrieveImageFromPath(string imagePath)
         {
-            string imageData = null;
+            string? imageData = null;
 
             if (imagePath != null)
             {
                 imageData = GetBase64ImageDataFromPath(imagePath);
             }
 
-            return imageData;
+            return imageData ?? "";
         }
 
         /// <summary>
@@ -59,16 +59,16 @@ namespace Gordon360.Utilities
         /// <param name="imagePath">The path to which the image belongs</param>
         /// <param name="imageData">The base64 image data to be stored</param>
         /// <param name="format">The format to save the image as. Defaults to Jpeg</param>
-        public static void UploadImage(string imagePath, string imageData, ImageFormat format = null)
+        public static void UploadImage(string imagePath, string imageData, ImageFormat? format = null)
         {
             if (imageData == null) { return; }
 
-            if (!Directory.Exists(Path.GetDirectoryName(imagePath)))
+            if (Path.GetDirectoryName(imagePath) is string path && !Directory.Exists(path))
             {
-                Directory.CreateDirectory(Path.GetDirectoryName(imagePath));
+                Directory.CreateDirectory(path);
             }
 
-            byte[] imageDataArray = System.Convert.FromBase64String(imageData);
+            byte[] imageDataArray = Convert.FromBase64String(imageData);
 
             try
             {
@@ -84,7 +84,7 @@ namespace Gordon360.Utilities
                 return;//Saving image was successful
             }
 
-            catch (System.Exception e)
+            catch (Exception e)
             {
                 System.Diagnostics.Debug.WriteLine(e.Message);
                 System.Diagnostics.Debug.WriteLine("Something went wrong trying to save an image to " + imagePath);


### PR DESCRIPTION
This pr fixes updating involvements, which broke in the API update.

The fix consisted of changing the typing on involvement update params and implementing the ASP.NET Core version of uploading images.