### PR TITLE
Fix errors loading schedule for students

### DIFF
--- a/Gordon360/Controllers/ScheduleController.cs
+++ b/Gordon360/Controllers/ScheduleController.cs
@@ -83,21 +83,21 @@ namespace Gordon360.Controllers
 
                 if (viewerGroups.Contains(AuthGroup.Police) || viewerGroups.Contains(AuthGroup.SiteAdmin))
                 {
-                    scheduleResult = await _scheduleService.GetScheduleStudentAsync(id);
+                    scheduleResult = await _scheduleService.GetScheduleStudentAsync(username);
                 }
                 else if (viewerGroups.Contains(AuthGroup.Student) && schedulePrivacy == 0)
                 {
 
-                    scheduleResult = await _scheduleService.GetScheduleStudentAsync(id);
+                    scheduleResult = await _scheduleService.GetScheduleStudentAsync(username);
                 }
                 else if (viewerGroups.Contains(AuthGroup.Advisors))
                 {
-                    scheduleResult = await _scheduleService.GetScheduleStudentAsync(id);
+                    scheduleResult = await _scheduleService.GetScheduleStudentAsync(username);
                 }
             }
             else if (groups.Contains(AuthGroup.FacStaff))
             {
-                scheduleResult = await _scheduleService.GetScheduleFacultyAsync(id);
+                scheduleResult = await _scheduleService.GetScheduleFacultyAsync(username);
             }
             else
             {

--- a/Gordon360/Models/ViewModels/ScheduleViewModel.cs
+++ b/Gordon360/Models/ViewModels/ScheduleViewModel.cs
@@ -18,9 +18,9 @@ namespace Gordon360.Models.ViewModels
         public string THURSDAY_CDE { get; set; }
         public string FRIDAY_CDE { get; set; }
 
-        public Nullable<System.TimeSpan> BEGIN_TIME { get; set; }
+        public TimeSpan? BEGIN_TIME { get; set; }
 
-        public Nullable<System.TimeSpan> END_TIME { get; set; }
+        public TimeSpan? END_TIME { get; set; }
 
 
     }

--- a/Gordon360/Services/ScheduleService.cs
+++ b/Gordon360/Services/ScheduleService.cs
@@ -38,7 +38,21 @@ namespace Gordon360.Services
             var sessionCode = Helpers.GetCurrentSession(_context);
             var result = await _context.Procedures.STUDENT_COURSES_BY_ID_NUM_AND_SESS_CDEAsync(int.Parse(account.gordon_id), sessionCode);
 
-            return (IEnumerable<ScheduleViewModel>)result;
+            return result.Select(x => new ScheduleViewModel
+            {
+                ID_NUM = x.ID_NUM,
+                CRS_CDE = x.CRS_CDE,
+                CRS_TITLE = x.CRS_TITLE,
+                BLDG_CDE = x.BLDG_CDE,
+                ROOM_CDE = x.ROOM_CDE,
+                MONDAY_CDE = x.MONDAY_CDE,
+                TUESDAY_CDE = x.TUESDAY_CDE,
+                WEDNESDAY_CDE = x.WEDNESDAY_CDE,
+                THURSDAY_CDE = x.THURSDAY_CDE,
+                FRIDAY_CDE = x.FRIDAY_CDE,
+                BEGIN_TIME = x.BEGIN_TIME,
+                END_TIME = x.END_TIME
+            });
         }
 
 


### PR DESCRIPTION
This PR fixes two errors loading student schedules:
1. The ScheduleService expects username as the param to `GetStudentScheduleAsync`, but we were passing it ID_Num.
2. The `GetStudentScheduleAsync` method was trying to cast `STUDENT_COURSES_BY_ID_NUM_AND_SESS_CDEResult` to `ScheduleViewModel`. Even though they're exactly the same shape, C# doesn't let you cast from one to the other, so we now explicitly select our results into the correct type.