### PR TITLE
Clifton Strengths privacy

### DIFF
--- a/Gordon360/Controllers/ProfilesController.cs
+++ b/Gordon360/Controllers/ProfilesController.cs
@@ -121,13 +121,51 @@ namespace Gordon360.Controllers
         [HttpGet]
         [Route("clifton/{username}")]
         [StateYourBusiness(operation = Operation.READ_ONE, resource = Resource.PROFILE)]
-        public ActionResult<string[]> GetCliftonStrengths(string username)
+        public ActionResult<string[]> GetCliftonStrengths_DEPRECATED(string username)
         {
             var id = _accountService.GetAccountByUsername(username).GordonID;
             var strengths = _profileService.GetCliftonStrengths(int.Parse(id));
 
-            return Ok(strengths);
+            if (strengths is null)
+            {
+                return NotFound("No strengths were found for this user");
+            }
 
+            return Ok(strengths.Themes);
+        }
+
+
+        /// <summary> Gets the clifton strengths of a particular user </summary>
+        /// <param name="username"> The username for which to retrieve info </param>
+        /// <returns> Clifton strengths of the given user. </returns>
+        [HttpGet]
+        [Route("{username}/clifton")]
+        [StateYourBusiness(operation = Operation.READ_ONE, resource = Resource.PROFILE)]
+        public ActionResult<CliftonStrengthsViewModel> GetCliftonStrengths(string username)
+        {
+            var id = _accountService.GetAccountByUsername(username).GordonID;
+            var strengths = _profileService.GetCliftonStrengths(int.Parse(id));
+
+            if (strengths is null)
+            {
+                return NotFound("No strengths were found for this user");
+            }
+
+            return Ok(strengths);
+        }
+
+        /// <summary>Toggle privacy of the current user's Clifton Strengths</summary>
+        /// <returns>New privacy value</returns>
+        [HttpGet]
+        [Route("clifton/privacy")]
+        [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.PROFILE)]
+        public async Task<ActionResult<bool>> ToggleCliftonStrengthsPrivacyAsync()
+        {
+            var username = AuthUtils.GetUsername(User);
+            var id = _accountService.GetAccountByUsername(username).GordonID;
+            var privacy = await _profileService.ToggleCliftonStrengthsPrivacyAsync(int.Parse(id));
+
+            return Ok(privacy);
         }
 
         /// <summary> Gets the emergency contact information of a particular user </summary>

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -663,10 +663,19 @@
              provides first name, last name, and username.
              </returns>
         </member>
+        <member name="M:Gordon360.Controllers.ProfilesController.GetCliftonStrengths_DEPRECATED(System.String)">
+            <summary> Gets the clifton strengths of a particular user </summary>
+            <param name="username"> The username for which to retrieve info </param>
+            <returns> Clifton strengths of the given user. </returns>
+        </member>
         <member name="M:Gordon360.Controllers.ProfilesController.GetCliftonStrengths(System.String)">
             <summary> Gets the clifton strengths of a particular user </summary>
             <param name="username"> The username for which to retrieve info </param>
             <returns> Clifton strengths of the given user. </returns>
+        </member>
+        <member name="M:Gordon360.Controllers.ProfilesController.ToggleCliftonStrengthsPrivacyAsync">
+            <summary>Toggle privacy of the current user's Clifton Strengths</summary>
+            <returns>New privacy value</returns>
         </member>
         <member name="M:Gordon360.Controllers.ProfilesController.GetEmergencyContact(System.String)">
             <summary> Gets the emergency contact information of a particular user </summary>
@@ -975,6 +984,11 @@
             </summary>
             <param name="status">The current status of the user to post, of type WellnessStatusColor</param>
             <returns>The status that was stored in the database</returns>
+        </member>
+        <member name="P:Gordon360.Models.CCT.Clifton_Strengths.Private">
+            <summary>
+            Whether the user wants their strengths to be private (not shown to other users)
+            </summary>
         </member>
         <member name="P:Gordon360.Models.StudentTimesheets.student_timesheets.ID_NUM">
             <summary>
@@ -1871,6 +1885,14 @@
             <summary> Gets the clifton strengths of a particular user </summary>
             <param name="id"> The id of the user for which to retrieve info </param>
             <returns> Clifton strengths of the given user. </returns>
+        </member>
+        <member name="M:Gordon360.Services.ProfileService.ToggleCliftonStrengthsPrivacyAsync(System.Int32)">
+            <summary>
+            Toggles the privacy of the Clifton Strengths data associated with the given id
+            </summary>
+            <param name="id">ID of the user whose Clifton Strengths privacy is toggled</param>
+            <returns>The new privacy value</returns>
+            <exception cref="T:Gordon360.Exceptions.ResourceNotFoundException">Thrown when the given ID doesn't match any Clifton Strengths rows</exception>
         </member>
         <member name="M:Gordon360.Services.ProfileService.GetEmergencyContact(System.String)">
             <summary> Gets the emergency contact information of a particular user </summary>

--- a/Gordon360/Models/CCT/Clifton_Strengths.cs
+++ b/Gordon360/Models/CCT/Clifton_Strengths.cs
@@ -37,5 +37,9 @@ namespace Gordon360.Models.CCT
         [StringLength(100)]
         [Unicode(false)]
         public string THEME_5 { get; set; }
+        /// <summary>
+        /// Whether the user wants their strengths to be private (not shown to other users)
+        /// </summary>
+        public bool Private { get; set; }
     }
 }

--- a/Gordon360/Models/CCT/Context/CCTContext.cs
+++ b/Gordon360/Models/CCT/Context/CCTContext.cs
@@ -143,6 +143,8 @@ namespace Gordon360.Models.CCT.Context
             {
                 entity.HasKey(e => new { e.ID_NUM, e.ACCESS_CODE })
                     .HasName("PK_CliftonStrengths");
+
+                entity.Property(e => e.Private).HasComment("Whether the user wants their strengths to be private (not shown to other users)");
             });
 
             modelBuilder.Entity<Countries>(entity =>

--- a/Gordon360/Models/ViewModels/CliftonStrengthsViewModel.cs
+++ b/Gordon360/Models/ViewModels/CliftonStrengthsViewModel.cs
@@ -1,0 +1,15 @@
+﻿using Gordon360.Models.CCT;
+using System;
+
+namespace Gordon360.Models.ViewModels
+{
+    public record CliftonStrengthsViewModel(string AccessCode, string Email, DateTime? DateCompleted, string[] Themes, bool Private)
+    {
+        public static implicit operator CliftonStrengthsViewModel?(Clifton_Strengths? cs) => cs is null ? null : new(
+            AccessCode: cs.ACCESS_CODE, 
+            Email: cs.EMAIL, 
+            DateCompleted: cs.DTE_COMPLETED,
+            Themes: new string[5] { cs.THEME_1, cs.THEME_2, cs.THEME_3, cs.THEME_4, cs.THEME_5 },
+            Private: cs.Private);
+    };
+}

--- a/Gordon360/Services/ProfileService.cs
+++ b/Gordon360/Services/ProfileService.cs
@@ -137,12 +137,30 @@ namespace Gordon360.Services
         /// <summary> Gets the clifton strengths of a particular user </summary>
         /// <param name="id"> The id of the user for which to retrieve info </param>
         /// <returns> Clifton strengths of the given user. </returns>
-        public string[] GetCliftonStrengths(int id)
+        public CliftonStrengthsViewModel? GetCliftonStrengths(int id)
         {
             return _context.Clifton_Strengths
-                .Where(c => c.ID_NUM == id)
-                .Select(s => new string[] { s.THEME_1, s.THEME_2, s.THEME_3, s.THEME_4, s.THEME_5 })
-                .FirstOrDefault() ?? Array.Empty<string>();
+                .FirstOrDefault(c => c.ID_NUM == id);
+        }
+
+        /// <summary>
+        /// Toggles the privacy of the Clifton Strengths data associated with the given id
+        /// </summary>
+        /// <param name="id">ID of the user whose Clifton Strengths privacy is toggled</param>
+        /// <returns>The new privacy value</returns>
+        /// <exception cref="ResourceNotFoundException">Thrown when the given ID doesn't match any Clifton Strengths rows</exception>
+        public async Task<bool> ToggleCliftonStrengthsPrivacyAsync(int id)
+        {
+            var strengths = _context.Clifton_Strengths.FirstOrDefault(cs => cs.ID_NUM == id);
+            if (strengths is null)
+            {
+                throw new ResourceNotFoundException { ExceptionMessage = "No Strengths found" };
+            }
+
+            strengths.Private = !strengths.Private;
+            await _context.SaveChangesAsync();
+
+            return strengths.Private;
         }
 
         /// <summary> Gets the emergency contact information of a particular user </summary>

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -21,7 +21,8 @@ namespace Gordon360.Services
         MailboxViewModel GetMailboxCombination(string username);
         DateTime GetBirthdate(string username);
         Task<IEnumerable<AdvisorViewModel>> GetAdvisorsAsync(string username);
-        string[] GetCliftonStrengths(int id);
+        CliftonStrengthsViewModel? GetCliftonStrengths(int id);
+        Task<bool> ToggleCliftonStrengthsPrivacyAsync(int id);
         IEnumerable<EmergencyContactViewModel> GetEmergencyContact(string username);
         ProfileCustomViewModel? GetCustomUserInfo(string username);
         Task<PhotoPathViewModel?> GetPhotoPathAsync(string username);


### PR DESCRIPTION
This PR adds privacy to Clifton Strengths. To do this, we need to send metadata about Clifton Strengths, whereas previously we just sent the strengths themes as an array of strings. So, I have deprecated the old GET Clifton Strengths route (it can be removed once all clients are using the new route) and added a new one that sends the appropriate metadata. Also, users need to be able to manage the privacy of their strength, so I created a new route to toggle the privacy of their Clifton Strengths.