### PR TITLE
Return appropriate epmty data, not 404.

### DIFF
--- a/Gordon360/Controllers/ProfilesController.cs
+++ b/Gordon360/Controllers/ProfilesController.cs
@@ -126,12 +126,7 @@ namespace Gordon360.Controllers
             var id = _accountService.GetAccountByUsername(username).GordonID;
             var strengths = _profileService.GetCliftonStrengths(int.Parse(id));
 
-            if (strengths is null)
-            {
-                return NotFound("No strengths were found for this user");
-            }
-
-            return Ok(strengths.Themes);
+            return Ok(strengths?.Themes ?? Array.Empty<string>());
         }
 
 
@@ -141,15 +136,10 @@ namespace Gordon360.Controllers
         [HttpGet]
         [Route("{username}/clifton")]
         [StateYourBusiness(operation = Operation.READ_ONE, resource = Resource.PROFILE)]
-        public ActionResult<CliftonStrengthsViewModel> GetCliftonStrengths(string username)
+        public ActionResult<CliftonStrengthsViewModel?> GetCliftonStrengths(string username)
         {
             var id = _accountService.GetAccountByUsername(username).GordonID;
             var strengths = _profileService.GetCliftonStrengths(int.Parse(id));
-
-            if (strengths is null)
-            {
-                return NotFound("No strengths were found for this user");
-            }
 
             return Ok(strengths);
         }


### PR DESCRIPTION
When a user doesn't have Clifton Strengths, we return null (or an empty array for the deprecated route). Returning a 404 was throwing an error in the frontend, even though we expect that not everyone has Clifton Strengths.