### PR TITLE
Fix null dining balance

### DIFF
--- a/Gordon360/Controllers/DiningController.cs
+++ b/Gordon360/Controllers/DiningController.cs
@@ -34,7 +34,7 @@ namespace Gordon360.Controllers
         {
             var sessionCode = Helpers.GetCurrentSession(_context);
             var authenticatedUsername = AuthUtils.GetUsername(User);
-            var authenticatedUserId = int.Parse(_accountService.GetAccountByUsername(authenticatedUsername)?.GordonID);
+            var authenticatedUserId = int.Parse(_accountService.GetAccountByUsername(authenticatedUsername).GordonID);
             var diningInfo = _diningService.GetDiningPlanInfo(authenticatedUserId, sessionCode);
 
             if (diningInfo == null)

--- a/Gordon360/Controllers/DiningController.cs
+++ b/Gordon360/Controllers/DiningController.cs
@@ -43,7 +43,7 @@ namespace Gordon360.Controllers
             }
             if (diningInfo.ChoiceDescription == "None")
             {
-                var diningBalance = _diningService.GetBalance(authenticatedUserId, FACSTAFF_MEALPLAN_ID);
+                var diningBalance = DiningService.GetBalance(authenticatedUserId, FACSTAFF_MEALPLAN_ID);
                 if (diningBalance == null)
                 {
                     return NotFound();

--- a/Gordon360/Services/DiningService.cs
+++ b/Gordon360/Services/DiningService.cs
@@ -73,7 +73,7 @@ namespace Gordon360.Services
         /// <param name="cardHolderID"></param>
         /// <param name="planID"></param>
         /// <returns></returns>
-        public string GetBalance(int cardHolderID, string planID)
+        public static string GetBalance(int cardHolderID, string planID)
         {
             string balance = "";
             try
@@ -148,17 +148,13 @@ namespace Gordon360.Services
                     PlanDescriptions = d.PlanDescriptions,
                     PlanId = d.PlanId,
                     PlanType = d.PlanType,
-                    InitialBalance = d.InitialBalance ?? 0
+                    InitialBalance = d.InitialBalance ?? 0,
+                    CurrentBalance = GetBalance(cardHolderID, d.PlanId)
                 });
 
             if (result == null)
             {
                 throw new ResourceNotFoundException() { ExceptionMessage = "The plan was not found." };
-            }
-
-            foreach (var row in result)
-            {
-                row.CurrentBalance = GetBalance(cardHolderID, row.PlanId);
             }
 
             return new DiningViewModel(result);

--- a/Gordon360/Services/DiningService.cs
+++ b/Gordon360/Services/DiningService.cs
@@ -75,9 +75,9 @@ namespace Gordon360.Services
         /// <returns></returns>
         public static string GetBalance(int cardHolderID, string planID)
         {
-            string balance = "";
             try
             {
+
                 ServicePointManager.Expect100Continue = false;
 
                 WebRequest request = WebRequest.Create("https://bbapi.campuscardcenter.com/cs/api/mealplanDrCr");
@@ -87,13 +87,7 @@ namespace Gordon360.Services
                 string timestamp = getTimestamp();
 
                 // Create POST data and convert it to a byte array.  
-                string postData = "issuerId=" + issuerID + "&"
-                   + "cardholderId=" + cardHolderID + "&"
-                   + "planId=" + planID + "&"
-                   + "applicationId=" + applicationId + "&"
-                   + "valueCmd=bal" + "&" + "value=0" + "&"
-                   + "timestamp=" + timestamp + "&"
-                   + "hash=" + getHash(cardHolderID, planID, timestamp);
+                string postData = $"issuerId={issuerID}&cardholderId={cardHolderID}&planId={planID}&applicationId={applicationId}&valueCmd=bal&value=0&timestamp={timestamp}&hash={getHash(cardHolderID, planID, timestamp)}";
                 byte[] byteArray = Encoding.UTF8.GetBytes(postData);
 
                 request.ContentType = "application/x-www-form-urlencoded";
@@ -114,7 +108,7 @@ namespace Gordon360.Services
                 StreamReader reader = new StreamReader(dataStream);
                 string responseFromServer = reader.ReadToEnd();
                 JObject json = JObject.Parse(responseFromServer);
-                balance = json["balance"].ToString();
+                string balance = json["balance"].ToString();
 
                 // Display the content.  
                 Console.WriteLine(responseFromServer);
@@ -124,13 +118,12 @@ namespace Gordon360.Services
                 reader.Close();
                 dataStream.Close();
                 response.Close();
+                return balance;
             }
             catch
             {
-                balance = "0";
+                return "0";
             }
-
-            return balance;
         }
 
         /// <summary>

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -53,7 +53,6 @@ namespace Gordon360.Services
     public interface IDiningService
     {
         DiningViewModel GetDiningPlanInfo(int id, string sessionCode);
-        string GetBalance(int cardHolderID, string planID);
     }
 
     public interface IAccountService


### PR DESCRIPTION
The Dining Service was returning a null balance for students because, after retrieving their balance, it was attempting to mutate the DiningInfoViewModel to update the CurrentBalance property, but this change wasn't affecting the collection returned by the Service. I have fixed the issue by making GetBalance a static method (which it already should've been since it doesn't depend on any instance methods), and calling it in the Select that produces the collection, thereby avoiding mutation entirely.