### PR TITLE
Fix conversion from `FINALIZATION_GETHOLDSBYIDResult` to `AcademicCheckInViewModel`

### DIFF
--- a/Gordon360/Services/AcademicCheckInService.cs
+++ b/Gordon360/Services/AcademicCheckInService.cs
@@ -115,7 +115,20 @@ namespace Gordon360.Services
                 throw new ResourceNotFoundException() { ExceptionMessage = "The data was not found." };
             }
 
-            return (IEnumerable<AcademicCheckInViewModel>)result;
+            return result.Select(x => new AcademicCheckInViewModel
+            {
+                FinancialHold = x.FinancialHold ?? false,
+                HighSchoolHold = x.HighSchoolHold ?? false,
+                MedicalHold = x.MedicalHold ?? false,
+                MajorHold = x.MajorHold ?? false,
+                RegistrarHold = x.RegistrarHold ?? false,
+                LaVidaHold = x.LaVidaHold ?? false,
+                MustRegisterForClasses = x.MustRegisterForClasses ?? false,
+                NewStudent = x.NewStudent,
+                FinancialHoldText = x.FinancialHoldText,
+                MeetingDate = x.MeetingDate,
+                MeetingLocations = x.MeetingLocations
+            });
         }
 
         /// <summary> Sets the user as having been checked in </summary>


### PR DESCRIPTION
Replaced cast with `Select()` to transform `FINALIZATION_GETHOLDSBYIDResult` into `AcademicCheckInViewModel`. Apparently, explicit casts are not safe and may generate runtime errors (which is what is happening in this case). We now perform an explicit Select, which actually succeeds and returns good data.