### PR TITLE
Fix faculty course schedules

### DIFF
--- a/Gordon360/Services/ScheduleService.cs
+++ b/Gordon360/Services/ScheduleService.cs
@@ -73,7 +73,21 @@ namespace Gordon360.Services
             var sessionCode = Helpers.GetCurrentSession(_context);
             var result = await _context.Procedures.INSTRUCTOR_COURSES_BY_ID_NUM_AND_SESS_CDEAsync(int.Parse(account.gordon_id), sessionCode);
 
-            return (IEnumerable<ScheduleViewModel>)result;
+            return result.Select(x => new ScheduleViewModel
+            {
+                ID_NUM = x.ID_NUM ?? default,
+                CRS_CDE = x.CRS_CDE,
+                CRS_TITLE = x.CRS_TITLE,
+                BLDG_CDE = x.BLDG_CDE,
+                ROOM_CDE = x.ROOM_CDE,
+                MONDAY_CDE = x.MONDAY_CDE,
+                TUESDAY_CDE = x.TUESDAY_CDE,
+                WEDNESDAY_CDE = x.WEDNESDAY_CDE,
+                THURSDAY_CDE = x.THURSDAY_CDE,
+                FRIDAY_CDE = x.FRIDAY_CDE,
+                BEGIN_TIME = x.BEGIN_TIME,
+                END_TIME = x.END_TIME
+            });
         }
     }
 }


### PR DESCRIPTION
Faculty Schedules were appearing as empty on 360 because a bad cast was causing the API to error. I have replaced the cast with an explicit Select, which works nicely.