### PR TITLE
Allow users to view their own memberships

### DIFF
--- a/Gordon360/Controllers/MembershipsController.cs
+++ b/Gordon360/Controllers/MembershipsController.cs
@@ -221,7 +221,7 @@ namespace Gordon360.Controllers
             var authenticatedUserUsername = AuthUtils.GetUsername(User);
             var viewerGroups = AuthUtils.GetGroups(User);
 
-            if (viewerGroups.Contains(AuthGroup.SiteAdmin) || viewerGroups.Contains(AuthGroup.Police))              //super admin and gordon police reads all
+            if (username == authenticatedUserUsername || viewerGroups.Contains(AuthGroup.SiteAdmin) || viewerGroups.Contains(AuthGroup.Police))              //super admin and gordon police reads all
                 return Ok(result);
             else
             {


### PR DESCRIPTION
Somehow, I broke the memberships controller so that users wouldn't see their own memberships that were private (or on a private involvement) unless they were a site admin or Police. This PR makes it so that users can see all their own memberships, as intended.