### PR TITLE
Perform quick search in parallel, centralize search logic, and misc search cleanup

### DIFF
--- a/Gordon360/Controllers/AccountsController.cs
+++ b/Gordon360/Controllers/AccountsController.cs
@@ -83,17 +83,13 @@ namespace Gordon360.Controllers
         {
             var accounts = await _accountService.GetAllBasicInfoExceptAlumniAsync();
 
-            var matches = new ConcurrentDictionary<string, BasicInfoViewModel>();
+            var searchResults = accounts.AsParallel()
+                .Select(account => (matchKey: account.MatchSearch(searchString), account))
+                .Where(pair => pair.matchKey is not null)
+                .OrderBy(pair => pair.matchKey)
+                .Select(pair => pair.account);
 
-            Parallel.ForEach(accounts, account =>
-            {
-                if (account.MatchSearch(searchString) is string sortKey)
-                {
-                    while (!matches.TryAdd(sortKey, account)) sortKey += "1";
-                }
-            });
-
-            return Ok(matches.OrderBy(pair => pair.Key).Select(pair => pair.Value));
+            return Ok(searchResults);
         }
 
         /// <summary>
@@ -109,16 +105,13 @@ namespace Gordon360.Controllers
         {
             var accounts = await _accountService.GetAllBasicInfoExceptAlumniAsync();
 
-            var matches = new ConcurrentDictionary<string, BasicInfoViewModel>();
-            Parallel.ForEach(accounts, account =>
-            {
-                if (account.MatchSearch(firstnameSearch, lastnameSearch) is string sortKey)
-                {
-                    while (!matches.TryAdd(sortKey, account)) sortKey += "1";
-                }
-            });
+            var searchResults = accounts.AsParallel()
+                .Select(account => (matchKey: account.MatchSearch(firstnameSearch, lastnameSearch), account))
+                .Where(pair => pair.matchKey is not null)
+                .OrderBy(pair => pair.matchKey)
+                .Select(pair => pair.account);
 
-            return Ok(matches.OrderBy(pair => pair.Key).Select(pair => pair.Value));
+            return Ok(searchResults);
         }
 
         /// <summary>

--- a/Gordon360/Controllers/AccountsController.cs
+++ b/Gordon360/Controllers/AccountsController.cs
@@ -87,10 +87,9 @@ namespace Gordon360.Controllers
 
             Parallel.ForEach(accounts, account =>
             {
-                if (account.MatchSearch(searchString) is (string match, int precedence))
+                if (account.MatchSearch(searchString) is string sortKey)
                 {
-                    var key = GenerateKey(match, precedence);
-                    while (!matches.TryAdd(key, account)) key += "1";
+                    while (!matches.TryAdd(sortKey, account)) sortKey += "1";
                 }
             });
 
@@ -113,14 +112,9 @@ namespace Gordon360.Controllers
             var matches = new ConcurrentDictionary<string, BasicInfoViewModel>();
             Parallel.ForEach(accounts, account =>
             {
-                if (account.MatchSearch(firstnameSearch, lastnameSearch) is
-                    (string firstnameMatch,
-                     int    firstnamePrecedence,
-                     string lastnameMatch,
-                     int    lastnamePrecedence))
+                if (account.MatchSearch(firstnameSearch, lastnameSearch) is string sortKey)
                 {
-                    string key = GenerateKey(firstnameMatch, lastnameMatch, firstnamePrecedence + lastnamePrecedence);
-                    while (!matches.TryAdd(key, account)) key += "1";
+                    while (!matches.TryAdd(sortKey, account)) sortKey += "1";
                 }
             });
 
@@ -168,57 +162,22 @@ namespace Gordon360.Controllers
                 accountTypes.Remove("student");
             }
 
-            var searchResults = _accountService.AdvancedSearch(
-                accountTypes,
-                firstname?.ToLower() ?? "",
-                lastname?.ToLower() ?? "",
-                major ?? "",
-                minor ?? "",
-                hall ?? "",
-                classType ?? "",
-                homeCity?.ToLower() ?? "",
-                state ?? "",
-                country ?? "",
-                department ?? "",
-                building ?? "");
+            var searchResults = _accountService.AdvancedSearch(accountTypes,
+                                                               firstname?.ToLower() ?? "",
+                                                               lastname?.ToLower() ?? "",
+                                                               major ?? "",
+                                                               minor ?? "",
+                                                               hall ?? "",
+                                                               classType ?? "",
+                                                               homeCity?.ToLower() ?? "",
+                                                               state ?? "",
+                                                               country ?? "",
+                                                               department ?? "",
+                                                               building ?? "");
 
 
             // Return all of the profile views
             return Ok(searchResults);
-        }
-
-        /// <Summary>
-        ///   This function generates a key for each account
-        ///   The key is of the form "z...keyBase" where z is repeated precedence times.
-        /// </Summary>
-        /// <remarks>
-        ///   The leading precedence number of z's are used to put keep the highest precedence matches first.
-        ///   The keyBase is used to sort within the precedence level.
-        /// </remarks>
-        ///
-        /// <param name="keyBase">The base value to use for the key - i.e. the user's highest precedence info that matches the search string</param>
-        /// <param name="precedence">Set where in the dictionary this key group will be ordered</param>
-        private static string GenerateKey(string keyBase, int precedence)
-        {
-            return string.Concat(Enumerable.Repeat("z", precedence)) + keyBase;
-        }
-
-
-        /// <Summary>
-        ///   This function generates a key for each account
-        ///   The key is of the form "z...firstname1lastname" where z is repeated precedence times.
-        /// </Summary>
-        /// <remarks>
-        ///   The leading precedence number of z's are used to put keep the highest precedence matches first.
-        ///   The keyBase is used to sort within the precedence level.
-        /// </remarks>
-        ///
-        /// <param name="firstnameKey">The firstname value to use for the key - i.e. the user's highest precedence firstname info that matches the search string</param>
-        /// <param name="lastnameKey">The lastname value to use for the key - i.e. the user's highest precedence lastname info that matches the search string</param>
-        /// <param name="precedence">Set where in the dictionary this key group will be ordered</param>
-        private static string GenerateKey(string firstnameKey, string lastnameKey, int precedence)
-        {
-            return string.Concat(Enumerable.Repeat("z", precedence)) + $"{firstnameKey}1${lastnameKey}";
         }
     }
 }

--- a/Gordon360/Controllers/AccountsController.cs
+++ b/Gordon360/Controllers/AccountsController.cs
@@ -1,10 +1,8 @@
 using Gordon360.Authorization;
-using Gordon360.Models.CCT.Context;
 using Gordon360.Models.ViewModels;
 using Gordon360.Services;
 using Gordon360.Static.Names;
 using Microsoft.AspNetCore.Mvc;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -52,31 +50,10 @@ namespace Gordon360.Controllers
         }
 
         /// <summary>
-        /// Return a list of accounts matching some or all of the search parameter
+        /// Return a list of accounts matching some or all of <c>searchString</c>.
         /// </summary>
-        /// 
-        /// 
-        /// Full Explanation:
-        /// 
-        /// Returns a list of accounts ordered by key of a combination of users first/last/user name in the following order
-        ///     1.first or last name begins with search query,
-        ///     2.first or last name in Username that begins with search query
-        ///     3.first or last name that contains the search query
-        ///     
-        /// If Full Names of any two accounts are the same the follow happens to the dictionary key to solve this problem
-        ///     1. If there is a number attached to their account this is appened to the end of their key
-        ///     2. Otherwise an '1' is appended to the end
-        ///     
-        /// Note:
-        /// A '1' is added inbetween a key's first and last name or first and last username in order to preserve the presedence set by shorter names
-        /// as both first and last are used as a part of the key in order to order matching first/last names with the remaining part of their name
-        /// but this resulted in the presedence set by shorter names to be lost
-        /// 
-        /// Note:
-        /// "z" s are added in order to keep each case split into each own group in the dictionary
-        /// 
-        /// <param name="searchString"> The input to search for </param>
-        /// <returns> All accounts meeting some or all of the parameter</returns>
+        /// <param name="searchString">The input to search for</param>
+        /// <returns>All accounts meeting some or all of the parameter, sorted according to how well the account matched the search.</returns>
         [HttpGet]
         [Route("search/{searchString}")]
         public async Task<ActionResult<IEnumerable<BasicInfoViewModel>>> SearchAsync(string searchString)
@@ -93,12 +70,11 @@ namespace Gordon360.Controllers
         }
 
         /// <summary>
-        /// Return a list of accounts matching some or all of the search parameter
-        /// We are searching through a concatonated string, containing several pieces of info about each user.
+        /// Return a list of accounts matching some or all of the search parameter.
         /// </summary>
-        /// <param name="firstnameSearch"> The firstname portion of the search</param>
-        /// <param name="lastnameSearch"> The lastname portion of the search</param>
-        /// <returns> All accounts matching some or all of both the firstname and lastname parameters</returns>
+        /// <param name="firstnameSearch">The firstname portion of the search</param>
+        /// <param name="lastnameSearch">The lastname portion of the search</param>
+        /// <returns> All accounts matching some or all of both the firstname and lastname parameters, sorted by how well the account matched the search.</returns>
         [HttpGet]
         [Route("search/{firstnameSearch}/{lastnameSearch}")]
         public async Task<ActionResult<IEnumerable<BasicInfoViewModel>>> SearchWithSpaceAsync(string firstnameSearch, string lastnameSearch)

--- a/Gordon360/Controllers/AccountsController.cs
+++ b/Gordon360/Controllers/AccountsController.cs
@@ -116,7 +116,7 @@ namespace Gordon360.Controllers
                 if (account.MatchSearch(firstnameSearch, lastnameSearch) is
                     (string firstnameMatch,
                      int    firstnamePrecedence,
-                        string lastnameMatch,
+                     string lastnameMatch,
                      int    lastnamePrecedence))
                 {
                     string key = GenerateKey(firstnameMatch, lastnameMatch, firstnamePrecedence + lastnamePrecedence);
@@ -148,17 +148,17 @@ namespace Gordon360.Controllers
         [Route("advanced-people-search")]
         public async Task<ActionResult<IEnumerable<AdvancedSearchViewModel>>> AdvancedPeopleSearchAsync(
             [FromQuery] List<string> accountTypes,
-            string? firstname = "",
-            string? lastname = "",
-            string? major = "",
-            string? minor = "",
-            string? hall = "",
-            string? classType = "",
-            string? homeCity = "",
-            string? state = "",
-            string? country = "",
-            string? department = "",
-            string? building = "")
+            string? firstname,
+            string? lastname,
+            string? major,
+            string? minor,
+            string? hall,
+            string? classType,
+            string? homeCity,
+            string? state,
+            string? country,
+            string? department,
+            string? building)
         {
             var viewerGroups = AuthUtils.GetGroups(User);
 
@@ -168,18 +168,19 @@ namespace Gordon360.Controllers
                 accountTypes.Remove("student");
             }
 
-            var searchResults = _accountService.AdvancedSearch(accountTypes,
-                                                               firstname?.ToLower(),
-                                                               lastname?.ToLower(),
-                                                               major,
-                                                               minor,
-                                                               hall,
-                                                               classType,
-                                                               homeCity?.ToLower(),
-                                                               state,
-                                                               country,
-                                                               department,
-                                                               building);
+            var searchResults = _accountService.AdvancedSearch(
+                accountTypes,
+                firstname?.ToLower() ?? "",
+                lastname?.ToLower() ?? "",
+                major ?? "",
+                minor ?? "",
+                hall ?? "",
+                classType ?? "",
+                homeCity?.ToLower() ?? "",
+                state ?? "",
+                country ?? "",
+                department ?? "",
+                building ?? "");
 
 
             // Return all of the profile views

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -40,40 +40,18 @@
         </member>
         <member name="M:Gordon360.Controllers.AccountsController.SearchAsync(System.String)">
             <summary>
-            Return a list of accounts matching some or all of the search parameter
+            Return a list of accounts matching some or all of <c>searchString</c>.
             </summary>
-            
-            
-            Full Explanation:
-            
-            Returns a list of accounts ordered by key of a combination of users first/last/user name in the following order
-                1.first or last name begins with search query,
-                2.first or last name in Username that begins with search query
-                3.first or last name that contains the search query
-                
-            If Full Names of any two accounts are the same the follow happens to the dictionary key to solve this problem
-                1. If there is a number attached to their account this is appened to the end of their key
-                2. Otherwise an '1' is appended to the end
-                
-            Note:
-            A '1' is added inbetween a key's first and last name or first and last username in order to preserve the presedence set by shorter names
-            as both first and last are used as a part of the key in order to order matching first/last names with the remaining part of their name
-            but this resulted in the presedence set by shorter names to be lost
-            
-            Note:
-            "z" s are added in order to keep each case split into each own group in the dictionary
-            
-            <param name="searchString"> The input to search for </param>
-            <returns> All accounts meeting some or all of the parameter</returns>
+            <param name="searchString">The input to search for</param>
+            <returns>All accounts meeting some or all of the parameter, sorted according to how well the account matched the search.</returns>
         </member>
         <member name="M:Gordon360.Controllers.AccountsController.SearchWithSpaceAsync(System.String,System.String)">
             <summary>
-            Return a list of accounts matching some or all of the search parameter
-            We are searching through a concatonated string, containing several pieces of info about each user.
+            Return a list of accounts matching some or all of the search parameter.
             </summary>
-            <param name="firstnameSearch"> The firstname portion of the search</param>
-            <param name="lastnameSearch"> The lastname portion of the search</param>
-            <returns> All accounts matching some or all of both the firstname and lastname parameters</returns>
+            <param name="firstnameSearch">The firstname portion of the search</param>
+            <param name="lastnameSearch">The lastname portion of the search</param>
+            <returns> All accounts matching some or all of both the firstname and lastname parameters, sorted by how well the account matched the search.</returns>
         </member>
         <member name="M:Gordon360.Controllers.AccountsController.AdvancedPeopleSearchAsync(System.Collections.Generic.List{System.String},System.String,System.String,System.String,System.String,System.String,System.String,System.String,System.String,System.String,System.String,System.String)">
             <summary>
@@ -93,33 +71,6 @@
             <param name="department"></param>   
             <param name="building"></param>     
             <returns> All accounts meeting some or all of the parameter</returns>
-        </member>
-        <member name="M:Gordon360.Controllers.AccountsController.GenerateKey(System.String,System.Int32)">
-             <Summary>
-               This function generates a key for each account
-               The key is of the form "z...keyBase" where z is repeated precedence times.
-             </Summary>
-             <remarks>
-               The leading precedence number of z's are used to put keep the highest precedence matches first.
-               The keyBase is used to sort within the precedence level.
-             </remarks>
-            
-             <param name="keyBase">The base value to use for the key - i.e. the user's highest precedence info that matches the search string</param>
-             <param name="precedence">Set where in the dictionary this key group will be ordered</param>
-        </member>
-        <member name="M:Gordon360.Controllers.AccountsController.GenerateKey(System.String,System.String,System.Int32)">
-             <Summary>
-               This function generates a key for each account
-               The key is of the form "z...firstname1lastname" where z is repeated precedence times.
-             </Summary>
-             <remarks>
-               The leading precedence number of z's are used to put keep the highest precedence matches first.
-               The keyBase is used to sort within the precedence level.
-             </remarks>
-            
-             <param name="firstnameKey">The firstname value to use for the key - i.e. the user's highest precedence firstname info that matches the search string</param>
-             <param name="lastnameKey">The lastname value to use for the key - i.e. the user's highest precedence lastname info that matches the search string</param>
-             <param name="precedence">Set where in the dictionary this key group will be ordered</param>
         </member>
         <member name="M:Gordon360.Controllers.ActivitiesController.GetActivitiesForSessionAsync(System.String)">
             <summary>Gets the activities taking place during a given session</summary>
@@ -1000,6 +951,73 @@
             <summary>
             a job&apos;s unique id number
             </summary>
+        </member>
+        <member name="M:Gordon360.Models.ViewModels.BasicInfoViewModel.MatchSearch(System.String)">
+            <summary>
+            Matches basic info fields against <c>search</c>, returning a match key representing the value and precedence of the first match, or <c>null</c>.
+            </summary>
+            
+            <remarks>
+            The match key is leading 'z's equal to the precedence of the match, followed by the matched field.
+            This key, when used to sort aplhabetically, will sort matched accounts by the precedence of the matched field and alphabetically within precedence level.
+            The precedence of a match is determined by the following, in order:
+            <list type="number">
+            <item><description>How the search matches the field</description>
+                <list type="number">
+                    <item><description>Equals</description></item>
+                    <item><description>Starts With</description></item>
+                    <item><description>Contains</description></item>
+                </list>
+            </item>
+            <item><description>Which field the search matches</description>
+                <list type="number">
+                    <item><description>FirstName</description></item>
+                    <item><description>NickName</description></item>
+                    <item><description>LastName</description></item>
+                    <item><description>MaidenName</description></item>
+                    <item><description>UserName</description></item>
+                </list>
+            </item>
+            </list>
+            
+            </remarks>
+            
+            <param name="search">The search input to match against</param>
+            <returns>The match key if <c>search</c> matched a field, or <c>null</c></returns>
+        </member>
+        <member name="M:Gordon360.Models.ViewModels.BasicInfoViewModel.MatchSearch(System.String,System.String)">
+            <summary>
+            Matches basic info fields against the first and last names of a search, returning a match key representing the value and precedence of the first match, or <c>null</c>.
+            </summary>
+            
+            <remarks>
+            The match key is leading 'z's equal to the precedence of both matches, followed by the matched fields (first then last), separated by a '1' to sort short first names above longer first names.
+            This key, when used to sort aplhabetically, will sort matched accounts by the precedence of the matched field and alphabetically within precedence level.
+            The precedence of a match is determined by the following, in order:
+            <list type="number">
+            <item><description>How the search matches the field</description>
+                <list type="number">
+                    <item><description>Equals</description></item>
+                    <item><description>Starts With</description></item>
+                    <item><description>Contains</description></item>
+                </list>
+            </item>
+            <item><description>Which field the search matches</description>
+                <list type="number">
+                    <item><description>FirstName</description></item>
+                    <item><description>NickName</description></item>
+                    <item><description>LastName</description></item>
+                    <item><description>MaidenName</description></item>
+                    <item><description>UserName</description></item>
+                </list>
+            </item>
+            </list>
+            
+            </remarks>
+            
+            <param name="firstnameSearch">The first name of the search input to match against</param>
+            <param name="lastnameSearch">The last name of the search input to match against</param>
+            <returns>The match key if first and last name both matched a field, or <c>null</c></returns>
         </member>
         <member name="T:Gordon360.Services.AcademicCheckInService">
             <summary>

--- a/Gordon360/Models/ViewModels/BasicInfoViewModel.cs
+++ b/Gordon360/Models/ViewModels/BasicInfoViewModel.cs
@@ -8,7 +8,6 @@ namespace Gordon360.Models.ViewModels
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public string UserName { get; set; }
-        public string ConcatonatedInfo { get; set; }
         public string Nickname { get; set; }
         public string MaidenName { get; set; }
 

--- a/Gordon360/Models/ViewModels/BasicInfoViewModel.cs
+++ b/Gordon360/Models/ViewModels/BasicInfoViewModel.cs
@@ -11,22 +11,7 @@ namespace Gordon360.Models.ViewModels
         public string Nickname { get; set; }
         public string MaidenName { get; set; }
 
-        public static implicit operator BasicInfoViewModel(ACCOUNT a)
-        {
-            BasicInfoViewModel vm = new BasicInfoViewModel
-            {
-                FirstName = a.firstname,
-                LastName = a.lastname,
-                UserName = a.AD_Username ?? "",
-                ConcatonatedInfo = "",
-                Nickname = "",
-                MaidenName = ""
-            };
-
-            return vm;
-        }
-
-        private bool FirstNameMatches(string matchString)
+        private bool FirstNameEquals(string matchString)
         {
             return FirstName?.ToLower() == matchString;
         }
@@ -41,7 +26,7 @@ namespace Gordon360.Models.ViewModels
             return FirstName?.ToLower()?.Contains(searchString) ?? false;
         }
 
-        private bool LastNameMatches(string matchString)
+        private bool LastNameEquals(string matchString)
         {
             return LastName?.ToLower() == matchString;
         }
@@ -81,7 +66,7 @@ namespace Gordon360.Models.ViewModels
             return UserName.Contains('.') ? UserName?.Split('.')?[1] ?? "" : "";
         }
 
-        private bool NicknameMatches(string matchString)
+        private bool NicknameEquals(string matchString)
         {
             return Nickname?.ToLower() == matchString;
         }
@@ -96,7 +81,7 @@ namespace Gordon360.Models.ViewModels
             return Nickname?.ToLower().Contains(searchString) ?? false;
         }
 
-        private bool MaidenNameMatches(string matchString)
+        private bool MaidenNameEquals(string matchString)
         {
             return MaidenName?.ToLower() == matchString;
         }

--- a/Gordon360/Models/ViewModels/BasicInfoViewModel.cs
+++ b/Gordon360/Models/ViewModels/BasicInfoViewModel.cs
@@ -26,89 +26,145 @@ namespace Gordon360.Models.ViewModels
             return vm;
         }
 
-        public bool FirstNameMatches(string matchString)
+        private bool FirstNameMatches(string matchString)
         {
             return FirstName?.ToLower() == matchString;
         }
 
-        public bool FirstNameStartsWith(string searchString)
+        private bool FirstNameStartsWith(string searchString)
         {
             return FirstName?.ToLower()?.StartsWith(searchString) ?? false;
         }
 
-        public bool FirstNameContains(string searchString)
+        private bool FirstNameContains(string searchString)
         {
             return FirstName?.ToLower()?.Contains(searchString) ?? false;
         }
 
-        public bool LastNameMatches(string matchString)
+        private bool LastNameMatches(string matchString)
         {
             return LastName?.ToLower() == matchString;
         }
 
-        public bool LastNameStartsWith(string searchString)
+        private bool LastNameStartsWith(string searchString)
         {
             return LastName?.ToLower()?.StartsWith(searchString) ?? false;
         }
 
-        public bool LastNameContains(string searchString)
+        private bool LastNameContains(string searchString)
         {
             return LastName?.ToLower()?.Contains(searchString) ?? false;
         }
 
-        public bool UsernameFirstNameStartsWith(string searchString)
+        private bool UsernameFirstNameStartsWith(string searchString)
         {
             return GetFirstNameFromUsername()?.StartsWith(searchString) ?? false;
         }
 
-        public bool UsernameLastNameStartsWith(string searchString)
+        private bool UsernameLastNameStartsWith(string searchString)
         {
             return GetLastNameFromUsername()?.StartsWith(searchString) ?? false;
         }
 
-        public bool UsernameContains(string searchString)
+        private bool UsernameContains(string searchString)
         {
             return UserName?.ToLower()?.Contains(searchString) ?? false;
         }
 
-        public string GetFirstNameFromUsername()
+        private string GetFirstNameFromUsername()
         {
-            return UserName?.Split('.')?[0];
+            return UserName?.Split('.')?[0] ?? "";
         }
 
-        public string GetLastNameFromUsername()
+        private string GetLastNameFromUsername()
         {
-            return UserName.Contains('.') ? UserName?.Split('.')?[1] : null;
+            return UserName.Contains('.') ? UserName?.Split('.')?[1] ?? "" : "";
         }
 
-        public bool NicknameMatches(string matchString)
+        private bool NicknameMatches(string matchString)
         {
             return Nickname?.ToLower() == matchString;
         }
 
-        public bool NicknameStartsWith(string searchString)
+        private bool NicknameStartsWith(string searchString)
         {
             return Nickname?.ToLower().StartsWith(searchString) ?? false;
         }
 
-        public bool NicknameContains(string searchString)
+        private bool NicknameContains(string searchString)
         {
             return Nickname?.ToLower().Contains(searchString) ?? false;
         }
 
-        public bool MaidenNameMatches(string matchString)
+        private bool MaidenNameMatches(string matchString)
         {
             return MaidenName?.ToLower() == matchString;
         }
 
-        public bool MaidenNameStartsWith(string searchString)
+        private bool MaidenNameStartsWith(string searchString)
         {
             return MaidenName?.ToLower().StartsWith(searchString) ?? false;
         }
 
-        public bool MaidenNameContains(string searchString)
+        private bool MaidenNameContains(string searchString)
         {
             return MaidenName?.ToLower().Contains(searchString) ?? false;
+        }
+
+        public (string matchedValue, int precedence)? MatchSearch(string search)
+        {
+            return this switch
+            {
+                _ when FirstNameMatches(search) => (FirstName, 0),
+                _ when NicknameMatches(search) => (Nickname, 1),
+                _ when LastNameMatches(search) => (LastName, 2),
+                _ when MaidenNameMatches(search) => (MaidenName, 3),
+                _ when FirstNameStartsWith(search) => (FirstName, 4),
+                _ when NicknameStartsWith(search) => (Nickname, 5),
+                _ when LastNameStartsWith(search) => (LastName, 6),
+                _ when MaidenNameStartsWith(search) => (MaidenName, 7),
+                _ when UsernameFirstNameStartsWith(search) => (GetFirstNameFromUsername(), 8),
+                _ when UsernameLastNameStartsWith(search) => (GetLastNameFromUsername(), 9),
+                _ when FirstNameContains(search) => (FirstName, 10),
+                _ when NicknameContains(search) => (Nickname, 11),
+                _ when LastNameContains(search) => (LastName, 12),
+                _ when MaidenNameContains(search) => (MaidenName, 13),
+                _ when UsernameContains(search) => (UserName, 14),
+                _ => null
+            };
+        }
+
+        public (string firstnameMatch, int firstnamePrecedence, string lastnameMatch, int lastnamePrecedence)? MatchSearch(string firstnameSearch, string lastnameSearch)
+        {
+            (string, int)? firstname = this switch
+            {
+                _ when FirstNameMatches(firstnameSearch) => (FirstName, 0),
+                _ when NicknameMatches(firstnameSearch) => (Nickname, 1),
+                _ when FirstNameStartsWith(firstnameSearch) => (FirstName, 4),
+                _ when NicknameStartsWith(firstnameSearch) => (Nickname, 5),
+                _ when UsernameFirstNameStartsWith(firstnameSearch) => (GetFirstNameFromUsername(), 8),
+                _ when FirstNameContains(firstnameSearch) => (FirstName, 10),
+                _ when NicknameContains(firstnameSearch) => (Nickname, 11),
+                _ => null
+            };
+
+            if (firstname is not (string firstnameMatch, int firstnamePrecedence)) return null;
+
+            (string, int)? lastname = this switch
+            {
+                _ when LastNameMatches(lastnameSearch) => (LastName, 2),
+                _ when MaidenNameMatches(lastnameSearch) => (MaidenName, 3),
+                _ when LastNameStartsWith(lastnameSearch) => (LastName, 6),
+                _ when MaidenNameStartsWith(lastnameSearch) => (MaidenName, 7),
+                _ when UsernameLastNameStartsWith(lastnameSearch) => (GetLastNameFromUsername(), 9),
+                _ when LastNameContains(lastnameSearch) => (LastName, 12),
+                _ when MaidenNameContains(lastnameSearch) => (MaidenName, 13),
+                _ => null
+            };
+
+            if (lastname is not (string lastnameMatch, int lastnamePrecedence)) return null;
+
+            return (firstnameMatch, firstnamePrecedence, lastnameMatch, lastnamePrecedence);
         }
     }
 }

--- a/Gordon360/Models/ViewModels/BasicInfoViewModel.cs
+++ b/Gordon360/Models/ViewModels/BasicInfoViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using Gordon360.Models.CCT;
+using System.Linq;
 
 namespace Gordon360.Models.ViewModels
 {
@@ -111,9 +112,9 @@ namespace Gordon360.Models.ViewModels
             return MaidenName?.ToLower().Contains(searchString) ?? false;
         }
 
-        public (string matchedValue, int precedence)? MatchSearch(string search)
+        public string? MatchSearch(string search)
         {
-            return this switch
+            (string, int)? match = this switch
             {
                 _ when FirstNameMatches(search) => (FirstName, 0),
                 _ when NicknameMatches(search) => (Nickname, 1),
@@ -132,9 +133,13 @@ namespace Gordon360.Models.ViewModels
                 _ when UsernameContains(search) => (UserName, 14),
                 _ => null
             };
+
+            if (match is not (string matchedValue, int matchPrecedence)) return null;
+
+            return string.Concat(Enumerable.Repeat("z", matchPrecedence)) + matchedValue;
         }
 
-        public (string firstnameMatch, int firstnamePrecedence, string lastnameMatch, int lastnamePrecedence)? MatchSearch(string firstnameSearch, string lastnameSearch)
+        public string? MatchSearch(string firstnameSearch, string lastnameSearch)
         {
             (string, int)? firstname = this switch
             {
@@ -164,7 +169,36 @@ namespace Gordon360.Models.ViewModels
 
             if (lastname is not (string lastnameMatch, int lastnamePrecedence)) return null;
 
-            return (firstnameMatch, firstnamePrecedence, lastnameMatch, lastnamePrecedence);
+            var totalPrecedence = firstnamePrecedence + lastnamePrecedence;
+            var keyBase = $"{firstnameMatch}1${lastnameMatch}";
+
+            return string.Concat(Enumerable.Repeat("z", totalPrecedence)) + keyBase;
         }
+
+        /// <Summary>
+        ///   This function generates a key for each account
+        ///   The key is of the form "z...keyBase" where z is repeated precedence times.
+        /// </Summary>
+        /// <remarks>
+        ///   The leading precedence number of z's are used to put keep the highest precedence matches first.
+        ///   The keyBase is used to sort within the precedence level.
+        /// </remarks>
+        ///
+        /// <param name="keyBase">The base value to use for the key - i.e. the user's highest precedence info that matches the search string</param>
+        /// <param name="precedence">Set where in the dictionary this key group will be ordered</param>
+
+
+        /// <Summary>
+        ///   This function generates a key for each account
+        ///   The key is of the form "z...firstname1lastname" where z is repeated precedence times.
+        /// </Summary>
+        /// <remarks>
+        ///   The leading precedence number of z's are used to put keep the highest precedence matches first.
+        ///   The keyBase is used to sort within the precedence level.
+        /// </remarks>
+        ///
+        /// <param name="firstnameKey">The firstname value to use for the key - i.e. the user's highest precedence firstname info that matches the search string</param>
+        /// <param name="lastnameKey">The lastname value to use for the key - i.e. the user's highest precedence lastname info that matches the search string</param>
+        /// <param name="precedence">Set where in the dictionary this key group will be ordered</param>
     }
 }

--- a/Gordon360/Services/AccountService.cs
+++ b/Gordon360/Services/AccountService.cs
@@ -191,7 +191,6 @@ namespace Gordon360.Services
             return basicInfo.Select(
                 b => new BasicInfoViewModel
                 {
-                    ConcatonatedInfo = b.ConcatonatedInfo,
                     FirstName = b.FirstName,
                     LastName = b.LastName,
                     Nickname = b.Nickname,
@@ -209,7 +208,6 @@ namespace Gordon360.Services
             return basicInfo.Select(
                 b => new BasicInfoViewModel
                 {
-                    ConcatonatedInfo = b.ConcatonatedInfo,
                     FirstName = b.firstname,
                     LastName = b.lastname,
                     Nickname = b.Nickname,

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -62,17 +62,17 @@ namespace Gordon360.Services
         AccountViewModel GetAccountByEmail(string email);
         AccountViewModel GetAccountByUsername(string username);
         IEnumerable<AdvancedSearchViewModel> AdvancedSearch(List<string> accountTypes,
-                                                            string? firstname,
-                                                            string? lastname,
-                                                            string? major,
-                                                            string? minor,
-                                                            string? hall,
-                                                            string? classType,
-                                                            string? homeCity,
-                                                            string? state,
-                                                            string? country,
-                                                            string? department,
-                                                            string? building);
+                                                            string firstname,
+                                                            string lastname,
+                                                            string major,
+                                                            string minor,
+                                                            string hall,
+                                                            string classType,
+                                                            string homeCity,
+                                                            string state,
+                                                            string country,
+                                                            string department,
+                                                            string building);
         Task<IEnumerable<BasicInfoViewModel>> GetAllBasicInfoAsync();
         Task<IEnumerable<BasicInfoViewModel>> GetAllBasicInfoExceptAlumniAsync();
     }


### PR DESCRIPTION
The `accounts/search` routes perform an in-memory search of all Student, Faculty, and Staff accounts. This can be unacceptably slow for unconstrained queries (>1.5s for a search string 'a').

By performing the search in parallel (using Parallel LINQ for concise, safe parallelism), we can take full advantage of our cores, resulting in massive speed ups (1.5s query becomes a 50ms query, 36ms query becomes a 9ms query).

I benchmarked several different parallel (and non-parallel) search strategies, and this iteration of Parallel LINQ performed best in every metric.

While I was updating the search code, I took the liberty of refactoring it. We previously had a significant amount of search logic cluttering up the `AccountsController` (100 lines of single-use helper methods, plus a bunch of implementation details as XML comments). I have migrated that logic to the `BasicInfoViewModel` class, which is only used for performing this quick search functionality. I also refactored for more ergonomic code with an easier to understand flow. I updated the doc comments where needed.