### PR TITLE
[Rec-IM] Matchservice Bug Fix

### DIFF
--- a/Gordon360/Controllers/RecIM/MatchesController.cs
+++ b/Gordon360/Controllers/RecIM/MatchesController.cs
@@ -49,6 +49,13 @@ namespace Gordon360.Controllers.RecIM
             var match = _matchService.GetMatchByID(matchID);
             return Ok(match);
         }
+        [HttpGet]
+        [Route("team/{teamID}")]
+        public ActionResult<MatchViewModel> GetMatchHistoryByTeamID(int teamID)
+        {
+            var match = _matchService.GetMatchHistoryByTeamID(teamID);
+            return Ok(match);
+        }
 
         /// <summary>
         /// Updates Match Scores, Sportsmanship Ratings, and Team Status

--- a/Gordon360/Controllers/RecIM/MatchesController.cs
+++ b/Gordon360/Controllers/RecIM/MatchesController.cs
@@ -49,13 +49,6 @@ namespace Gordon360.Controllers.RecIM
             var match = _matchService.GetMatchByID(matchID);
             return Ok(match);
         }
-        [HttpGet]
-        [Route("team/{teamID}")]
-        public ActionResult<MatchViewModel> GetMatchHistoryByTeamID(int teamID)
-        {
-            var match = _matchService.GetMatchHistoryByTeamID(teamID);
-            return Ok(match);
-        }
 
         /// <summary>
         /// Updates Match Scores, Sportsmanship Ratings, and Team Status

--- a/Gordon360/Services/RecIM/MatchService.cs
+++ b/Gordon360/Services/RecIM/MatchService.cs
@@ -64,9 +64,9 @@ namespace Gordon360.Services.RecIM
                                 MatchHistory = _context.Match
                                     .Where(mh => mh.StatusID == 6)
                                         .Join(_context.MatchTeam
-                                            .Where(mt => mt.TeamID == mt.TeamID)
+                                            .Where(matchteam => matchteam.TeamID == mt.TeamID)
                                             .Join(
-                                                _context.MatchTeam,
+                                                _context.MatchTeam.Where(matchteam => matchteam.TeamID != mt.TeamID),
                                                 mt0 => mt0.MatchID,
                                                 mt1 => mt1.MatchID,
                                                 (mt0, mt1) => new
@@ -120,7 +120,7 @@ namespace Gordon360.Services.RecIM
                                 .Where(mt => mt.TeamID == teamID)
 
                                     .Join(
-                                        _context.MatchTeam,
+                                        _context.MatchTeam.Where(mt => mt.TeamID != teamID),
                                         mt0 => mt0.MatchID,
                                         mt1 => mt1.MatchID,
                                         (mt0, mt1) => new


### PR DESCRIPTION
Match History for did a query to find all MatchTeam instances and used that to create an Opponent viewmodel. However, the query did not check to ensure that your own team was not a part of that join. Updated to fix that error.