### PR TITLE
hide members who are private

### DIFF
--- a/Gordon360/Services/EmailService.cs
+++ b/Gordon360/Services/EmailService.cs
@@ -39,7 +39,7 @@ namespace Gordon360.Services
 
             var membershipService = new MembershipService(_context);
 
-            var result = membershipService.MembershipEmails(activityCode, sessionCode, participationType);
+            var result = await membershipService.MembershipEmailsAsync(activityCode, sessionCode, participationType);
 
             if (result == null)
             {

--- a/Gordon360/Services/MembershipService.cs
+++ b/Gordon360/Services/MembershipService.cs
@@ -132,6 +132,8 @@ namespace Gordon360.Services
                 memberships = memberships.Where(m => m.SessionCode.Trim() == sessionCode);
             }
 
+            memberships = memberships.Where(m => m.AccountPrivate == 0);
+
             return memberships.OrderByDescending(x => x.StartDate).Select(m => new MembershipViewModel
             {
                 MembershipID = m.MembershipID,
@@ -410,23 +412,23 @@ namespace Gordon360.Services
             return _context.MEMBERSHIP.Any(membership => membership.ID_NUM == gordonID && membership.GRP_ADMIN == true);
         }
 
-        public IEnumerable<EmailViewModel> MembershipEmails(string activityCode, string sessionCode, ParticipationType? participationCode = null)
+        public async Task<IEnumerable<EmailViewModel>> MembershipEmailsAsync(string activityCode, string sessionCode, ParticipationType? participationCode = null)
         {
-            var memberships = _context.MEMBERSHIP.Where(m => m.ACT_CDE == activityCode && m.SESS_CDE == sessionCode);
+            var memberships = await GetMembershipsForActivityAsync(activityCode);
 
             if (participationCode != null)
             {
                 if (participationCode == ParticipationType.GroupAdmin)
                 {
-                    memberships = memberships.Where(m => m.GRP_ADMIN == true);
+                    memberships = memberships.Where(m => m.GroupAdmin == true);
                 }
                 else
                 {
-                    memberships = memberships.Where(m => m.PART_CDE == participationCode.Value);
+                    memberships = memberships.Where(m => m.Participation == participationCode.Value);
                 }
             }
 
-            return memberships.Join(_context.ACCOUNT, m => m.ID_NUM.ToString(), a => a.gordon_id, (m, a) => new EmailViewModel { Email = a.email, FirstName = a.firstname, LastName = a.lastname, Description = m.COMMENT_TXT });
+            return memberships.Join(_context.ACCOUNT, m => m.IDNumber.ToString(), a => a.gordon_id, (m, a) => new EmailViewModel { Email = a.email, FirstName = a.firstname, LastName = a.lastname, Description = m.ParticipationDescription });
         }
 
         public class ParticipationType

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -191,6 +191,7 @@ namespace Gordon360.Services
         void TogglePrivacy(int membershipID, bool isPrivate);
         MEMBERSHIP Delete(int membershipID);
         bool IsGroupAdmin(int gordonID);
+        Task<IEnumerable<EmailViewModel>> MembershipEmailsAsync(string activityCode, string sessionCode, ParticipationType? participationCode);
     }
 
     public interface IJobsService


### PR DESCRIPTION
Changed the GetMembershipsForActivityAsync method to return only users who are not private. Updated methods that are affected.