### PR TITLE
[RecIM] Add Participant Notifications to Participants

### DIFF
--- a/Gordon360/Controllers/RecIM/ParticipantsController.cs
+++ b/Gordon360/Controllers/RecIM/ParticipantsController.cs
@@ -48,7 +48,6 @@ namespace Gordon360.Controllers.RecIM
             return Ok(res);
         }
 
-        //this will be handled eventually by team routes
         [HttpGet]
         [Route("{username}/teams")]
         public ActionResult<IEnumerable<TeamViewModel>> GetParticipantTeams(string username)
@@ -64,6 +63,15 @@ namespace Gordon360.Controllers.RecIM
             await _participantService.PostParticipant(participantID);
             return (Ok(participantID));
         }
+
+        [HttpPost]
+        [Route("notifications/{username}")]
+        public async Task<IActionResult> SendParticipantNotification(string username, ParticipantNotificationUploadViewModel notificationVM)
+        {
+            var res = await _participantService.SendParticipantNotification(username, notificationVM);
+            return CreatedAtAction("SendParticipantNotification", new { id = res.ID },res);
+        }
+
 
         [HttpPatch]
         [Route("{username}")]

--- a/Gordon360/Controllers/RecIM/ParticipantsController.cs
+++ b/Gordon360/Controllers/RecIM/ParticipantsController.cs
@@ -65,7 +65,7 @@ namespace Gordon360.Controllers.RecIM
         }
 
         [HttpPost]
-        [Route("notifications/{username}")]
+        [Route("{username}/notifications")]
         public async Task<IActionResult> SendParticipantNotification(string username, ParticipantNotificationUploadViewModel notificationVM)
         {
             var res = await _participantService.SendParticipantNotification(username, notificationVM);
@@ -83,7 +83,7 @@ namespace Gordon360.Controllers.RecIM
         }
 
         [HttpPatch]
-        [Route("Status/{username}")]
+        [Route("{username}/status")]
         public async Task<ActionResult> UpdateParticipantStatus(string username, ParticipantStatusPatchViewModel updatedParticipant)
         {
             await _participantService.UpdateParticipantStatus(updatedParticipant);

--- a/Gordon360/Models/ViewModels/RecIM/ParticipantNotificationUploadViewModel.cs
+++ b/Gordon360/Models/ViewModels/RecIM/ParticipantNotificationUploadViewModel.cs
@@ -1,0 +1,13 @@
+﻿using Gordon360.Models.CCT;
+using Microsoft.Graph;
+using System;
+using System.Collections.Generic;
+
+namespace Gordon360.Models.ViewModels.RecIM
+{
+    public class ParticipantNotificationUploadViewModel
+    {
+        public string Message { get; set; }
+        public DateTime EndDate { get; set; }
+    }
+}

--- a/Gordon360/Models/ViewModels/RecIM/ParticipantNotificationViewModel.cs
+++ b/Gordon360/Models/ViewModels/RecIM/ParticipantNotificationViewModel.cs
@@ -1,0 +1,23 @@
+﻿using Gordon360.Models.CCT;
+using Microsoft.Graph;
+using System;
+using System.Collections.Generic;
+
+namespace Gordon360.Models.ViewModels.RecIM
+{
+    public class ParticipantNotificationViewModel
+    {
+        public int ID { get; set; }
+        public string Message { get; set; }
+        public DateTime DispatchDate { get; set; }
+        public static implicit operator ParticipantNotificationViewModel(ParticipantNotification p)
+        {
+            return new ParticipantNotificationViewModel
+            {
+                ID = p.ID,
+                Message = p.Message,
+                DispatchDate = p.DispatchDate
+            };
+        }
+    }
+}

--- a/Gordon360/Models/ViewModels/RecIM/ParticipantViewModel.cs
+++ b/Gordon360/Models/ViewModels/RecIM/ParticipantViewModel.cs
@@ -10,7 +10,7 @@ namespace Gordon360.Models.ViewModels.RecIM
         public string Username { get; set; }
         public string Email { get; set; }
         public string? Role { get; set; }
-        public string? Status { get; set; }
+        public string Status { get; set; }
         public IEnumerable<ParticipantNotificationViewModel> Notification { get; set; } 
             = new List<ParticipantNotificationViewModel>();
 

--- a/Gordon360/Models/ViewModels/RecIM/ParticipantViewModel.cs
+++ b/Gordon360/Models/ViewModels/RecIM/ParticipantViewModel.cs
@@ -11,6 +11,8 @@ namespace Gordon360.Models.ViewModels.RecIM
         public string Email { get; set; }
         public string? Role { get; set; }
         public string? Status { get; set; }
+        public IEnumerable<ParticipantNotificationViewModel> Notification { get; set; } 
+            = new List<ParticipantNotificationViewModel>();
 
         public static implicit operator ParticipantViewModel(ACCOUNT a)
         {

--- a/Gordon360/Services/RecIM/ParticipantService.cs
+++ b/Gordon360/Services/RecIM/ParticipantService.cs
@@ -28,16 +28,9 @@ namespace Gordon360.Services.RecIM
             return _context.ACCOUNT
                         .FirstOrDefault(a => a.gordon_id == $"{ID}");
         }
-        private int GetParticipantIdByUsername(string username)
-        {
-            return Int32.Parse(_context.ACCOUNT
-                        .FirstOrDefault(a => a.AD_Username == username)
-                        .gordon_id);
-        }
-
         public ParticipantViewModel GetParticipantByUsername(string username)
         {
-            int participantID = GetParticipantIdByUsername(username);
+            int participantID = Int32.Parse(_accountService.GetAccountByUsername(username).GordonID);
             var participant = _context.Participant
                                 .Where(p => p.ID == participantID)
                                 .Select(p => new ParticipantViewModel
@@ -56,19 +49,18 @@ namespace Gordon360.Services.RecIM
                                                         (psh, ps) => ps.Description)
                                                 .FirstOrDefault(),
                                     Notification = _context.ParticipantNotification
-                                                    .Where(pn => pn.ParticipantID == participantID)
+                                                    .Where(pn => pn.ParticipantID == participantID && pn.EndDate > DateTime.Now)
                                                     .OrderByDescending(pn => pn.DispatchDate)
                                                     .Select(pn => (ParticipantNotificationViewModel)pn)
                                                     .AsEnumerable()
                                 })
                                 .FirstOrDefault();
-
             return participant;
         }
 
         public async Task<ParticipantNotification> SendParticipantNotification(string username, ParticipantNotificationUploadViewModel notificationVM)
         {
-            int participantID = GetParticipantIdByUsername(username);
+            int participantID = Int32.Parse(_accountService.GetAccountByUsername(username).GordonID);
             var newNotification = new ParticipantNotification
             {
                 ParticipantID = participantID,
@@ -82,7 +74,7 @@ namespace Gordon360.Services.RecIM
         }
         public IEnumerable<ParticipantStatusViewModel> GetParticipantStatusHistory(string username)
         {
-            int participantID = GetParticipantIdByUsername(username);
+            int participantID = Int32.Parse(_accountService.GetAccountByUsername(username).GordonID);
             var status = _context.ParticipantStatusHistory
                             .Where(psh => psh.ParticipantID == participantID)
                             .OrderByDescending(psh => psh.ID)
@@ -101,7 +93,7 @@ namespace Gordon360.Services.RecIM
         public IEnumerable<TeamViewModel> GetParticipantTeams(string username)
         {
             //to be handled by teamservice
-            int participantID = GetParticipantIdByUsername(username);
+            int participantID = Int32.Parse(_accountService.GetAccountByUsername(username).GordonID);
             var teams = _context.ParticipantTeam
                             .Where(pt => pt.ParticipantID == participantID)
                                 .Join(_context.Team,
@@ -151,7 +143,7 @@ namespace Gordon360.Services.RecIM
         }
         public async Task UpdateParticipant(ParticipantPatchViewModel updatedParticipant)
         {
-            int participantID = GetParticipantIdByUsername(updatedParticipant.Username);
+            int participantID = Int32.Parse(_accountService.GetAccountByUsername(updatedParticipant.Username).GordonID);
             if (updatedParticipant.ActivityID is not null)
             {
                 var participantActivity = _context.ParticipantActivity
@@ -180,7 +172,7 @@ namespace Gordon360.Services.RecIM
         {
             var status = new ParticipantStatusHistory
             {
-                ParticipantID = GetParticipantIdByUsername(participantStatus.Username),
+                ParticipantID = Int32.Parse(_accountService.GetAccountByUsername(participantStatus.Username).GordonID),
                 StatusID = _context.ParticipantStatus
                                 .FirstOrDefault(ps => ps.Description == participantStatus.StatusDescription)
                                 .ID,

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -347,6 +347,7 @@ namespace Gordon360.Services
             IEnumerable<TeamViewModel> GetParticipantTeams(string username);
 
             Task PostParticipant(int participantID);
+            Task<ParticipantNotification> SendParticipantNotification(string username, ParticipantNotificationUploadViewModel notificationVM);
             Task UpdateParticipant(ParticipantPatchViewModel updatedParticipant);
             Task UpdateParticipantStatus(ParticipantStatusPatchViewModel participantStatus);
         }


### PR DESCRIPTION
As the name implies, this adds a new Route for Creating Participant Notifications and will be fetched/included in the old GetParticipantByUsername route.

New Route!
HttpPost
api/recim/participants/notifications/{username}
takes ParticipantNotificationUploadViewmodel { Message: "string", EndDate: DateTime }

New return values will be implemented throughout the project but this is the starting point:
CreatedAtAction<IActionResult> will now return the entire created resource as suggested by @EjPlatzer & @bennettforkner 
