### PR TITLE
Add IsAlumni to Membership Viewmodel

### DIFF
--- a/Gordon360/Controllers/EmailsController.cs
+++ b/Gordon360/Controllers/EmailsController.cs
@@ -3,6 +3,7 @@ using Gordon360.Models.CCT.Context;
 using Gordon360.Models.ViewModels;
 using Gordon360.Services;
 using Gordon360.Static.Names;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/Gordon360/Controllers/EmailsController.cs
+++ b/Gordon360/Controllers/EmailsController.cs
@@ -3,7 +3,6 @@ using Gordon360.Models.CCT.Context;
 using Gordon360.Models.ViewModels;
 using Gordon360.Services;
 using Gordon360.Static.Names;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/Gordon360/Models/ViewModels/MembershipViewModel.cs
+++ b/Gordon360/Models/ViewModels/MembershipViewModel.cs
@@ -16,6 +16,7 @@ namespace Gordon360.Models.ViewModels
         public string AD_Username { get; set; }
         public string FirstName { get; set; }
         public string LastName { get; set; }
+        public bool? IsAlumni { get; set; }
         public string Mail_Location { get; set; }
         public string Participation { get; set; }
         public string ParticipationDescription { get; set; }

--- a/Gordon360/Services/MembershipService.cs
+++ b/Gordon360/Services/MembershipService.cs
@@ -1,4 +1,5 @@
-﻿using Gordon360.Models.CCT.Context;
+﻿using Gordon360.Authorization;
+using Gordon360.Models.CCT.Context;
 using Gordon360.Exceptions;
 using Gordon360.Models.CCT;
 using Gordon360.Models.ViewModels;
@@ -132,27 +133,31 @@ namespace Gordon360.Services
                 memberships = memberships.Where(m => m.SessionCode.Trim() == sessionCode);
             }
 
-            return memberships.OrderByDescending(x => x.StartDate).Select(m => new MembershipViewModel
+            return memberships.OrderByDescending(x => x.StartDate).Select(m =>
             {
-                MembershipID = m.MembershipID,
-                ActivityCode = m.ActivityCode.Trim(),
-                ActivityDescription = m.ActivityDescription.Trim(),
-                ActivityImagePath = m.ActivityImagePath,
-                SessionCode = m.SessionCode.Trim(),
-                SessionDescription = m.SessionDescription.Trim(),
-                IDNumber = m.IDNumber,
-                AD_Username = m.AD_Username,
-                FirstName = m.FirstName.Trim(),
-                LastName = m.LastName.Trim(),
-                IsAlumni = _context.Alumni.Any(a => a.AD_Username == m.AD_Username),
-                Mail_Location = m.Mail_Location,
-                Participation = m.Participation.Trim(),
-                ParticipationDescription = m.ParticipationDescription.Trim(),
-                StartDate = m.StartDate,
-                EndDate = m.EndDate,
-                Description = m.Description,
-                GroupAdmin = m.GroupAdmin,
-                AccountPrivate = m.AccountPrivate
+                var groups = AuthUtils.GetGroups(m.AD_Username);
+                return new MembershipViewModel
+                {
+                    MembershipID = m.MembershipID,
+                    ActivityCode = m.ActivityCode.Trim(),
+                    ActivityDescription = m.ActivityDescription.Trim(),
+                    ActivityImagePath = m.ActivityImagePath,
+                    SessionCode = m.SessionCode.Trim(),
+                    SessionDescription = m.SessionDescription.Trim(),
+                    IDNumber = m.IDNumber,
+                    AD_Username = m.AD_Username,
+                    FirstName = m.FirstName.Trim(),
+                    LastName = m.LastName.Trim(),
+                    IsAlumni = groups.Contains(AuthGroup.Alumni) && !groups.Contains(AuthGroup.Student) && !groups.Contains(AuthGroup.FacStaff),
+                    Mail_Location = m.Mail_Location,
+                    Participation = m.Participation.Trim(),
+                    ParticipationDescription = m.ParticipationDescription.Trim(),
+                    StartDate = m.StartDate,
+                    EndDate = m.EndDate,
+                    Description = m.Description,
+                    GroupAdmin = m.GroupAdmin,
+                    AccountPrivate = m.AccountPrivate
+                };
             });
         }
 

--- a/Gordon360/Services/MembershipService.cs
+++ b/Gordon360/Services/MembershipService.cs
@@ -144,6 +144,7 @@ namespace Gordon360.Services
                 AD_Username = m.AD_Username,
                 FirstName = m.FirstName.Trim(),
                 LastName = m.LastName.Trim(),
+                IsAlumni = _context.Alumni.Any(a => a.AD_Username == m.AD_Username),
                 Mail_Location = m.Mail_Location,
                 Participation = m.Participation.Trim(),
                 ParticipationDescription = m.ParticipationDescription.Trim(),
@@ -426,7 +427,14 @@ namespace Gordon360.Services
                 }
             }
 
-            return memberships.Join(_context.ACCOUNT, m => m.ID_NUM.ToString(), a => a.gordon_id, (m, a) => new EmailViewModel { Email = a.email, FirstName = a.firstname, LastName = a.lastname, Description = m.COMMENT_TXT });
+            return memberships.Join(_context.ACCOUNT, m => m.ID_NUM.ToString(), a => a.gordon_id, (m, a) => new EmailViewModel
+                {
+                    Email = a.email,
+                    FirstName = a.firstname,
+                    LastName = a.lastname,
+                    Description = m.COMMENT_TXT
+                }
+            );
         }
 
         public class ParticipationType

--- a/Gordon360/Services/MembershipService.cs
+++ b/Gordon360/Services/MembershipService.cs
@@ -97,24 +97,30 @@ namespace Gordon360.Services
         {
             var allMemberships = await _context.Procedures.ALL_MEMBERSHIPSAsync();
 
-            return allMemberships.OrderByDescending(m => m.StartDate).Select(m => new MembershipViewModel
+            return allMemberships.OrderByDescending(m => m.StartDate).Select(m =>
             {
-                MembershipID = m.MembershipID,
-                ActivityCode = m.ActivityCode.Trim(),
-                ActivityDescription = m.ActivityDescription.Trim(),
-                ActivityImagePath = m.ActivityImagePath,
-                SessionCode = m.SessionCode.Trim(),
-                SessionDescription = m.SessionDescription.Trim(),
-                IDNumber = m.IDNumber,
-                FirstName = m.FirstName.Trim(),
-                LastName = m.LastName.Trim(),
-                Participation = m.Participation.Trim(),
-                ParticipationDescription = m.ParticipationDescription.Trim(),
-                StartDate = m.StartDate,
-                EndDate = m.EndDate,
-                Description = m.Description,
-                GroupAdmin = m.GroupAdmin,
-                Privacy = m.Privacy
+                var username = _context.ACCOUNT.FirstOrDefault(a => a.gordon_id == m.IDNumber.ToString())?.AD_Username;
+                var groups = AuthUtils.GetGroups(username);
+                return new MembershipViewModel
+                {
+                    MembershipID = m.MembershipID,
+                    ActivityCode = m.ActivityCode.Trim(),
+                    ActivityDescription = m.ActivityDescription.Trim(),
+                    ActivityImagePath = m.ActivityImagePath,
+                    SessionCode = m.SessionCode.Trim(),
+                    SessionDescription = m.SessionDescription.Trim(),
+                    IDNumber = m.IDNumber,
+                    FirstName = m.FirstName.Trim(),
+                    LastName = m.LastName.Trim(),
+                    IsAlumni = groups.Contains(AuthGroup.Alumni) && !groups.Contains(AuthGroup.Student) && !groups.Contains(AuthGroup.FacStaff),
+                    Participation = m.Participation.Trim(),
+                    ParticipationDescription = m.ParticipationDescription.Trim(),
+                    StartDate = m.StartDate,
+                    EndDate = m.EndDate,
+                    Description = m.Description,
+                    GroupAdmin = m.GroupAdmin,
+                    Privacy = m.Privacy
+                };
             });
         }
 
@@ -212,26 +218,31 @@ namespace Gordon360.Services
 
             var memberships = await _context.Procedures.MEMBERSHIPS_PER_STUDENT_IDAsync(int.Parse(account.gordon_id));
 
-            return memberships.OrderByDescending(x => x.StartDate).Select(m => new MembershipViewModel
+            return memberships.OrderByDescending(x => x.StartDate).Select(m =>
             {
-                MembershipID = m.MembershipID,
-                ActivityCode = m.ActivityCode.Trim(),
-                ActivityDescription = m.ActivityDescription.Trim(),
-                ActivityImagePath = m.ActivityImagePath,
-                SessionCode = m.SessionCode.Trim(),
-                SessionDescription = m.SessionDescription.Trim(),
-                IDNumber = m.IDNumber,
-                FirstName = m.FirstName.Trim(),
-                LastName = m.LastName.Trim(),
-                Participation = m.Participation.Trim(),
-                ParticipationDescription = m.ParticipationDescription.Trim(),
-                StartDate = m.StartDate,
-                EndDate = m.EndDate,
-                Description = m.Description,
-                ActivityType = m.ActivityType.Trim(),
-                ActivityTypeDescription = m.ActivityTypeDescription.Trim(),
-                GroupAdmin = m.GroupAdmin,
-                Privacy = m.Privacy,
+                var groups = AuthUtils.GetGroups(username);
+                return new MembershipViewModel
+                {
+                    MembershipID = m.MembershipID,
+                    ActivityCode = m.ActivityCode.Trim(),
+                    ActivityDescription = m.ActivityDescription.Trim(),
+                    ActivityImagePath = m.ActivityImagePath,
+                    SessionCode = m.SessionCode.Trim(),
+                    SessionDescription = m.SessionDescription.Trim(),
+                    IDNumber = m.IDNumber,
+                    FirstName = m.FirstName.Trim(),
+                    LastName = m.LastName.Trim(),
+                    IsAlumni = groups.Contains(AuthGroup.Alumni) && !groups.Contains(AuthGroup.Student) && !groups.Contains(AuthGroup.FacStaff),
+                    Participation = m.Participation.Trim(),
+                    ParticipationDescription = m.ParticipationDescription.Trim(),
+                    StartDate = m.StartDate,
+                    EndDate = m.EndDate,
+                    Description = m.Description,
+                    ActivityType = m.ActivityType.Trim(),
+                    ActivityTypeDescription = m.ActivityTypeDescription.Trim(),
+                    GroupAdmin = m.GroupAdmin,
+                    Privacy = m.Privacy,
+                };
             });
         }
 


### PR DESCRIPTION
This PR adds a new variable `bool` `IsAlumni` to `MembershipViewModel`. This allows the frontend PR to check whether the user is a student and looking at `MemberListItem` that contains `alumni account`, then if so, remove the link to the alumni's profile.

UI PR: https://github.com/gordon-cs/gordon-360-ui/pull/1566.