### PR TITLE
HOTFIX: Remove extra slash from image url

### DIFF
--- a/Gordon360/Services/ActivityService.cs
+++ b/Gordon360/Services/ActivityService.cs
@@ -315,7 +315,7 @@ namespace Gordon360.Services
             var serverAddress = _serverUtils.GetAddress();
             if (serverAddress is not string) throw new Exception("Could not upload Involvement Image: Server Address is null");
 
-            var url = $"{serverAddress}/browseable/uploads/{involvement_code}/{filename}";
+            var url = $"{serverAddress}browseable/uploads/{involvement_code}/{filename}";
 
             //delete old image file if it exists.
             if (Path.GetDirectoryName(imagePath) is string directory && Directory.Exists(directory))


### PR DESCRIPTION
The UpdateActivityImageAsync method is using a URL with two slashes after the server name (i.e. `https://360api1.gordon.edu//browseable...`). This PR fixes the issue.