### PR TITLE
Match chapel events to 25Live events properly and robustly

### DIFF
--- a/Gordon360/Models/ViewModels/AttendedEventViewModel.cs
+++ b/Gordon360/Models/ViewModels/AttendedEventViewModel.cs
@@ -18,36 +18,21 @@ namespace Gordon360.Models.ViewModels
 
         // We're gonna take an eventviewmodel (info from 25Live) and a Chapeleventviewmodel (info form our database) 
         // then mash 'em together
-        public AttendedEventViewModel(EventViewModel a, ChapelEventViewModel b)
+        public AttendedEventViewModel(EventViewModel? a, ChapelEventViewModel b)
         {
             // First the EventViewModel
             LiveID = b.LiveID;
-            CHDate = b.CHDate.Value.Add(b.CHTime.Value.TimeOfDay);
+            CHDate = b.CHDate is not null && b.CHTime is not null ? b.CHDate.Value.Add(b.CHTime.Value.TimeOfDay) : null;
             CHTermCD = b.CHTermCD.Trim();
             Required = b.Required;
-            // Then the CHapelEventViewModel
-            if (a != null)
-            {
-                Event_Name = a.Event_Name ?? "";
-                Event_Title = a.Event_Title ?? "";
-                Description = a.Description ?? "";
-                Organization = a.Organization ?? "";
-                StartDate = a.StartDate ?? "";
-                EndDate = a.EndDate ?? "";
-                Location = a.Location ?? "";
 
-            }
-            // If it's null, fill it with empty strings so we don't crash
-            else
-            {
-                Event_Name = "";
-                Event_Title = "";
-                Description = "";
-                Organization = "";
-                StartDate = "";
-                EndDate = "";
-                Location = "";
-            }
+            Event_Name = a?.Event_Name ?? "";
+            Event_Title = a?.Event_Title ?? "";
+            Description = a?.Description ?? "";
+            Organization = a?.Organization ?? "";
+            StartDate = a?.StartDate ?? "";
+            EndDate = a?.EndDate ?? "";
+            Location = a?.Location ?? "";
 
         }
     }

--- a/Gordon360/Services/EventService.cs
+++ b/Gordon360/Services/EventService.cs
@@ -97,13 +97,13 @@ namespace Gordon360.Services
                 return Enumerable.Empty<AttendedEventViewModel>();
             }
 
-            return chapelEvents
-                .Join(
-                    Events,
-                    c => c.LiveID,
-                    e => e.Event_ID,
-                    (c, e) => new AttendedEventViewModel(e, c)
-                );
+            // Left join to 25Live Events for extra event data when matching 25Live event is found
+            var attendedEvents = from chapelEvent in chapelEvents
+                           join event25Live in Events on chapelEvent.LiveID equals event25Live.Event_ID?.Split('_')?.FirstOrDefault() into liveEvents
+                           from liveEvent in liveEvents.DefaultIfEmpty()
+                           select new AttendedEventViewModel(liveEvent, chapelEvent);
+
+            return attendedEvents;
         }
 
 


### PR DESCRIPTION
25Live event IDs were changed, but the join from chapel events was never updated, so the join always returned an empty array. I have updated the join to properly compare event IDs ignoring the concatenated Occurrence ID.

I also updated the process to be a Left Join, so that if a Chapel Event ever fails to match a 25Live event, it will still appear in the results (albeit lacking crucial data like name, description, location, and start/end date). This way, the event still appears in the users Attended Events list, even though we can't show them useful data about that event.

For clarity: the crucial change here is that `event25Live.Event_ID` became `event25Live.Event_ID?.Split('_')?.FirstOrDefault()` in the key selector of the join function, which splits the new `Event_ID` property of the revamped `EventViewModel` to only look at the 25Live `event_id` and not the 25Live `occurrence_id` that is concatenated to it.

Everything else is to handle cases where no 25Live event matches a given ChapelEvent.