### PR TITLE
[RecIM] Add authorization to RecIM (fixes naming conventions)

### DIFF
--- a/Gordon360/Authorization/StateYourBusiness.cs
+++ b/Gordon360/Authorization/StateYourBusiness.cs
@@ -37,7 +37,7 @@ namespace Gordon360.Authorization
         // Operation to be performed: Will get as parameters to the attribute
         public string operation { get; set; }
         // Int Variable to be parsed: Will get as parameters to the attribute
-        public int integer { get; set; }
+        // public int integer { get; set; }
 
         private ActionExecutingContext context;
         private IWebHostEnvironment _webHostEnvironment;
@@ -68,7 +68,7 @@ namespace Gordon360.Authorization
                 return;
             }
 
-            bool isAuthorized = await CanPerformOperationAsync(resource, operation, integer);
+            bool isAuthorized = await CanPerformOperationAsync(resource, operation);
             if (!isAuthorized)
             {
                 throw new UnauthorizedAccessException("Authorization has been denied for this request.");
@@ -78,7 +78,7 @@ namespace Gordon360.Authorization
         }
 
 
-        private async Task<bool> CanPerformOperationAsync(string resource, string operation, int? integer)
+        private async Task<bool> CanPerformOperationAsync(string resource, string operation)
             => operation switch
             {
                 Operation.READ_ONE => await CanReadOneAsync(resource),
@@ -86,7 +86,7 @@ namespace Gordon360.Authorization
                 Operation.READ_PARTIAL => await CanReadPartialAsync(resource),
                 Operation.ADD => await CanAddAsync(resource),
                 Operation.DENY_ALLOW => await CanDenyAllowAsync(resource),
-                Operation.UPDATE => await CanUpdateAsync(resource, integer),
+                Operation.UPDATE => await CanUpdateAsync(resource),
                 Operation.DELETE => await CanDeleteAsync(resource),
                 Operation.READ_PUBLIC => CanReadPublic(resource),
                 _ => false,
@@ -484,7 +484,7 @@ namespace Gordon360.Authorization
                 default: return false;
             }
         }
-        private async Task<bool> CanUpdateAsync(string resource, int? integer)
+        private async Task<bool> CanUpdateAsync(string resource)
         {
             switch (resource)
             {
@@ -688,7 +688,8 @@ namespace Gordon360.Authorization
                         var participantService = new ParticipantService(context, accountService);
                         var matchService = new MatchService(context, participantService, accountService);
                         var teamService = new TeamService(context, matchService, participantService, accountService);
-                        return teamService.IsTeamCaptain(user_name, integer);
+                        // return teamService.IsTeamCaptain(user_name, integer);
+                        return true;
                     }
 
                 case Resource.RECIM_MATCH:
@@ -697,9 +698,10 @@ namespace Gordon360.Authorization
                         var matchService = new MatchService(context, participantService, accountService);
                         var seriesService = new SeriesService(context, matchService);
                         var activityService = new ActivityService(context, seriesService);
-                        var match = matchService.GetMatchByID(integer);
-                        var series = seriesService.GetSeriesByID(match.SeriesID);
-                        return activityService.IsReferee(user_name, series.ActivityID);
+                        // var match = matchService.GetMatchByID(integer);
+                        // var series = seriesService.GetSeriesByID(match.SeriesID);
+                        // return activityService.IsReferee(user_name, series.ActivityID);
+                        return true;
                     }
                 default: return false;
             }

--- a/Gordon360/Authorization/StateYourBusiness.cs
+++ b/Gordon360/Authorization/StateYourBusiness.cs
@@ -688,23 +688,23 @@ namespace Gordon360.Authorization
 
                 case Resource.RECIM_TEAM:
                     {
+                        var teamID = (int)context.ActionArguments["teamID"];
                         var participantService = new ParticipantService(_CCTContext, _accountService);
                         var matchService = new MatchService(_CCTContext, _accountService);
                         var teamService = new TeamService(_CCTContext, matchService, participantService, _accountService);
-                        // return teamService.IsTeamCaptain(user_name, integer);
-                        return true;
+                        return teamService.IsTeamCaptain(user_name, teamID);
                     }
 
                 case Resource.RECIM_MATCH:
                     {
+                        var matchID = (int)context.ActionArguments["matchID"];
                         var participantService = new ParticipantService(_CCTContext, _accountService);
                         var matchService = new MatchService(_CCTContext, _accountService);
                         var seriesService = new SeriesService(_CCTContext, matchService);
                         var activityService = new Gordon360.Services.RecIM.ActivityService(_CCTContext, seriesService);
-                        // var match = matchService.GetMatchByID(integer);
-                        // var series = seriesService.GetSeriesByID(match.SeriesID);
-                        // return activityService.IsReferee(user_name, series.ActivityID);
-                        return true;
+                        var match = matchService.GetMatchByID(matchID);
+                        var series = seriesService.GetSeriesByID(match.SeriesID);
+                        return activityService.IsReferee(user_name, series.ActivityID);
                     }
                 default: return false;
             }

--- a/Gordon360/Authorization/StateYourBusiness.cs
+++ b/Gordon360/Authorization/StateYourBusiness.cs
@@ -36,8 +36,6 @@ namespace Gordon360.Authorization
         public string resource { get; set; }
         // Operation to be performed: Will get as parameters to the attribute
         public string operation { get; set; }
-        // Int Variable to be parsed: Will get as parameters to the attribute
-        // public int integer { get; set; }
 
         private ActionExecutingContext context;
         private IWebHostEnvironment _webHostEnvironment;
@@ -692,7 +690,7 @@ namespace Gordon360.Authorization
                         var participantService = new ParticipantService(_CCTContext, _accountService);
                         var matchService = new MatchService(_CCTContext, _accountService);
                         var teamService = new TeamService(_CCTContext, matchService, participantService, _accountService);
-                        return teamService.IsTeamCaptain(user_name, teamID);
+                        return teamService.IsTeamCaptain(user_name, teamID) || participantService.IsAdmin(user_name);
                     }
 
                 case Resource.RECIM_MATCH:
@@ -704,7 +702,7 @@ namespace Gordon360.Authorization
                         var activityService = new Gordon360.Services.RecIM.ActivityService(_CCTContext, seriesService);
                         var match = matchService.GetMatchByID(matchID);
                         var series = seriesService.GetSeriesByID(match.SeriesID);
-                        return activityService.IsReferee(user_name, series.ActivityID);
+                        return activityService.IsReferee(user_name, series.ActivityID) || participantService.IsAdmin(user_name);
                     }
                 default: return false;
             }

--- a/Gordon360/Controllers/RecIM/ActivitiesController.cs
+++ b/Gordon360/Controllers/RecIM/ActivitiesController.cs
@@ -86,7 +86,7 @@ namespace Gordon360.Controllers.RecIM
                 var activity = await _activityService.PostActivityAsync(username, newActivity);
                 return CreatedAtAction("CreateActivity", activity);
             }
-            return Unauthorized();
+            return Forbid();
         }
 
         /// <summary>
@@ -106,7 +106,7 @@ namespace Gordon360.Controllers.RecIM
                 var activity = await _activityService.UpdateActivityAsync(activityID, updatedActivity);
                 return CreatedAtAction("UpdateActivity", activity);
             }
-            return Unauthorized();
+            return Forbid();
         }
     }
 }

--- a/Gordon360/Controllers/RecIM/ActivitiesController.cs
+++ b/Gordon360/Controllers/RecIM/ActivitiesController.cs
@@ -79,7 +79,7 @@ namespace Gordon360.Controllers.RecIM
         [StateYourBusiness(operation = Operation.ADD, resource = Resource.RECIM_ACTIVITY)]
         public async Task<ActionResult<ActivityCreatedViewModel>> CreateActivity(ActivityUploadViewModel newActivity)
         {
-            var activity = await _activityService.PostActivityAsync(username, newActivity);
+            var activity = await _activityService.PostActivityAsync(newActivity);
             return CreatedAtAction("CreateActivity", activity);
         }
 

--- a/Gordon360/Controllers/RecIM/ActivitiesController.cs
+++ b/Gordon360/Controllers/RecIM/ActivitiesController.cs
@@ -83,7 +83,7 @@ namespace Gordon360.Controllers.RecIM
             var isAdmin = _participantService.IsAdmin(username);
             if (isAdmin)
             {
-                var activity = await _activityService.PostActivity(username, newActivity);
+                var activity = await _activityService.PostActivityAsync(username, newActivity);
                 return CreatedAtAction("CreateActivity", activity);
             }
             return Unauthorized();
@@ -103,7 +103,7 @@ namespace Gordon360.Controllers.RecIM
             var isAdmin = _participantService.IsAdmin(username);
             if (isAdmin)
             {
-                var activity = await _activityService.UpdateActivity(activityID, updatedActivity);
+                var activity = await _activityService.UpdateActivityAsync(activityID, updatedActivity);
                 return CreatedAtAction("UpdateActivity", activity);
             }
             return Unauthorized();

--- a/Gordon360/Controllers/RecIM/ActivitiesController.cs
+++ b/Gordon360/Controllers/RecIM/ActivitiesController.cs
@@ -1,6 +1,7 @@
 ﻿using Gordon360.Models.CCT;
 using Gordon360.Models.ViewModels.RecIM;
 using Gordon360.Services.RecIM;
+using Gordon360.Authorization;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -76,9 +77,11 @@ namespace Gordon360.Controllers.RecIM
         [Route("")]
         public async Task<ActionResult> CreateActivity(ActivityUploadViewModel newActivity)
         {
-            var activity = await _activityService.PostActivity(newActivity);
+            var username = AuthUtils.GetUsername(User);
+            var activity = await _activityService.PostActivity(username, newActivity);
             return CreatedAtAction("CreateActivity",activity);
         }
+
         /// <summary>
         /// Updates Activity based on input
         /// </summary>
@@ -89,8 +92,14 @@ namespace Gordon360.Controllers.RecIM
         [Route("{activityID}")]
         public async Task<ActionResult> UpdateActivity(int activityID, ActivityPatchViewModel updatedActivity)
         {
-            var activity = await _activityService.UpdateActivity(activityID, updatedActivity);
-            return CreatedAtAction("UpdateActivity", activity);
+            var username = AuthUtils.GetUsername(User);
+            var isActivityAdmin = _activityService.IsActivityAdmin(username, activityID);
+            if (isActivityAdmin)
+            {
+                var activity = await _activityService.UpdateActivity(activityID, updatedActivity);
+                return CreatedAtAction("UpdateActivity", activity);
+            }
+            return Unauthorized();
         }
     }
 }

--- a/Gordon360/Controllers/RecIM/ActivitiesController.cs
+++ b/Gordon360/Controllers/RecIM/ActivitiesController.cs
@@ -2,6 +2,7 @@
 using Gordon360.Models.ViewModels.RecIM;
 using Gordon360.Services.RecIM;
 using Gordon360.Authorization;
+using Gordon360.Static.Names;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -18,12 +19,10 @@ namespace Gordon360.Controllers.RecIM
     public class ActivitiesController : GordonControllerBase
     {
         private readonly IActivityService _activityService;
-        private readonly IParticipantService _participantService;
 
-        public ActivitiesController(IActivityService activityService, IParticipantService participantService)
+        public ActivitiesController(IActivityService activityService)
         {
             _activityService = activityService;
-            _participantService = participantService;
         }
 
         ///<summary>Gets a list of all Activities by parameter </summary>
@@ -77,16 +76,11 @@ namespace Gordon360.Controllers.RecIM
         /// <returns>Posted Activity</returns>
         [HttpPost]
         [Route("")]
+        [StateYourBusiness(operation = Operation.ADD, resource = Resource.RECIM_ACTIVITY)]
         public async Task<ActionResult> CreateActivity(ActivityUploadViewModel newActivity)
         {
-            var username = AuthUtils.GetUsername(User);
-            var isAdmin = _participantService.IsAdmin(username);
-            if (isAdmin)
-            {
-                var activity = await _activityService.PostActivityAsync(username, newActivity);
-                return CreatedAtAction("CreateActivity", activity);
-            }
-            return Forbid();
+            var activity = await _activityService.PostActivityAsync(username, newActivity);
+            return CreatedAtAction("CreateActivity", activity);
         }
 
         /// <summary>
@@ -97,16 +91,11 @@ namespace Gordon360.Controllers.RecIM
         /// <returns></returns>
         [HttpPatch]
         [Route("{activityID}")]
+        [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_ACTIVITY)]
         public async Task<ActionResult> UpdateActivity(int activityID, ActivityPatchViewModel updatedActivity)
         {
-            var username = AuthUtils.GetUsername(User);
-            var isAdmin = _participantService.IsAdmin(username);
-            if (isAdmin)
-            {
-                var activity = await _activityService.UpdateActivityAsync(activityID, updatedActivity);
-                return CreatedAtAction("UpdateActivity", activity);
-            }
-            return Forbid();
+            var activity = await _activityService.UpdateActivityAsync(activityID, updatedActivity);
+            return CreatedAtAction("UpdateActivity", activity);
         }
     }
 }

--- a/Gordon360/Controllers/RecIM/ActivitiesController.cs
+++ b/Gordon360/Controllers/RecIM/ActivitiesController.cs
@@ -18,10 +18,12 @@ namespace Gordon360.Controllers.RecIM
     public class ActivitiesController : GordonControllerBase
     {
         private readonly IActivityService _activityService;
+        private readonly IParticipantService _participantService;
 
-        public ActivitiesController(IActivityService activityService)
+        public ActivitiesController(IActivityService activityService, IParticipantService participantService)
         {
             _activityService = activityService;
+            _participantService = participantService;
         }
 
         ///<summary>Gets a list of all Activities by parameter </summary>
@@ -78,8 +80,13 @@ namespace Gordon360.Controllers.RecIM
         public async Task<ActionResult> CreateActivity(ActivityUploadViewModel newActivity)
         {
             var username = AuthUtils.GetUsername(User);
-            var activity = await _activityService.PostActivity(username, newActivity);
-            return CreatedAtAction("CreateActivity",activity);
+            var isAdmin = _participantService.IsAdmin(username);
+            if (isAdmin)
+            {
+                var activity = await _activityService.PostActivity(username, newActivity);
+                return CreatedAtAction("CreateActivity", activity);
+            }
+            return Unauthorized();
         }
 
         /// <summary>
@@ -93,8 +100,8 @@ namespace Gordon360.Controllers.RecIM
         public async Task<ActionResult> UpdateActivity(int activityID, ActivityPatchViewModel updatedActivity)
         {
             var username = AuthUtils.GetUsername(User);
-            var isActivityAdmin = _activityService.IsActivityAdmin(username, activityID);
-            if (isActivityAdmin)
+            var isAdmin = _participantService.IsAdmin(username);
+            if (isAdmin)
             {
                 var activity = await _activityService.UpdateActivity(activityID, updatedActivity);
                 return CreatedAtAction("UpdateActivity", activity);

--- a/Gordon360/Controllers/RecIM/MatchesController.cs
+++ b/Gordon360/Controllers/RecIM/MatchesController.cs
@@ -147,7 +147,7 @@ namespace Gordon360.Controllers.RecIM
         public async Task<ActionResult> AddAttendance(int matchID, [FromBody] string username)
         {
             // We don't have to send username through requests, Microsoft.AspNetCore is able
-            // to get/set the user who of this request.
+            // to get/set the user of this request.
             // We'll refactor the routes in the future PRs
             // var username = AuthUtils.GetUsername(User);
 

--- a/Gordon360/Controllers/RecIM/MatchesController.cs
+++ b/Gordon360/Controllers/RecIM/MatchesController.cs
@@ -96,7 +96,7 @@ namespace Gordon360.Controllers.RecIM
                 var stats = await _matchService.UpdateTeamStatsAsync(matchID, updatedMatch);
                 return CreatedAtAction("UpdateStats", stats);
             }
-            return Unauthorized();
+            return Forbid();
         }
 
         /// <summary>
@@ -119,7 +119,7 @@ namespace Gordon360.Controllers.RecIM
                 var match = await _matchService.UpdateMatchAsync(matchID, updatedMatch);
                 return CreatedAtAction("UpdateMatch", match);
             }
-            return Unauthorized();
+            return Forbid();
         }
 
         /// <summary>
@@ -138,7 +138,7 @@ namespace Gordon360.Controllers.RecIM
                 var match = await _matchService.PostMatchAsync(newMatch);
                 return CreatedAtAction("CreateMatch", match);
             }
-            return Unauthorized();
+            return Forbid();
         }
 
         /// <summary>
@@ -165,7 +165,7 @@ namespace Gordon360.Controllers.RecIM
                 var attendance = await _matchService.AddParticipantAttendanceAsync(username, matchID);
                 return CreatedAtAction("AddAttendance", attendance);
             }
-            return Unauthorized();
+            return Forbid();
         }
 
     }

--- a/Gordon360/Controllers/RecIM/MatchesController.cs
+++ b/Gordon360/Controllers/RecIM/MatchesController.cs
@@ -20,7 +20,7 @@ namespace Gordon360.Controllers.RecIM
     {
         private readonly IMatchService _matchService;
 
-        public MatchesController(IMatchService matchServicece)
+        public MatchesController(IMatchService matchService)
         {
             _matchService = matchService;
         }
@@ -94,7 +94,7 @@ namespace Gordon360.Controllers.RecIM
         /// <returns></returns>
         [HttpPatch]
         [Route("{matchID}")]
-        [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_MATCH, integer = [FromQueryAttribute] matchID)]
+        [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_MATCH)]
         public async Task<ActionResult<MatchCreatedViewModel>> UpdateMatch(int matchID, MatchPatchViewModel updatedMatch)
         {
             var match = await _matchService.UpdateMatchAsync(matchID, updatedMatch);
@@ -123,7 +123,7 @@ namespace Gordon360.Controllers.RecIM
         /// <returns></returns>
         [HttpPost]
         [Route("{matchID}/attendance")]
-        [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_MATCH, integer = [FromQueryAttribute] matchID)]
+        [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_MATCH)]
         public async Task<ActionResult<MatchParticipantViewModel>> AddAttendance(int matchID, [FromBody] string username)
         {
             var attendance = await _matchService.AddParticipantAttendanceAsync(username, matchID);

--- a/Gordon360/Controllers/RecIM/MatchesController.cs
+++ b/Gordon360/Controllers/RecIM/MatchesController.cs
@@ -93,7 +93,7 @@ namespace Gordon360.Controllers.RecIM
             var isReferee = _activityService.IsReferee(username, activity.ID);
             if (isReferee)
             {
-                var stats = await _matchService.UpdateTeamStats(matchID, updatedMatch);
+                var stats = await _matchService.UpdateTeamStatsAsync(matchID, updatedMatch);
                 return CreatedAtAction("UpdateStats", stats);
             }
             return Unauthorized();
@@ -116,7 +116,7 @@ namespace Gordon360.Controllers.RecIM
             var isReferee = _activityService.IsReferee(username, activity.ID);
             if (isReferee)
             {
-                var match = await _matchService.UpdateMatch(matchID, updatedMatch);
+                var match = await _matchService.UpdateMatchAsync(matchID, updatedMatch);
                 return CreatedAtAction("UpdateMatch", match);
             }
             return Unauthorized();
@@ -135,7 +135,7 @@ namespace Gordon360.Controllers.RecIM
             var isAdmin = _participantService.IsAdmin(username);
             if (isAdmin)
             {
-                var match = await _matchService.PostMatch(newMatch);
+                var match = await _matchService.PostMatchAsync(newMatch);
                 return CreatedAtAction("CreateMatch", match);
             }
             return Unauthorized();
@@ -162,7 +162,7 @@ namespace Gordon360.Controllers.RecIM
             var isReferee = _activityService.IsReferee(username, activity.ID);
             if (isReferee)
             {
-                var attendance = await _matchService.AddParticipantAttendance(username, matchID);
+                var attendance = await _matchService.AddParticipantAttendanceAsync(username, matchID);
                 return CreatedAtAction("AddAttendance", attendance);
             }
             return Unauthorized();

--- a/Gordon360/Controllers/RecIM/MatchesController.cs
+++ b/Gordon360/Controllers/RecIM/MatchesController.cs
@@ -79,7 +79,7 @@ namespace Gordon360.Controllers.RecIM
         /// <returns></returns>
         [HttpPatch]
         [Route("{matchID}/stats")]
-        [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_MATCH, integer = [FromQueryAttribute] matchID)]
+        [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_MATCH)]
         public async Task<ActionResult<MatchTeamViewModel>> UpdateStats(int matchID, MatchStatsPatchViewModel updatedMatch)
         {
             var stats = await _matchService.UpdateTeamStatsAsync(matchID, updatedMatch);

--- a/Gordon360/Controllers/RecIM/ParticipantsController.cs
+++ b/Gordon360/Controllers/RecIM/ParticipantsController.cs
@@ -75,7 +75,7 @@ namespace Gordon360.Controllers.RecIM
         [Route("{username}")]
         public async Task<ActionResult> AddParticipant(string username)
         {
-            var participant = await _participantService.PostParticipant(username);
+            var participant = await _participantService.PostParticipantAsync(username);
             return CreatedAtAction("AddParticipant", participant);
         }
 
@@ -83,7 +83,7 @@ namespace Gordon360.Controllers.RecIM
         [Route("{username}")]
         public async Task<ActionResult> UpdateParticipant(string username, [FromBody] bool isAdmin)
         {
-            var participant = await _participantService.UpdateParticipant(username,isAdmin);
+            var participant = await _participantService.UpdateParticipantAsync(username,isAdmin);
             return CreatedAtAction("AddParticipant", participant);
         }
 
@@ -92,7 +92,7 @@ namespace Gordon360.Controllers.RecIM
         [Route("{username}/notifications")]
         public async Task<IActionResult> SendParticipantNotification(string username, ParticipantNotificationUploadViewModel notificationVM)
         {
-            var notification = await _participantService.SendParticipantNotification(username, notificationVM);
+            var notification = await _participantService.SendParticipantNotificationAsync(username, notificationVM);
             return CreatedAtAction("SendParticipantNotification", notification);
         }
 
@@ -102,7 +102,7 @@ namespace Gordon360.Controllers.RecIM
         public async Task<ActionResult> UpdateParticipantActivity(string username, ParticipantActivityPatchViewModel updatedParticipantActivity)
         {
 
-            var participant = await _participantService.UpdateParticipantActivity(username, updatedParticipantActivity);
+            var participant = await _participantService.UpdateParticipantActivityAsync(username, updatedParticipantActivity);
             return CreatedAtAction("UpdateParticipantActivity", participant);
         }
 
@@ -110,7 +110,7 @@ namespace Gordon360.Controllers.RecIM
         [Route("{username}/status")]
         public async Task<ActionResult> UpdateParticipantStatus(string username, ParticipantStatusPatchViewModel updatedParticipant)
         {
-            var status = await _participantService.UpdateParticipantStatus(username, updatedParticipant);
+            var status = await _participantService.UpdateParticipantStatusAsync(username, updatedParticipant);
             return CreatedAtAction("UpdateParticipantStatus",status);
         }
 

--- a/Gordon360/Controllers/RecIM/SeriesController.cs
+++ b/Gordon360/Controllers/RecIM/SeriesController.cs
@@ -84,7 +84,7 @@ namespace Gordon360.Controllers.RecIM
                 var series = await _seriesService.UpdateSeriesAsync(seriesID, updatedSeries);
                 return CreatedAtAction("UpdateSeries", series);
             }
-            return Unauthorized();
+            return Forbid();
         }
 
         /// <summary>
@@ -104,7 +104,7 @@ namespace Gordon360.Controllers.RecIM
                 var series = await _seriesService.PostSeriesAsync(newSeries, referenceSeriesID);
                 return CreatedAtAction("CreateSeries", series);
             }
-            return Unauthorized();
+            return Forbid();
         }
 
     }

--- a/Gordon360/Controllers/RecIM/SeriesController.cs
+++ b/Gordon360/Controllers/RecIM/SeriesController.cs
@@ -18,11 +18,12 @@ namespace Gordon360.Controllers.RecIM
     public class SeriesController : GordonControllerBase
     {
         private readonly ISeriesService _seriesService;
-        private readonly IActivityService _activityService;
+        private readonly IParticipantService _participantService;
 
-        public SeriesController(ISeriesService seriesService)
+        public SeriesController(ISeriesService seriesService, IParticipantService participantService)
         {
             _seriesService = seriesService;
+            _participantService = participantService;
         }
 
         /// <summary>
@@ -77,9 +78,8 @@ namespace Gordon360.Controllers.RecIM
         public async Task<ActionResult> UpdateSeries(int seriesID, SeriesPatchViewModel updatedSeries)
         {
             var username = AuthUtils.GetUsername(User);
-            var updatingSeries = _seriesService.GetSeriesByID(seriesID);
-            var isActivityAdmin = _activityService.IsActivityAdmin(username, updatingSeries.ActivityID);
-            if (isActivityAdmin)
+            var isAdmin = _participantService.IsAdmin(username);
+            if (isAdmin)
             {
                 var series = await _seriesService.UpdateSeries(seriesID, updatedSeries);
                 return CreatedAtAction("UpdateSeries", series);
@@ -98,8 +98,8 @@ namespace Gordon360.Controllers.RecIM
         public async Task<ActionResult> CreateSeries(SeriesUploadViewModel newSeries, [FromQuery]int? referenceSeriesID)
         {
             var username = AuthUtils.GetUsername(User);
-            var isActivityAdmin = _activityService.IsActivityAdmin(username, newSeries.ActivityID);
-            if (isActivityAdmin)
+            var isAdmin = _participantService.IsAdmin(username);
+            if (isAdmin)
             {
                 var series = await _seriesService.PostSeries(newSeries, referenceSeriesID);
                 return CreatedAtAction("CreateSeries", series);

--- a/Gordon360/Controllers/RecIM/SeriesController.cs
+++ b/Gordon360/Controllers/RecIM/SeriesController.cs
@@ -2,6 +2,7 @@
 using Gordon360.Models.ViewModels.RecIM;
 using Gordon360.Services.RecIM;
 using Gordon360.Authorization;
+using Gordon360.Static.Names;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -18,12 +19,10 @@ namespace Gordon360.Controllers.RecIM
     public class SeriesController : GordonControllerBase
     {
         private readonly ISeriesService _seriesService;
-        private readonly IParticipantService _participantService;
 
-        public SeriesController(ISeriesService seriesService, IParticipantService participantService)
+        public SeriesController(ISeriesService seriesService)
         {
             _seriesService = seriesService;
-            _participantService = participantService;
         }
 
         /// <summary>
@@ -75,16 +74,11 @@ namespace Gordon360.Controllers.RecIM
         /// <returns>modified series</returns>
         [HttpPatch]
         [Route("{seriesID}")]
+        [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_SERIES)]
         public async Task<ActionResult> UpdateSeriesAsync(int seriesID, SeriesPatchViewModel updatedSeries)
         {
-            var username = AuthUtils.GetUsername(User);
-            var isAdmin = _participantService.IsAdmin(username);
-            if (isAdmin)
-            {
-                var series = await _seriesService.UpdateSeriesAsync(seriesID, updatedSeries);
-                return CreatedAtAction("UpdateSeries", series);
-            }
-            return Forbid();
+            var series = await _seriesService.UpdateSeriesAsync(seriesID, updatedSeries);
+            return CreatedAtAction("UpdateSeries", series);
         }
 
         /// <summary>
@@ -95,16 +89,11 @@ namespace Gordon360.Controllers.RecIM
         /// <returns>created series</returns>
         [HttpPost]
         [Route("")]
+        [StateYourBusiness(operation = Operation.ADD, resource = Resource.RECIM_SERIES)]
         public async Task<ActionResult> CreateSeries(SeriesUploadViewModel newSeries, [FromQuery]int? referenceSeriesID)
         {
-            var username = AuthUtils.GetUsername(User);
-            var isAdmin = _participantService.IsAdmin(username);
-            if (isAdmin)
-            {
-                var series = await _seriesService.PostSeriesAsync(newSeries, referenceSeriesID);
-                return CreatedAtAction("CreateSeries", series);
-            }
-            return Forbid();
+            var series = await _seriesService.PostSeriesAsync(newSeries, referenceSeriesID);
+            return CreatedAtAction("CreateSeries", series);
         }
 
     }

--- a/Gordon360/Controllers/RecIM/SeriesController.cs
+++ b/Gordon360/Controllers/RecIM/SeriesController.cs
@@ -75,13 +75,13 @@ namespace Gordon360.Controllers.RecIM
         /// <returns>modified series</returns>
         [HttpPatch]
         [Route("{seriesID}")]
-        public async Task<ActionResult> UpdateSeries(int seriesID, SeriesPatchViewModel updatedSeries)
+        public async Task<ActionResult> UpdateSeriesAsync(int seriesID, SeriesPatchViewModel updatedSeries)
         {
             var username = AuthUtils.GetUsername(User);
             var isAdmin = _participantService.IsAdmin(username);
             if (isAdmin)
             {
-                var series = await _seriesService.UpdateSeries(seriesID, updatedSeries);
+                var series = await _seriesService.UpdateSeriesAsync(seriesID, updatedSeries);
                 return CreatedAtAction("UpdateSeries", series);
             }
             return Unauthorized();
@@ -101,7 +101,7 @@ namespace Gordon360.Controllers.RecIM
             var isAdmin = _participantService.IsAdmin(username);
             if (isAdmin)
             {
-                var series = await _seriesService.PostSeries(newSeries, referenceSeriesID);
+                var series = await _seriesService.PostSeriesAsync(newSeries, referenceSeriesID);
                 return CreatedAtAction("CreateSeries", series);
             }
             return Unauthorized();

--- a/Gordon360/Controllers/RecIM/SportsController.cs
+++ b/Gordon360/Controllers/RecIM/SportsController.cs
@@ -53,7 +53,7 @@ namespace Gordon360.Controllers.RecIM
                 var sport = await _sportService.UpdateSportAsync(updatedSport);
                 return CreatedAtAction("UpdateSport", sport);
             }
-            return Unauthorized();
+            return Forbid();
         }
 
         [HttpPost]
@@ -67,7 +67,7 @@ namespace Gordon360.Controllers.RecIM
                 var sport = await _sportService.PostSportAsync(newSport);
                 return CreatedAtAction("UpdateSport", sport);
             }
-            return Unauthorized();
+            return Forbid();
         }
 
     }

--- a/Gordon360/Controllers/RecIM/SportsController.cs
+++ b/Gordon360/Controllers/RecIM/SportsController.cs
@@ -55,7 +55,7 @@ namespace Gordon360.Controllers.RecIM
         [StateYourBusiness(operation = Operation.ADD, resource = Resource.RECIM_SPORT)]
         public async Task<ActionResult<SportViewModel>> CreateSport(SportUploadViewModel newSport)
         {
-            var sport = await _sportService.PostSport(newSport);
+            var sport = await _sportService.PostSportAsync(newSport);
             return CreatedAtAction("CreateSport", sport);
         }
 

--- a/Gordon360/Controllers/RecIM/SportsController.cs
+++ b/Gordon360/Controllers/RecIM/SportsController.cs
@@ -1,4 +1,5 @@
-﻿using Gordon360.Models.CCT;
+﻿using Gordon360.Authorization;
+using Gordon360.Models.CCT;
 using Gordon360.Models.ViewModels.RecIM;
 using Gordon360.Services.RecIM;
 using Microsoft.AspNetCore.Authorization;
@@ -17,10 +18,12 @@ namespace Gordon360.Controllers.RecIM
     public class SportsController : GordonControllerBase
     {
         private readonly ISportService _sportService;
+        private readonly IParticipantService _participantService;
 
-        public SportsController(ISportService sportService)
+        public SportsController(ISportService sportService, IParticipantService participantService)
         {
             _sportService = sportService;
+            _participantService = participantService;
         }
 
         [HttpGet]
@@ -43,16 +46,28 @@ namespace Gordon360.Controllers.RecIM
         [Route("{sportID}")]
         public async Task<ActionResult> UpdateSport(int sportID, SportViewModel updatedSport)
         {
-            var sport = await _sportService.UpdateSport(updatedSport);
-            return CreatedAtAction("UpdateSport", sport);
+            var username = AuthUtils.GetUsername(User);
+            var isAdmin = _participantService.IsAdmin(username);
+            if (isAdmin)
+            {
+                var sport = await _sportService.UpdateSport(updatedSport);
+                return CreatedAtAction("UpdateSport", sport);
+            }
+            return Unauthorized();
         }
 
         [HttpPost]
         [Route("")]
         public async Task<ActionResult> CreateSport(SportUploadViewModel newSport)
         {
-            var sport = await _sportService.PostSport(newSport);
-            return CreatedAtAction("UpdateSport", sport);
+            var username = AuthUtils.GetUsername(User);
+            var isAdmin = _participantService.IsAdmin(username);
+            if (isAdmin)
+            {
+                var sport = await _sportService.PostSport(newSport);
+                return CreatedAtAction("UpdateSport", sport);
+            }
+            return Unauthorized();
         }
 
     }

--- a/Gordon360/Controllers/RecIM/SportsController.cs
+++ b/Gordon360/Controllers/RecIM/SportsController.cs
@@ -50,7 +50,7 @@ namespace Gordon360.Controllers.RecIM
             var isAdmin = _participantService.IsAdmin(username);
             if (isAdmin)
             {
-                var sport = await _sportService.UpdateSport(updatedSport);
+                var sport = await _sportService.UpdateSportAsync(updatedSport);
                 return CreatedAtAction("UpdateSport", sport);
             }
             return Unauthorized();
@@ -64,7 +64,7 @@ namespace Gordon360.Controllers.RecIM
             var isAdmin = _participantService.IsAdmin(username);
             if (isAdmin)
             {
-                var sport = await _sportService.PostSport(newSport);
+                var sport = await _sportService.PostSportAsync(newSport);
                 return CreatedAtAction("UpdateSport", sport);
             }
             return Unauthorized();

--- a/Gordon360/Controllers/RecIM/SportsController.cs
+++ b/Gordon360/Controllers/RecIM/SportsController.cs
@@ -2,6 +2,7 @@
 using Gordon360.Models.CCT;
 using Gordon360.Models.ViewModels.RecIM;
 using Gordon360.Services.RecIM;
+using Gordon360.Static.Names;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -18,12 +19,10 @@ namespace Gordon360.Controllers.RecIM
     public class SportsController : GordonControllerBase
     {
         private readonly ISportService _sportService;
-        private readonly IParticipantService _participantService;
 
-        public SportsController(ISportService sportService, IParticipantService participantService)
+        public SportsController(ISportService sportService)
         {
             _sportService = sportService;
-            _participantService = participantService;
         }
 
         [HttpGet]
@@ -44,30 +43,20 @@ namespace Gordon360.Controllers.RecIM
       
         [HttpPatch]
         [Route("{sportID}")]
+        [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_SPORT)]
         public async Task<ActionResult> UpdateSport(int sportID, SportViewModel updatedSport)
         {
-            var username = AuthUtils.GetUsername(User);
-            var isAdmin = _participantService.IsAdmin(username);
-            if (isAdmin)
-            {
-                var sport = await _sportService.UpdateSportAsync(updatedSport);
-                return CreatedAtAction("UpdateSport", sport);
-            }
-            return Forbid();
+            var sport = await _sportService.UpdateSportAsync(updatedSport);
+            return CreatedAtAction("UpdateSport", sport);
         }
 
         [HttpPost]
         [Route("")]
+        [StateYourBusiness(operation = Operation.ADD, resource = Resource.RECIM_SPORT)]
         public async Task<ActionResult> CreateSport(SportUploadViewModel newSport)
         {
-            var username = AuthUtils.GetUsername(User);
-            var isAdmin = _participantService.IsAdmin(username);
-            if (isAdmin)
-            {
-                var sport = await _sportService.PostSportAsync(newSport);
-                return CreatedAtAction("UpdateSport", sport);
-            }
-            return Forbid();
+            var sport = await _sportService.PostSportAsync(newSport);
+            return CreatedAtAction("UpdateSport", sport);
         }
 
     }

--- a/Gordon360/Controllers/RecIM/TeamsController.cs
+++ b/Gordon360/Controllers/RecIM/TeamsController.cs
@@ -89,9 +89,15 @@ namespace Gordon360.Controllers.RecIM
         [Route("{teamID}/participants")]
         public async Task<ActionResult> AddParticipantToTeam(int teamID, ParticipantTeamUploadViewModel participant)
         {
-            participant.RoleTypeID = participant.RoleTypeID ?? 3;
-            var participantTeam = await _teamService.AddUserToTeamAsync(teamID, participant);
-            return CreatedAtAction("AddParticipantToTeam",participantTeam);
+            var username = AuthUtils.GetUsername(User);
+            var isTeamCaptain = _teamService.IsTeamCaptain(username, teamID);
+            if (isTeamCaptain)
+            {
+                participant.RoleTypeID = participant.RoleTypeID ?? 3;
+                var participantTeam = await _teamService.AddUserToTeamAsync(teamID, participant);
+                return CreatedAtAction("AddParticipantToTeam", participantTeam);
+            }
+            return Unauthorized();
         }
 
         /// <summary>
@@ -104,9 +110,15 @@ namespace Gordon360.Controllers.RecIM
         [Route("{teamID}/participants")]
         public async Task<ActionResult> UpdateTeamParticipant(int teamID, ParticipantTeamUploadViewModel participant)
         {
-            participant.RoleTypeID = participant.RoleTypeID ?? 3;
-            var participantTeam = await _teamService.UpdateParticipantRoleAsync(teamID, participant);
-            return CreatedAtAction("UpdateTeamParticipant",participantTeam);
+            var username = AuthUtils.GetUsername(User);
+            var isTeamCaptain = _teamService.IsTeamCaptain(username, teamID);
+            if (isTeamCaptain)
+            {
+                participant.RoleTypeID = participant.RoleTypeID ?? 3;
+                var participantTeam = await _teamService.UpdateParticipantRoleAsync(teamID, participant);
+                return CreatedAtAction("UpdateTeamParticipant", participantTeam);
+            }
+            return Unauthorized();
         }
 
         /// <summary>
@@ -119,8 +131,14 @@ namespace Gordon360.Controllers.RecIM
         [Route("{teamID}")]
         public async Task<ActionResult> UpdateTeamInfo(int teamID, TeamPatchViewModel team)
         {
-            var updatedTeam = await _teamService.UpdateTeamAsync(teamID, team);
-            return CreatedAtAction("UpdateTeamInfo",updatedTeam);
-        }
+            var username = AuthUtils.GetUsername(User);
+            var isTeamCaptain = _teamService.IsTeamCaptain(username, teamID);
+            if (isTeamCaptain)
+            {
+                var updatedTeam = await _teamService.UpdateTeamAsync(teamID, team);
+                return CreatedAtAction("UpdateTeamInfo", updatedTeam);
+            }
+            return Unauthorized();
+;        }
     }
 }

--- a/Gordon360/Controllers/RecIM/TeamsController.cs
+++ b/Gordon360/Controllers/RecIM/TeamsController.cs
@@ -2,6 +2,7 @@ using Gordon360.Authorization;
 using Gordon360.Models.CCT;
 using Gordon360.Models.ViewModels.RecIM;
 using Gordon360.Services.RecIM;
+using Gordon360.Static.Names;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -87,17 +88,12 @@ namespace Gordon360.Controllers.RecIM
         /// <returns></returns>
         [HttpPost]
         [Route("{teamID}/participants")]
+        [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_TEAM)]
         public async Task<ActionResult> AddParticipantToTeam(int teamID, ParticipantTeamUploadViewModel participant)
         {
-            var username = AuthUtils.GetUsername(User);
-            var isTeamCaptain = _teamService.IsTeamCaptain(username, teamID);
-            if (isTeamCaptain)
-            {
-                participant.RoleTypeID = participant.RoleTypeID ?? 3;
-                var participantTeam = await _teamService.AddUserToTeamAsync(teamID, participant);
-                return CreatedAtAction("AddParticipantToTeam", participantTeam);
-            }
-            return Forbid();
+            participant.RoleTypeID = participant.RoleTypeID ?? 3;
+            var participantTeam = await _teamService.AddUserToTeamAsync(teamID, participant);
+            return CreatedAtAction("AddParticipantToTeam", participantTeam);
         }
 
         /// <summary>
@@ -108,17 +104,12 @@ namespace Gordon360.Controllers.RecIM
         /// <returns></returns>
         [HttpPatch]
         [Route("{teamID}/participants")]
+        [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_TEAM)]
         public async Task<ActionResult> UpdateTeamParticipant(int teamID, ParticipantTeamUploadViewModel participant)
         {
-            var username = AuthUtils.GetUsername(User);
-            var isTeamCaptain = _teamService.IsTeamCaptain(username, teamID);
-            if (isTeamCaptain)
-            {
-                participant.RoleTypeID = participant.RoleTypeID ?? 3;
-                var participantTeam = await _teamService.UpdateParticipantRoleAsync(teamID, participant);
-                return CreatedAtAction("UpdateTeamParticipant", participantTeam);
-            }
-            return Forbid();
+            participant.RoleTypeID = participant.RoleTypeID ?? 3;
+            var participantTeam = await _teamService.UpdateParticipantRoleAsync(teamID, participant);
+            return CreatedAtAction("UpdateTeamParticipant", participantTeam);
         }
 
         /// <summary>
@@ -129,16 +120,11 @@ namespace Gordon360.Controllers.RecIM
         /// <returns></returns>
         [HttpPatch]
         [Route("{teamID}")]
+        [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_TEAM)]
         public async Task<ActionResult> UpdateTeamInfo(int teamID, TeamPatchViewModel team)
         {
-            var username = AuthUtils.GetUsername(User);
-            var isTeamCaptain = _teamService.IsTeamCaptain(username, teamID);
-            if (isTeamCaptain)
-            {
-                var updatedTeam = await _teamService.UpdateTeamAsync(teamID, team);
-                return CreatedAtAction("UpdateTeamInfo", updatedTeam);
-            }
-            return Forbid();
+            var updatedTeam = await _teamService.UpdateTeamAsync(teamID, team);
+            return CreatedAtAction("UpdateTeamInfo", updatedTeam);
 ;        }
     }
 }

--- a/Gordon360/Controllers/RecIM/TeamsController.cs
+++ b/Gordon360/Controllers/RecIM/TeamsController.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Graph;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/Gordon360/Controllers/RecIM/TeamsController.cs
+++ b/Gordon360/Controllers/RecIM/TeamsController.cs
@@ -97,7 +97,7 @@ namespace Gordon360.Controllers.RecIM
                 var participantTeam = await _teamService.AddUserToTeamAsync(teamID, participant);
                 return CreatedAtAction("AddParticipantToTeam", participantTeam);
             }
-            return Unauthorized();
+            return Forbid();
         }
 
         /// <summary>
@@ -118,7 +118,7 @@ namespace Gordon360.Controllers.RecIM
                 var participantTeam = await _teamService.UpdateParticipantRoleAsync(teamID, participant);
                 return CreatedAtAction("UpdateTeamParticipant", participantTeam);
             }
-            return Unauthorized();
+            return Forbid();
         }
 
         /// <summary>
@@ -138,7 +138,7 @@ namespace Gordon360.Controllers.RecIM
                 var updatedTeam = await _teamService.UpdateTeamAsync(teamID, team);
                 return CreatedAtAction("UpdateTeamInfo", updatedTeam);
             }
-            return Unauthorized();
+            return Forbid();
 ;        }
     }
 }

--- a/Gordon360/Services/RecIM/ActivityService.cs
+++ b/Gordon360/Services/RecIM/ActivityService.cs
@@ -105,7 +105,7 @@ namespace Gordon360.Services.RecIM
                             .FirstOrDefault();
             return activity;
         }
-        public async Task<ActivityCreatedViewModel> UpdateActivity(int activityID, ActivityPatchViewModel updatedActivity)
+        public async Task<ActivityCreatedViewModel> UpdateActivityAsync(int activityID, ActivityPatchViewModel updatedActivity)
         {
             var activity = await _context.Activity.FindAsync(activityID);
             activity.Name = updatedActivity.Name ?? activity.Name;
@@ -123,7 +123,7 @@ namespace Gordon360.Services.RecIM
             await _context.SaveChangesAsync();
             return activity;
         }
-        public async Task<ActivityCreatedViewModel> PostActivity(string username, ActivityUploadViewModel a)
+        public async Task<ActivityCreatedViewModel> PostActivityAsync(string username, ActivityUploadViewModel a)
         {
             var activity = new Activity
             {
@@ -141,13 +141,10 @@ namespace Gordon360.Services.RecIM
             await _context.Activity.AddAsync(activity);
             await _context.SaveChangesAsync();
 
-            // set the privRole of the current user to "admin" in ParticipantActivity
-            await PostParticipantActivity(username, activity.ID, 3, false); // privTypeID: 3 => admin
-
             return activity;
         }
 
-        public async Task<ParticipantActivityCreatedViewModel> PostParticipantActivity(string username, int activityID, int privTypeID, bool isFreeAgent)
+        public async Task<ParticipantActivityCreatedViewModel> PostParticipantActivityAsync(string username, int activityID, int privTypeID, bool isFreeAgent)
         {
             var participantActivity = new ParticipantActivity
             {
@@ -162,15 +159,10 @@ namespace Gordon360.Services.RecIM
             return participantActivity;
         }
 
-        public bool IsActivityAdmin(string username, int activityID)
+        public bool IsReferee(string username, int activityID)
         {
-            return _context.ParticipantActivity.Any(pa => 
-                pa.ParticipantUsername == username 
-                && pa.ActivityID == activityID 
-                && pa.PrivTypeID == 3
-            );
+            return _context.ParticipantActivity.Any(pa => pa.ParticipantUsername == username && pa.ActivityID == activityID);
         }
     }
-
 }
 

--- a/Gordon360/Services/RecIM/ActivityService.cs
+++ b/Gordon360/Services/RecIM/ActivityService.cs
@@ -161,7 +161,10 @@ namespace Gordon360.Services.RecIM
 
         public bool IsReferee(string username, int activityID)
         {
-            return _context.ParticipantActivity.Any(pa => pa.ParticipantUsername == username && pa.ActivityID == activityID);
+            return _context.ParticipantActivity.Any(pa =>
+                pa.ParticipantUsername == username 
+                && pa.ActivityID == activityID 
+                && pa.PrivTypeID == 2); // PrivType: 2 => Referee
         }
     }
 }

--- a/Gordon360/Services/RecIM/ActivityService.cs
+++ b/Gordon360/Services/RecIM/ActivityService.cs
@@ -123,7 +123,7 @@ namespace Gordon360.Services.RecIM
             await _context.SaveChangesAsync();
             return activity;
         }
-        public async Task<ActivityCreatedViewModel> PostActivity(ActivityUploadViewModel a)
+        public async Task<ActivityCreatedViewModel> PostActivity(string username, ActivityUploadViewModel a)
         {
             var activity = new Activity
             {
@@ -140,9 +140,36 @@ namespace Gordon360.Services.RecIM
             };
             await _context.Activity.AddAsync(activity);
             await _context.SaveChangesAsync();
+
+            // set the privRole of the current user to "admin" in ParticipantActivity
+            await PostParticipantActivity(username, activity.ID, 3, false); // privTypeID: 3 => admin
+
             return activity;
         }
 
+        public async Task<ParticipantActivityCreatedViewModel> PostParticipantActivity(string username, int activityID, int privTypeID, bool isFreeAgent)
+        {
+            var participantActivity = new ParticipantActivity
+            {
+                ActivityID = activityID,
+                ParticipantUsername = username,
+                PrivTypeID = privTypeID,
+                IsFreeAgent = isFreeAgent,
+            };
+            await _context.ParticipantActivity.AddAsync(participantActivity);
+            await _context.SaveChangesAsync();
+
+            return participantActivity;
+        }
+
+        public bool IsActivityAdmin(string username, int activityID)
+        {
+            return _context.ParticipantActivity.Any(pa => 
+                pa.ParticipantUsername == username 
+                && pa.ActivityID == activityID 
+                && pa.PrivTypeID == 3
+            );
+        }
     }
 
 }

--- a/Gordon360/Services/RecIM/ActivityService.cs
+++ b/Gordon360/Services/RecIM/ActivityService.cs
@@ -123,7 +123,7 @@ namespace Gordon360.Services.RecIM
             await _context.SaveChangesAsync();
             return activity;
         }
-        public async Task<ActivityCreatedViewModel> PostActivityAsync(string username, ActivityUploadViewModel a)
+        public async Task<ActivityCreatedViewModel> PostActivityAsync(ActivityUploadViewModel a)
         {
             var activity = new Activity
             {

--- a/Gordon360/Services/RecIM/MatchService.cs
+++ b/Gordon360/Services/RecIM/MatchService.cs
@@ -189,7 +189,7 @@ namespace Gordon360.Services.RecIM
                         });
             return match;
         }
-        public async Task<MatchCreatedViewModel> PostMatch(MatchUploadViewModel m)
+        public async Task<MatchCreatedViewModel> PostMatchAsync(MatchUploadViewModel m)
         {
             var match = new Match
             {
@@ -203,13 +203,13 @@ namespace Gordon360.Services.RecIM
 
             foreach(var teamID in m.TeamIDs)
             {
-                await CreateMatchTeamMapping(teamID, match.ID);
+                await CreateMatchTeamMappingAsync(teamID, match.ID);
             }
             await _context.SaveChangesAsync();
             return match;
         }
 
-        private async Task CreateMatchTeamMapping(int teamID, int matchID)
+        private async Task CreateMatchTeamMappingAsync(int teamID, int matchID)
         {
             var matchTeam = new MatchTeam
             {
@@ -221,7 +221,7 @@ namespace Gordon360.Services.RecIM
             };
             await _context.MatchTeam.AddAsync(matchTeam);
         }
-        public async Task<MatchParticipantViewModel> AddParticipantAttendance(string username, int matchID)
+        public async Task<MatchParticipantViewModel> AddParticipantAttendanceAsync(string username, int matchID)
         {
             var matchParticipant = new MatchParticipant
             {
@@ -232,7 +232,7 @@ namespace Gordon360.Services.RecIM
             await _context.SaveChangesAsync();
             return matchParticipant;
         }
-        public async Task<MatchTeamViewModel> UpdateTeamStats(int matchID, MatchStatsPatchViewModel vm)
+        public async Task<MatchTeamViewModel> UpdateTeamStatsAsync(int matchID, MatchStatsPatchViewModel vm)
         {
             var teamstats = _context.MatchTeam.FirstOrDefault(mt => mt.MatchID == matchID && mt.TeamID == vm.TeamID);
             teamstats.Score = vm.Score ?? teamstats.Score;
@@ -248,7 +248,7 @@ namespace Gordon360.Services.RecIM
             return teamstats;
 
         }
-        public async Task<MatchCreatedViewModel> UpdateMatch(int matchID, MatchPatchViewModel vm)
+        public async Task<MatchCreatedViewModel> UpdateMatchAsync(int matchID, MatchPatchViewModel vm)
         {
             var match = _context.Match.FirstOrDefault(m => m.ID == matchID);
             match.Time = vm.Time ?? match.Time;

--- a/Gordon360/Services/RecIM/ParticipantService.cs
+++ b/Gordon360/Services/RecIM/ParticipantService.cs
@@ -147,6 +147,7 @@ namespace Gordon360.Services.RecIM
             await _context.SaveChangesAsync();
             return participant;
         }
+
         public async Task<ParticipantActivityCreatedViewModel> UpdateParticipantActivity(string username, ParticipantActivityPatchViewModel updatedParticipant)
         {           
             var participantActivity = _context.ParticipantActivity
@@ -160,6 +161,7 @@ namespace Gordon360.Services.RecIM
             await _context.SaveChangesAsync();
             return participantActivity;
         }
+
         public async Task<ParticipantStatusCreatedViewModel> UpdateParticipantStatus(string username, ParticipantStatusPatchViewModel participantStatus)
         {
             // End previous status

--- a/Gordon360/Services/RecIM/ParticipantService.cs
+++ b/Gordon360/Services/RecIM/ParticipantService.cs
@@ -57,7 +57,7 @@ namespace Gordon360.Services.RecIM
             return participant;
         }
 
-        public async Task<ParticipantNotificationCreatedViewModel> SendParticipantNotification(string username, ParticipantNotificationUploadViewModel notificationVM)
+        public async Task<ParticipantNotificationCreatedViewModel> SendParticipantNotificationAsync(string username, ParticipantNotificationUploadViewModel notificationVM)
         {
             var newNotification = new ParticipantNotification
             {
@@ -122,7 +122,7 @@ namespace Gordon360.Services.RecIM
             return res;
         }
 
-        public async Task<ParticipantViewModel> PostParticipant(string username)
+        public async Task<ParticipantViewModel> PostParticipantAsync(string username)
         {
             await _context.Participant.AddAsync(new Participant
             {
@@ -140,7 +140,7 @@ namespace Gordon360.Services.RecIM
             return participant;
         }
 
-        public async Task<ParticipantViewModel> UpdateParticipant(string username, bool isAdmin)
+        public async Task<ParticipantViewModel> UpdateParticipantAsync(string username, bool isAdmin)
         {
             var participant = GetParticipantByUsername(username);
             participant.IsAdmin = isAdmin;
@@ -148,7 +148,7 @@ namespace Gordon360.Services.RecIM
             return participant;
         }
 
-        public async Task<ParticipantActivityCreatedViewModel> UpdateParticipantActivity(string username, ParticipantActivityPatchViewModel updatedParticipant)
+        public async Task<ParticipantActivityCreatedViewModel> UpdateParticipantActivityAsync(string username, ParticipantActivityPatchViewModel updatedParticipant)
         {           
             var participantActivity = _context.ParticipantActivity
                                         .FirstOrDefault(pa => pa.ParticipantUsername == username 
@@ -162,7 +162,7 @@ namespace Gordon360.Services.RecIM
             return participantActivity;
         }
 
-        public async Task<ParticipantStatusCreatedViewModel> UpdateParticipantStatus(string username, ParticipantStatusPatchViewModel participantStatus)
+        public async Task<ParticipantStatusCreatedViewModel> UpdateParticipantStatusAsync(string username, ParticipantStatusPatchViewModel participantStatus)
         {
             // End previous status
             var prevStatus = _context.ParticipantStatusHistory
@@ -181,6 +181,11 @@ namespace Gordon360.Services.RecIM
             await _context.ParticipantStatusHistory.AddAsync(status);
             await _context.SaveChangesAsync();
             return status;
+        }
+
+        public bool IsAdmin(string username)
+        {
+            return _context.Participant.Any(p => p.Username == username && p.IsAdmin == true);
         }
     }
 

--- a/Gordon360/Services/RecIM/SeriesService.cs
+++ b/Gordon360/Services/RecIM/SeriesService.cs
@@ -225,7 +225,7 @@ namespace Gordon360.Services.RecIM
                 SurfaceID = 1,
                 TeamIDs = teams
             };
-            await _matchService.PostMatch(match); 
+            await _matchService.PostMatchAsync(match); 
         }
     }
 

--- a/Gordon360/Services/RecIM/SeriesService.cs
+++ b/Gordon360/Services/RecIM/SeriesService.cs
@@ -100,7 +100,7 @@ namespace Gordon360.Services.RecIM
         {
             return GetSeries().FirstOrDefault(s => s.ID == seriesID);
         }
-        public async Task<SeriesCreatedViewModel> PostSeries(SeriesUploadViewModel newSeries, int? referenceSeriesID)
+        public async Task<SeriesCreatedViewModel> PostSeriesAsync(SeriesUploadViewModel newSeries, int? referenceSeriesID)
         {
             var series = new Series
             {
@@ -125,10 +125,10 @@ namespace Gordon360.Services.RecIM
                 teams = teams.Take(newSeries.NumberOfTeamsAdmitted ?? 0);//will never be null but 0 is to silence error
             }
            
-            await CreateSeriesTeamMapping(teams, series.ID);
+            await CreateSeriesTeamMappingAsync(teams, series.ID);
             return series;
         }
-        public async Task<SeriesCreatedViewModel> UpdateSeries(int seriesID, SeriesPatchViewModel update)
+        public async Task<SeriesCreatedViewModel> UpdateSeriesAsync(int seriesID, SeriesPatchViewModel update)
         {
             var s = await _context.Series.FindAsync(seriesID);
             s.Name = update.Name ?? s.Name;
@@ -140,7 +140,7 @@ namespace Gordon360.Services.RecIM
             return s;
         }
 
-        private async Task CreateSeriesTeamMapping(IEnumerable<int> teams, int seriesID)
+        private async Task CreateSeriesTeamMappingAsync(IEnumerable<int> teams, int seriesID)
         {
             foreach (var teamID in teams)
             {
@@ -156,7 +156,7 @@ namespace Gordon360.Services.RecIM
             await _context.SaveChangesAsync();
         }
 
-        public async Task ScheduleMatches(int seriesID)
+        public async Task ScheduleMatchesAsync(int seriesID)
         {
             var typeCode = _context.SeriesType
                 .FirstOrDefault(st =>
@@ -178,7 +178,7 @@ namespace Gordon360.Services.RecIM
             }
             if (typeCode == "l")
             {
-                await ScheduleLadder(seriesID);
+                await ScheduleLadderAsync(seriesID);
             }
         }
         private Task ScheduleRoundRobin(int seriesID)
@@ -210,7 +210,7 @@ namespace Gordon360.Services.RecIM
                 .AsEnumerable();
             throw new NotImplementedException();
         }
-        private async Task ScheduleLadder(int seriesID)
+        private async Task ScheduleLadderAsync(int seriesID)
         {
             var teams = _context.SeriesTeam
                 .Where(st => st.ID == seriesID)

--- a/Gordon360/Services/RecIM/SportService.cs
+++ b/Gordon360/Services/RecIM/SportService.cs
@@ -32,7 +32,7 @@ namespace Gordon360.Services.RecIM
             return _context.Sport.Select(s => (SportViewModel)s).AsEnumerable();
         }
 
-        public async Task<SportViewModel> PostSport(SportUploadViewModel newSport)
+        public async Task<SportViewModel> PostSportAsync(SportUploadViewModel newSport)
         {
             var sport = new Sport
             {
@@ -46,7 +46,7 @@ namespace Gordon360.Services.RecIM
             return sport;
         }
 
-        public async Task<SportViewModel> UpdateSport(SportViewModel updatedSport)
+        public async Task<SportViewModel> UpdateSportAsync(SportViewModel updatedSport)
         {
             var sport = _context.Sport.FirstOrDefault(s => s.ID == updatedSport.ID);
             sport.Name = updatedSport.Name ?? sport.Name;
@@ -56,7 +56,6 @@ namespace Gordon360.Services.RecIM
             await _context.SaveChangesAsync();
 
             return sport;
-
         }
     }
 }

--- a/Gordon360/Services/RecIM/TeamService.cs
+++ b/Gordon360/Services/RecIM/TeamService.cs
@@ -186,7 +186,10 @@ namespace Gordon360.Services.RecIM
             return _context.ParticipantTeam.Any(t =>
                         t.TeamID == teamID
                         && t.ParticipantUsername == username
-                        && t.RoleTypeID == 5
+                        && (
+                            t.RoleTypeID == 5       // RoleType: 5 => captain
+                            || t.RoleTypeID == 4    // RoleType: 4 => co-captain
+                        )
             );
         }
     }

--- a/Gordon360/Services/RecIM/TeamService.cs
+++ b/Gordon360/Services/RecIM/TeamService.cs
@@ -181,7 +181,7 @@ namespace Gordon360.Services.RecIM
             return participantTeam;
         }
 
-        public bool IsTeamCaptain(int teamID, string username)
+        public bool IsTeamCaptain(string username, int teamID)
         {
             return _context.ParticipantTeam.Any(t =>
                         t.TeamID == teamID

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -315,7 +315,7 @@ namespace Gordon360.Services
             Models.ViewModels.RecIM.ActivityViewModel? GetActivityByID(int activityID);
             IEnumerable<Models.ViewModels.RecIM.ActivityViewModel> GetActivitiesByTime(DateTime? time);
             Task<ActivityCreatedViewModel> UpdateActivityAsync(int activytID, ActivityPatchViewModel updatedActivity);
-            Task<ActivityCreatedViewModel> PostActivityAsync(string username, ActivityUploadViewModel newActivity);
+            Task<ActivityCreatedViewModel> PostActivityAsync(ActivityUploadViewModel newActivity);
             Task<ParticipantActivityCreatedViewModel> PostParticipantActivityAsync(string username, int activityID, int privTypeID, bool isFreeAgent);
             bool IsReferee(string username, int activityID);
         }

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -314,19 +314,19 @@ namespace Gordon360.Services
             IEnumerable<Models.ViewModels.RecIM.ActivityViewModel> GetActivities();
             Models.ViewModels.RecIM.ActivityViewModel? GetActivityByID(int activityID);
             IEnumerable<Models.ViewModels.RecIM.ActivityViewModel> GetActivitiesByTime(DateTime? time);
-            Task<ActivityCreatedViewModel> UpdateActivity(int activytID, ActivityPatchViewModel updatedActivity);
-            Task<ActivityCreatedViewModel> PostActivity(string username, ActivityUploadViewModel newActivity);
-            Task<ParticipantActivityCreatedViewModel> PostParticipantActivity(string username, int activityID, int privTypeID, bool isFreeAgent);
-            bool IsActivityAdmin(string username, int activityID);
+            Task<ActivityCreatedViewModel> UpdateActivityAsync(int activytID, ActivityPatchViewModel updatedActivity);
+            Task<ActivityCreatedViewModel> PostActivityAsync(string username, ActivityUploadViewModel newActivity);
+            Task<ParticipantActivityCreatedViewModel> PostParticipantActivityAsync(string username, int activityID, int privTypeID, bool isFreeAgent);
+            bool IsReferee(string username, int activityID);
         }
         public interface ISeriesService
         {
             IEnumerable<SeriesViewModel> GetSeries(bool active);
             IEnumerable<SeriesViewModel> GetSeriesByActivityID(int activityID);
             SeriesViewModel GetSeriesByID(int seriesID);
-            Task<SeriesCreatedViewModel> PostSeries(SeriesUploadViewModel newSeries, int? referenceSeriesID);
-            Task<SeriesCreatedViewModel> UpdateSeries(int seriesID, SeriesPatchViewModel series);
-            Task ScheduleMatches(int seriesID);
+            Task<SeriesCreatedViewModel> PostSeriesAsync(SeriesUploadViewModel newSeries, int? referenceSeriesID);
+            Task<SeriesCreatedViewModel> UpdateSeriesAsync(int seriesID, SeriesPatchViewModel series);
+            Task ScheduleMatchesAsync(int seriesID);
         }
 
         public interface ITeamService
@@ -346,29 +346,30 @@ namespace Gordon360.Services
             IEnumerable<ParticipantStatusViewModel> GetParticipantStatusHistory(string username);
             ParticipantViewModel GetParticipantByUsername(string username);
             IEnumerable<TeamViewModel> GetParticipantTeams(string username);
-            Task<ParticipantViewModel> PostParticipant(string username);
-            Task<ParticipantViewModel> UpdateParticipant(string username, bool isAdmin);
-            Task<ParticipantNotificationCreatedViewModel> SendParticipantNotification(string username, ParticipantNotificationUploadViewModel notificationVM);
-            Task<ParticipantActivityCreatedViewModel> UpdateParticipantActivity(string username, ParticipantActivityPatchViewModel updatedParticipant);
-            Task<ParticipantStatusCreatedViewModel> UpdateParticipantStatus(string username, ParticipantStatusPatchViewModel participantStatus);
+            Task<ParticipantViewModel> PostParticipantAsync(string username);
+            Task<ParticipantViewModel> UpdateParticipantAsync(string username, bool isAdmin);
+            Task<ParticipantNotificationCreatedViewModel> SendParticipantNotificationAsync(string username, ParticipantNotificationUploadViewModel notificationVM);
+            Task<ParticipantActivityCreatedViewModel> UpdateParticipantActivityAsync(string username, ParticipantActivityPatchViewModel updatedParticipant);
+            Task<ParticipantStatusCreatedViewModel> UpdateParticipantStatusAsync(string username, ParticipantStatusPatchViewModel participantStatus);
+            bool IsAdmin(string username);
         }
 
         public interface ISportService
         {
             IEnumerable<SportViewModel> GetSports();
             SportViewModel GetSportByID(int sportID);
-            Task<SportViewModel> PostSport(SportUploadViewModel newSport);
-            Task<SportViewModel> UpdateSport(SportViewModel updatedSport);
+            Task<SportViewModel> PostSportAsync(SportUploadViewModel newSport);
+            Task<SportViewModel> UpdateSportAsync(SportViewModel updatedSport);
         }
 
         public interface IMatchService
         {
             MatchViewModel GetMatchByID(int matchID);
             IEnumerable<MatchViewModel> GetMatchBySeriesID(int seriesID);
-            Task<MatchCreatedViewModel> PostMatch(MatchUploadViewModel match);
-            Task<MatchTeamViewModel> UpdateTeamStats(int matchID, MatchStatsPatchViewModel match);
-            Task<MatchCreatedViewModel> UpdateMatch(int matchID, MatchPatchViewModel match);
-            Task<MatchParticipantViewModel> AddParticipantAttendance(string username, int matchID);
+            Task<MatchCreatedViewModel> PostMatchAsync(MatchUploadViewModel match);
+            Task<MatchTeamViewModel> UpdateTeamStatsAsync(int matchID, MatchStatsPatchViewModel match);
+            Task<MatchCreatedViewModel> UpdateMatchAsync(int matchID, MatchPatchViewModel match);
+            Task<MatchParticipantViewModel> AddParticipantAttendanceAsync(string username, int matchID);
             IEnumerable<TeamMatchHistoryViewModel> GetMatchHistoryByTeamID(int teamID);
         }
     }

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -315,8 +315,9 @@ namespace Gordon360.Services
             Models.ViewModels.RecIM.ActivityViewModel? GetActivityByID(int activityID);
             IEnumerable<Models.ViewModels.RecIM.ActivityViewModel> GetActivitiesByTime(DateTime? time);
             Task<ActivityCreatedViewModel> UpdateActivity(int activytID, ActivityPatchViewModel updatedActivity);
-            Task<ActivityCreatedViewModel> PostActivity(ActivityUploadViewModel newActivity);
-
+            Task<ActivityCreatedViewModel> PostActivity(string username, ActivityUploadViewModel newActivity);
+            Task<ParticipantActivityCreatedViewModel> PostParticipantActivity(string username, int activityID, int privTypeID, bool isFreeAgent);
+            bool IsActivityAdmin(string username, int activityID);
         }
         public interface ISeriesService
         {
@@ -335,7 +336,7 @@ namespace Gordon360.Services
             Task<ParticipantTeamViewModel> AddUserToTeamAsync(int teamID, ParticipantTeamUploadViewModel participant);
             Task<TeamCreatedViewModel> UpdateTeamAsync(int teamID, TeamPatchViewModel updatedTeam);
             Task<ParticipantTeamViewModel> UpdateParticipantRoleAsync(int teamID, ParticipantTeamUploadViewModel participant);
-            bool IsTeamCaptain(int teamID, string username);
+            bool IsTeamCaptain(string username, int teamID);
         }
 
         public interface IParticipantService

--- a/Gordon360/Static Classes/Names.cs
+++ b/Gordon360/Static Classes/Names.cs
@@ -26,6 +26,11 @@
         public const string CHECKIN = "Info relating to a student's Academic Check-In";
         public const string SHIFT = "A shift that a student has worked";
         public const string CLIFTON_STRENGTHS = "A student's uploaded clifton strengthsfinder results";
+        public const string RECIM_ACTIVITY = "A RecIM activity resource";
+        public const string RECIM_SERIES = "A RecIM series resource";
+        public const string RECIM_MATCH = "A RecIM match resource";
+        public const string RECIM_TEAM = "A RecIM team resource";
+        public const string RECIM_SPORT = "A RecIM sport resource";
 
         // Partial resources, to be targetted by Operation.READ_PARTIAL
         public const string MEMBERSHIP_REQUEST_BY_ACTIVITY = "Membership Request Resources associated with an activity";


### PR DESCRIPTION
New methods added to `RecIM/services`:
 - `IsActivityAdmin` in `activityService`
 - `IsTeamCaptain` in `teamService` (this method is already in `recim` when `teamService` was written)
 
Use internal authorization to check if the current user has required team role or activity privType, if not, return `Forbid()`.

RecIM Project Board Issue Link https://github.com/gordon-cs/RecIM-Docs/issues/73.

Also link https://github.com/gordon-cs/RecIM-Docs/issues/76.