### PR TITLE
Require Username in MembershipUploadViewModel from Request

### DIFF
--- a/Gordon360/Models/ViewModels/MembershipUploadViewModel.cs
+++ b/Gordon360/Models/ViewModels/MembershipUploadViewModel.cs
@@ -20,21 +20,23 @@ namespace Gordon360.Models.ViewModels
                 ACT_CDE = this.Activity,
                 SESS_CDE = this.Session,
                 ID_NUM = gordonId,
-                BEGIN_DTE = beginDate,
                 PART_CDE = this.Participation,
+                BEGIN_DTE = beginDate,
                 COMMENT_TXT = this.CommentText,
                 GRP_ADMIN = this.GroupAdmin,
                 PRIVACY = this.Privacy,
-                USER_NAME = Environment.UserName
+                USER_NAME = Environment.UserName,
+                JOB_NAME = "360"
             };
         }
 
-        public static implicit operator MembershipUploadViewModel(REQUEST request)
+        public static MembershipUploadViewModel FromRequest(REQUEST request, String username)
         {
             return new MembershipUploadViewModel
             {
                 Activity = request.ACT_CDE,
                 Session = request.SESS_CDE,
+                Username = username,
                 Participation = request.PART_CDE,
                 CommentText = request.COMMENT_TXT,
                 GroupAdmin = false,

--- a/Gordon360/Services/MembershipRequestService.cs
+++ b/Gordon360/Services/MembershipRequestService.cs
@@ -81,7 +81,7 @@ namespace Gordon360.Services
                 throw new BadInputException() { ExceptionMessage = "The request has already been approved."};
             }
 
-            MembershipUploadViewModel newMembership = (MembershipUploadViewModel) request;
+            MembershipUploadViewModel newMembership = MembershipUploadViewModel.FromRequest(request, _accountService.GetAccountByID(request.ID_NUM.ToString()).ADUserName);
             newMembership.Username = _accountService.GetAccountByID(request.ID_NUM.ToString()).ADUserName;
 
             var createdMembership = await _membershipService.AddAsync(newMembership);

--- a/Gordon360/Services/MembershipRequestService.cs
+++ b/Gordon360/Services/MembershipRequestService.cs
@@ -81,8 +81,8 @@ namespace Gordon360.Services
                 throw new BadInputException() { ExceptionMessage = "The request has already been approved."};
             }
 
-            MembershipUploadViewModel newMembership = MembershipUploadViewModel.FromRequest(request, _accountService.GetAccountByID(request.ID_NUM.ToString()).ADUserName);
-            newMembership.Username = _accountService.GetAccountByID(request.ID_NUM.ToString()).ADUserName;
+            var username = _accountService.GetAccountByID(request.ID_NUM.ToString()).ADUserName;
+            MembershipUploadViewModel newMembership = MembershipUploadViewModel.FromRequest(request, username);
 
             var createdMembership = await _membershipService.AddAsync(newMembership);
 


### PR DESCRIPTION
OLD (see below): I found a bug in the conversion from a request to a new membership (after it is approved). It seems that the username field was not getting filled out. This PR adds the field as a calculated value in the service.

Update 01/05/23 - This is actually not a bug. As @EjPlatzer points out, the username is set on the following line in `MembershipRequestService.cs`. This PR is now just for cleanup as I would prefer the new method, requiring that the username field be filled on a new membership before the method returns the object.