### PR TITLE
Eliminate Negative Days Left in Session

### DIFF
--- a/Gordon360/Services/SessionService.cs
+++ b/Gordon360/Services/SessionService.cs
@@ -48,11 +48,17 @@ namespace Gordon360.Services
             DateTime sessionBegin = currentSession.SessionBeginDate.Value;
             DateTime startTime = DateTime.Today;
 
+            int daysLeft = (sessionEnd - startTime).TotalDays;
+            // Account for possible negative value in between sessions
+            daysLeft = daysLeft < 0 ? 0 : daysLeft;
+
+            int daysInSemester = (sessionEnd - sessionBegin).TotalDays;
+
             return new double[2] {
             // Days left in semester
-            (sessionEnd - startTime).TotalDays,
+            daysLeft,
             // Total days in the semester
-            (sessionEnd - sessionBegin).TotalDays
+            daysInSemester
             };
         }
 


### PR DESCRIPTION
This PR fixes a small issue where the session "days left" route returns a negative value if the end of the session has passed, but the following session has not yet been set to active. This route now returns a minimum of 0 days left.