### PR TITLE
Automatically Refresh the Events Cache periodically

### DIFF
--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -171,26 +171,15 @@
             Server makes call to the database and returns all admins
             </remarks>
         </member>
-        <member name="M:Gordon360.Controllers.AdminsController.GetByGordonId(System.String)">
-            <summary>
-            Get a specific admin
-            </summary>
-            <returns>
-            The specific admin
-            </returns>
-            <remarks>
-            Server makes call to the database and returns the specific admin
-            </remarks>
-        </member>
-        <member name="M:Gordon360.Controllers.AdminsController.Post(Gordon360.Models.CCT.ADMIN)">
+        <member name="M:Gordon360.Controllers.AdminsController.Post(Gordon360.Models.ViewModels.AdminViewModel)">
             <summary>Create a new admin to be added to database</summary>
             <param name="admin">The admin item containing all required and relevant information</param>
             <returns></returns>
             <remarks>Posts a new admin to the server to be added into the database</remarks>
         </member>
-        <member name="M:Gordon360.Controllers.AdminsController.Delete(System.Int32)">
+        <member name="M:Gordon360.Controllers.AdminsController.Delete(System.String)">
             <summary>Delete an existing admin</summary>
-            <param name="id">The identifier for the admin to be deleted</param>
+            <param name="username">The username of the user to demote</param>
             <remarks>Calls the server to make a call and remove the given admin from the database</remarks>
         </member>
         <member name="M:Gordon360.Controllers.AdvancedSearchController.GetMajors">
@@ -401,61 +390,37 @@
             <returns></returns>
             <remarks>Posts a new error_log to the server to be added into the database. Useful if you want to input the datetime in the front end for greater accuracy</remarks>
         </member>
-        <member name="M:Gordon360.Controllers.MembershipsController.GetAsync">
-            <summary>
-            Get all memberships
-            </summary>
-            <returns>
-            A list of all memberships
-            </returns>
-            <remarks>
-            Server makes call to the database and returns all current memberships
-            </remarks>
-        </member>
-        <member name="M:Gordon360.Controllers.MembershipsController.GetMembershipsForActivityAsync(System.String,System.String)">
+        <member name="M:Gordon360.Controllers.MembershipsController.GetMembershipsForActivity(System.String,System.String)">
             <summary>
             Get all the memberships associated with a given activity
             </summary>
             <param name="activityCode">The activity ID</param>
             <param name="sessionCode">Optional code of session to get for</param>
-            <returns>IHttpActionResult</returns>
+            <returns>An IEnumerable of the matching MembershipViews</returns>
         </member>
-        <member name="M:Gordon360.Controllers.MembershipsController.GetGroupAdminForActivityAsync(System.String)">
+        <member name="M:Gordon360.Controllers.MembershipsController.GetGroupAdminsForActivity(System.String,System.String)">
             <summary>
             Gets the group admin memberships associated with a given activity.
             </summary>
             <param name="activityCode">The activity ID.</param>
-            <returns>A list of all leader-type memberships for the specified activity.</returns>
+            <param name="sessionCode">The session code of the activity.</param>
+            <returns>An IEnumerable of all leader-type memberships for the specified activity.</returns>
         </member>
-        <member name="M:Gordon360.Controllers.MembershipsController.GetLeadersForActivityAsync(System.String)">
+        <member name="M:Gordon360.Controllers.MembershipsController.GetLeadersForActivity(System.String)">
             <summary>
             Gets the leader-type memberships associated with a given activity.
             </summary>
             <param name="activityCode">The activity ID.</param>
-            <returns>A list of all leader-type memberships for the specified activity.</returns>
+            <returns>An IEnumerable of all leader-type memberships for the specified activity.</returns>
         </member>
         <member name="M:Gordon360.Controllers.MembershipsController.GetAdvisorsForActivityAsync(System.String)">
             <summary>
             Gets the advisor-type memberships associated with a given activity.
             </summary>
             <param name="activityCode">The activity ID.</param>
-            <returns>A list of all advisor-type memberships for the specified activity.</returns>
+            <returns>An IEnumerable of all advisor-type memberships for the specified activity.</returns>
         </member>
-        <member name="M:Gordon360.Controllers.MembershipsController.GetActivityFollowersCountAsync(System.String)">
-            <summary>
-            Gets the number of followers of an activity
-            </summary>
-            <param name="activityCode">The activity ID.</param>
-            <returns>The number of followers of the activity</returns>
-        </member>
-        <member name="M:Gordon360.Controllers.MembershipsController.GetActivityMembersCountAsync(System.String)">
-            <summary>
-            Gets the number of members (besides followers) of an activity
-            </summary>
-            <param name="activityCode">The activity ID.</param>
-            <returns>The number of members of the activity</returns>
-        </member>
-        <member name="M:Gordon360.Controllers.MembershipsController.GetActivityFollowersCountForSessionAsync(System.String,System.String)">
+        <member name="M:Gordon360.Controllers.MembershipsController.GetActivitySubscribersCountForSession(System.String,System.String)">
             <summary>
             Gets the number of followers of an activity
             </summary>
@@ -463,7 +428,7 @@
             <param name="sessionCode">The session code</param>
             <returns>The number of followers of the activity</returns>
         </member>
-        <member name="M:Gordon360.Controllers.MembershipsController.GetActivityMembersCountForSessionAsync(System.String,System.String)">
+        <member name="M:Gordon360.Controllers.MembershipsController.GetActivityMembersCountForSession(System.String,System.String)">
             <summary>
             Gets the number of members (excluding followers) of an activity
             </summary>
@@ -471,47 +436,38 @@
             <param name="sessionCode">The session code</param>
             <returns>The number of members of the activity</returns>
         </member>
-        <member name="M:Gordon360.Controllers.MembershipsController.PostAsync(Gordon360.Models.CCT.MEMBERSHIP)">
+        <member name="M:Gordon360.Controllers.MembershipsController.PostAsync(Gordon360.Models.ViewModels.MembershipUploadViewModel)">
             <summary>Create a new membership item to be added to database</summary>
-            <param name="membership">The membership item containing all required and relevant information</param>
-            <returns></returns>
+            <param name="membershipUpload">The membership item containing all required and relevant information</param>
+            <returns>The newly created membership as a MembershipView object</returns>
             <remarks>Posts a new membership to the server to be added into the database</remarks>
         </member>
-        <member name="M:Gordon360.Controllers.MembershipsController.GetMembershipsForStudentByUsenameAsync(System.String)">
-            <summary>
-            Fetch memberships that a specific student has been a part of
-            @TODO: Move security checks to state your business? Or consider changing implementation here
-            </summary>
-            <param name="username">The Student Username</param>
-            <returns>The membership information that the student is a part of</returns>
-        </member>
-        <member name="M:Gordon360.Controllers.MembershipsController.PutAsync(System.Int32,Gordon360.Models.CCT.MEMBERSHIP)">
+        <member name="M:Gordon360.Controllers.MembershipsController.PutAsync(System.Int32,Gordon360.Models.ViewModels.MembershipUploadViewModel)">
             <summary>Update an existing membership item</summary>
-            <param name="id">The membership id of whichever one is to be changed</param>
+            <param name="membershipID">The membership id of whichever one is to be changed</param>
             <param name="membership">The content within the membership that is to be changed and what it will change to</param>
             <remarks>Calls the server to make a call and update the database with the changed information</remarks>
+            <returns>The updated membership as a MembershipView object</returns>
         </member>
-        <member name="M:Gordon360.Controllers.MembershipsController.ToggleGroupAdminAsync(Gordon360.Models.CCT.MEMBERSHIP)">
+        <member name="M:Gordon360.Controllers.MembershipsController.SetGroupAdminAsync(System.Int32,System.Boolean)">
             <summary>Update an existing membership item to be a group admin or not</summary>
-             /// <param name="membership">The content within the membership that is to be changed</param>
+            <param name="membershipID">The content within the membership that is to be changed</param>
+            <param name="isGroupAdmin">The new value of GroupAdmin</param>
             <remarks>Calls the server to make a call and update the database with the changed information</remarks>
+            <returns>The updated membership as a MembershipView object</returns>
         </member>
-        <member name="M:Gordon360.Controllers.MembershipsController.TogglePrivacy(System.Int32,System.Boolean)">
+        <member name="M:Gordon360.Controllers.MembershipsController.SetPrivacyAsync(System.Int32,System.Boolean)">
             <summary>Update an existing membership item to be private or not</summary>
-            <param name="id">The id of the membership</param>
-            <param name = "p">the boolean value</param>
+            <param name="membershipID">The membership to set the privacy of</param>
+            <param name="isPrivate">The new value of Privacy for the membership</param>
             <remarks>Calls the server to make a call and update the database with the changed information</remarks>
+            <returns>The updated membership as a MembershipView object</returns>
         </member>
         <member name="M:Gordon360.Controllers.MembershipsController.Delete(System.Int32)">
             <summary>Delete an existing membership</summary>
-            <param name="id">The identifier for the membership to be deleted</param>
+            <param name="membershipID">The identifier for the membership to be deleted</param>
             <remarks>Calls the server to make a call and remove the given membership from the database</remarks>
-        </member>
-        <member name="M:Gordon360.Controllers.MembershipsController.IsGroupAdmin(System.Int32)">
-            <summary>	
-            Determines whether or not the given student is a Group Admin of some activity	
-            </summary>
-            <param name="id">The student id</param>
+            <returns>The deleted membership as a MembershipView object</returns>
         </member>
         <member name="M:Gordon360.Controllers.MyScheduleController.Get">
             <summary>
@@ -717,67 +673,71 @@
             <param name="imagePath">Path to the profile image to load</param>
             <returns></returns>
         </member>
-        <member name="M:Gordon360.Controllers.RequestsController.GetAsync">
+        <member name="M:Gordon360.Controllers.ProfilesController.GetMembershipsByUser(System.String)">
+            <summary>
+            Fetch memberships that a specific student has been a part of
+            @TODO: Move security checks to state your business? Or consider changing implementation here
+            </summary>
+            <param name="username">The Student Username</param>
+            <returns>The membership information that the student is a part of</returns>
+        </member>
+        <member name="M:Gordon360.Controllers.RequestsController.Get">
             <summary>
             Gets all Membership Request Objects
             </summary>
             <returns>List of all requests for membership</returns>
         </member>
-        <member name="M:Gordon360.Controllers.RequestsController.GetAsync(System.Int32)">
+        <member name="M:Gordon360.Controllers.RequestsController.Get(System.Int32)">
             <summary>
              Gets a specific Membership Request Object
             </summary>
             <param name="id">The ID of the membership request</param>
-            <returns>A memberships request with the specified id</returns>
+            <returns>A RequestView that matches the specified id</returns>
         </member>
-        <member name="M:Gordon360.Controllers.RequestsController.GetMembershipsRequestsForActivityAsync(System.String)">
+        <member name="M:Gordon360.Controllers.RequestsController.GetMembershipRequestsByActivity(System.String,System.String,System.String)">
             <summary>
             Gets the memberships requests for the specified activity
             </summary>
-            <param name="id">The activity code</param>
+            <param name="activityCode">The activity code</param>
+            <param name="sessionCode">The session code</param>
+            <param name="requestStatus">The optional status of the requests to search</param>
             <returns>All membership requests associated with the activity</returns>
         </member>
-        <member name="M:Gordon360.Controllers.RequestsController.GetMembershipsRequestsForStudentAsync">
+        <member name="M:Gordon360.Controllers.RequestsController.GetMembershipsRequestsForCurrentUser">
             <summary>
             Gets the memberships requests for the person making the request
             </summary>
-            <returns>All membership requests associated with the student</returns>
+            <returns>All membership requests associated with the current user</returns>
         </member>
-        <member name="M:Gordon360.Controllers.RequestsController.Post(Gordon360.Models.CCT.REQUEST)">
+        <member name="M:Gordon360.Controllers.RequestsController.PostAsync(Gordon360.Models.CCT.RequestUploadViewModel)">
             <summary>
             Creates a new membership request
             </summary>
             <param name="membershipRequest">The request to be added</param>
             <returns>The added request if successful. HTTP error message if not.</returns>
         </member>
-        <member name="M:Gordon360.Controllers.RequestsController.Put(System.Int32,Gordon360.Models.CCT.REQUEST)">
+        <member name="M:Gordon360.Controllers.RequestsController.PutAsync(System.Int32,Gordon360.Models.CCT.RequestUploadViewModel)">
             <summary>
             Updates a membership request
             </summary>
-            <param name="id">The membership request id</param>
+            <param name="membershipRequestID">The membership request id</param>
             <param name="membershipRequest">The updated membership request object</param>
             <returns>The updated request if successful. HTTP error message if not.</returns>
         </member>
-        <member name="M:Gordon360.Controllers.RequestsController.ApproveRequest(System.Int32)">
+        <member name="M:Gordon360.Controllers.RequestsController.UpdateStatusAsync(System.Int32,System.String)">
             <summary>
             Sets a membership request to Approved
             </summary>
-            <param name="id">The id of the membership request in question.</param>
-            <returns>If successful: THe updated membership request wrapped in an OK Http status code.</returns>
-        </member>
-        <member name="M:Gordon360.Controllers.RequestsController.DenyRequest(System.Int32)">
-            <summary>
-            Sets the membership request to Denied
-            </summary>
-            <param name="id">The id of the membership request in question.</param>
-            <returns>If successful: The updated membership request wrapped in an OK Http status code.</returns>
+            <param name="membershipRequestID">The id of the membership request in question.</param>
+            <param name="status">The status that the membership requst will be changed to.</param>
+            <returns>The updated request</returns>
         </member>
         <member name="M:Gordon360.Controllers.RequestsController.Delete(System.Int32)">
             <summary>
             Deletes a membership request
             </summary>
-            <param name="id">The id of the membership request to delete</param>
-            <returns>The deleted object</returns>
+            <param name="membershipRequestID">The id of the membership request to delete</param>
+            <returns>The deleted request as a RequestView</returns>
         </member>
         <member name="M:Gordon360.Controllers.SaveController.GetUpcomingRides">
             <summary>
@@ -1092,7 +1052,7 @@
             Fetches the account record with the specified email.
             </summary>
             <param name="email">The email address associated with the account.</param>
-            <returns>the student account information</returns>
+            <returns>the first account object which matches the email</returns>
         </member>
         <member name="M:Gordon360.Services.AccountService.GetAccountByUsername(System.String)">
             <summary>
@@ -1263,42 +1223,34 @@
             Service class to facilitate interacting with the Admin table.
             </summary>
         </member>
-        <member name="M:Gordon360.Services.AdministratorService.Get(System.Int32)">
-            <summary>
-            Fetches the admin resource whose id is specified as an argument.
-            </summary>
-            <param name="id">The admin ID.l</param>
-            <returns>The Specified administrator. If none was found, a null value is returned.</returns>
-        </member>
-        <member name="M:Gordon360.Services.AdministratorService.Get(System.String)">
-            <summary>
-            Fetches the admin resource whose username matches the specified argument
-            </summary>
-            <param name="gordon_id">The administrator's gordon id</param>
-            <returns>The Specified administrator. If none was found, a null value is returned.</returns>
-        </member>
         <member name="M:Gordon360.Services.AdministratorService.GetAll">
             <summary>
             Fetches all the administrators from the database
             </summary>
             <returns>Returns a list of administrators. If no administrators were found, an empty list is returned.</returns>
         </member>
-        <member name="M:Gordon360.Services.AdministratorService.Add(Gordon360.Models.CCT.ADMIN)">
+        <member name="M:Gordon360.Services.AdministratorService.GetByUsername(System.String)">
+            <summary>
+            Fetches a specific admin from the database
+            </summary>
+            <returns>Returns a list of administrators. If no administrators were found, an empty list is returned.</returns>
+        </member>
+        <member name="M:Gordon360.Services.AdministratorService.Add(Gordon360.Models.ViewModels.AdminViewModel)">
             <summary>
             Adds a new Administrator record to storage. Since we can't establish foreign key constraints and relationships on the database side,
             we do it here by using the validateAdmin() method.
             </summary>
-            <param name="admin">The admin to be added</param>
+            <param name="adminView">The admin to be added</param>
             <returns>The newly added Admin object</returns>
         </member>
-        <member name="M:Gordon360.Services.AdministratorService.Delete(System.Int32)">
+        <member name="M:Gordon360.Services.AdministratorService.Delete(System.String)">
             <summary>
             Delete the admin whose id is specified by the parameter.
             </summary>
-            <param name="id">The admin id</param>
+            <param name="username">The username of the admin to demote</param>
             <returns>The admin that was just deleted</returns>
         </member>
-        <member name="M:Gordon360.Services.AdministratorService.validateAdmin(Gordon360.Models.CCT.ADMIN)">
+        <member name="M:Gordon360.Services.AdministratorService.validateAdmin(Gordon360.Models.ViewModels.AdminViewModel)">
             <summary>
             Helper method to Validate an admin
             </summary>
@@ -1461,7 +1413,7 @@
             Calls a stored procedure that returns a row in the staff whitelist which has the given user id,
             if it is in the whitelist
             </summary>
-            <param name="gordonID"> The id of the person using the page </param>
+            <param name="username"> The id of the person using the page </param>
             <returns> Whether or not the user is on the staff whitelist </returns>
         </member>
         <member name="M:Gordon360.Services.HousingService.DeleteApplication(System.Int32)">
@@ -1565,205 +1517,204 @@
             Service class to facilitate data transactions between the MembershipRequestController and the database
             </summary>
         </member>
-        <member name="M:Gordon360.Services.MembershipRequestService.Add(Gordon360.Models.CCT.REQUEST)">
+        <member name="M:Gordon360.Services.MembershipRequestService.AddAsync(Gordon360.Models.CCT.RequestUploadViewModel)">
             <summary>
             Generate a new request to join an activity at a participation level higher than 'Guest'
             </summary>
-            <param name="membershipRequest">The membership request object</param>
-            <returns>The membership request object once it is added</returns>
+            <param name="membershipRequestUpload">The membership request object</param>
+            <returns>The new request object as a RequestView</returns>
         </member>
-        <member name="M:Gordon360.Services.MembershipRequestService.ApproveRequest(System.Int32)">
+        <member name="M:Gordon360.Services.MembershipRequestService.ApproveAsync(System.Int32)">
             <summary>
             Approves the request with the specified ID.
             </summary>
             <param name="requestID">The ID of the request to be approved</param>
-            <returns>The approved membership</returns>
+            <returns>The approved request as a RequestView</returns>
         </member>
-        <member name="M:Gordon360.Services.MembershipRequestService.Delete(System.Int32)">
-            <summary>
-            Delete the membershipRequest object whose id is given in the parameters 
-            </summary>
-            <param name="requestID">The membership request id</param>
-            <returns>A copy of the deleted membership request</returns>
-        </member>
-        <member name="M:Gordon360.Services.MembershipRequestService.DenyRequest(System.Int32)">
+        <member name="M:Gordon360.Services.MembershipRequestService.DenyAsync(System.Int32)">
             <summary>
             Denies the membership request object whose id is given in the parameters
             </summary>
             <param name="requestID">The membership request id</param>
-            <returns></returns>
+            <returns>A RequestView object of the denied request</returns>
         </member>
-        <member name="M:Gordon360.Services.MembershipRequestService.GetAsync(System.Int32)">
+        <member name="M:Gordon360.Services.MembershipRequestService.SetPendingAsync(System.Int32)">
+            <summary>
+            Denies the membership request object whose id is given in the parameters
+            </summary>
+            <param name="requestID">The membership request id</param>
+            <returns>A RequestView object of the now pending request</returns>
+        </member>
+        <member name="M:Gordon360.Services.MembershipRequestService.DeleteAsync(System.Int32)">
+            <summary>
+            Delete the membershipRequest object whose id is given in the parameters 
+            </summary>
+            <param name="requestID">The membership request id</param>
+            <returns>A copy of the deleted request as a RequestView</returns>
+        </member>
+        <member name="M:Gordon360.Services.MembershipRequestService.Get(System.Int32)">
             <summary>
             Get the membership request object whose Id is specified in the parameters.
             </summary>
             <param name="requestID">The membership request id</param>
-            <returns>If found, returns MembershipRequestViewModel. If not found, returns null.</returns>
+            <returns>The matching RequestView</returns>
         </member>
-        <member name="M:Gordon360.Services.MembershipRequestService.GetAllAsync">
+        <member name="M:Gordon360.Services.MembershipRequestService.GetAll">
             <summary>
             Fetches all the membership request objects from the database.
             </summary>
-            <returns>MembershipRequestViewModel IEnumerable. If no records are found, returns an empty IEnumerable.</returns>
+            <returns>RequestView IEnumerable. If no records are found, returns an empty IEnumerable.</returns>
         </member>
-        <member name="M:Gordon360.Services.MembershipRequestService.GetMembershipRequestsForActivityAsync(System.String)">
+        <member name="M:Gordon360.Services.MembershipRequestService.GetMembershipRequests(System.String,System.String,System.String)">
             <summary>
             Fetches all the membership requests associated with this activity
             </summary>
             <param name="activityCode">The activity id</param>
-            <returns>MembershipRequestViewModel IEnumerable. If no records are found, returns an empty IEnumerable.</returns>
+            <param name="sessionCode">The session code to filter by</param>
+            <param name="requestStatus">The request status to filter by</param>
+            <returns>A RequestView IEnumerable. If no records are found, returns an empty IEnumerable.</returns>
         </member>
-        <member name="M:Gordon360.Services.MembershipRequestService.GetMembershipRequestsForStudentAsync(System.String)">
+        <member name="M:Gordon360.Services.MembershipRequestService.GetMembershipRequestsByUsername(System.String)">
             <summary>
             Fetches all the membership requests associated with this student
             </summary>
             <param name="username">The AD Username of the user</param>
-            <returns>MembershipRequestViewModel IEnumerable. If no records are found, returns an empty IEnumerable.</returns>
+            <returns>A RequestView IEnumerable. If no records are found, returns an empty IEnumerable.</returns>
         </member>
-        <member name="M:Gordon360.Services.MembershipRequestService.Update(System.Int32,Gordon360.Models.CCT.REQUEST)">
+        <member name="M:Gordon360.Services.MembershipRequestService.UpdateAsync(System.Int32,Gordon360.Models.CCT.RequestUploadViewModel)">
             <summary>
             Update an existing membership request object
             </summary>
             <param name="requestID">The membership request id</param>
             <param name="membershipRequest">The newly modified membership request</param>
-            <returns></returns>
+            <returns>A RequestView object of the updated request</returns>
         </member>
         <member name="T:Gordon360.Services.MembershipService">
             <summary>
             Service Class that facilitates data transactions between the MembershipsController and the Membership database model.
             </summary>
         </member>
-        <member name="M:Gordon360.Services.MembershipService.AddAsync(Gordon360.Models.CCT.MEMBERSHIP)">
+        <member name="M:Gordon360.Services.MembershipService.AddAsync(Gordon360.Models.ViewModels.MembershipUploadViewModel)">
             <summary>
             Adds a new Membership record to storage. Since we can't establish foreign key constraints and relationships on the database side,
             we do it here by using the validateMembership() method.
             </summary>
-            <param name="membership">The membership to be added</param>
-            <returns>The newly added Membership object</returns>
+            <param name="membershipUpload">The membership to be added</param>
+            <returns>The newly added membership object as a MembershipView</returns>
         </member>
         <member name="M:Gordon360.Services.MembershipService.Delete(System.Int32)">
             <summary>
             Delete the membership whose id is specified by the parameter.
             </summary>
             <param name="membershipID">The membership id</param>
-            <returns>The membership that was just deleted</returns>
+            <returns>The membership that was just deleted as a MembershipView</returns>
         </member>
         <member name="M:Gordon360.Services.MembershipService.GetSpecificMembership(System.Int32)">
             <summary>	
             Fetch the membership whose id is specified by the parameter	
             </summary>	
             <param name="membershipID">The membership id</param>	
-            <returns>MembershipViewModel if found, null if not found</returns>	
+            <returns>The found membership as a MembershipView</returns>	
         </member>
-        <member name="M:Gordon360.Services.MembershipService.GetAllAsync">
-            <summary>
-            Fetches all membership records from storage.
-            </summary>
-            <returns>MembershipViewModel IEnumerable. If no records were found, an empty IEnumerable is returned.</returns>
-        </member>
-        <member name="M:Gordon360.Services.MembershipService.GetMembershipsForActivityAsync(System.String,System.String)">
+        <member name="M:Gordon360.Services.MembershipService.GetMembershipsForActivity(System.String,System.String,System.Nullable{System.Boolean},System.String[])">
             <summary>
             Fetches the memberships associated with the activity whose code is specified by the parameter.
             </summary>
-            <param name="activityCode">The activity code.</param>
+            <param name="activityCode">The activity code</param>
             <param name="sessionCode">Optional code of session to get memberships for</param>
-            <returns>MembershipViewModel IEnumerable. If no records were found, an empty IEnumerable is returned.</returns>
+            <param name="groupAdmin">Optional filter for group admins</param>
+            <param name="participationTypes">Optional filter for involvement participation type (MEMBR, ADV, LEAD, GUEST)</param>
+            <returns>An IEnumerable of the matching MembershipView objects</returns>
         </member>
-        <member name="M:Gordon360.Services.MembershipService.GetGroupAdminMembershipsForActivityAsync(System.String)">
+        <member name="M:Gordon360.Services.MembershipService.GetGroupAdminMembershipsForActivity(System.String,System.String)">
             <summary>
             Fetches the group admin (who have edit privileges of the page) of the activity whose activity code is specified by the parameter.
             </summary>
-            <param name="activityCode">The activity code.</param>
-            <returns>MembershipViewModel IEnumerable. If no records were found, an empty IEnumerable is returned.</returns>
+            <param name="activityCode">The activity code</param>
+            <param name="sessionCode">The session code</param>
+            <returns>An IEnumerable of the matching MembershipView objects</returns>
         </member>
-        <member name="M:Gordon360.Services.MembershipService.GetLeaderMembershipsForActivityAsync(System.String)">
+        <member name="M:Gordon360.Services.MembershipService.GetLeaderMembershipsForActivity(System.String)">
             <summary>
             Fetches the leaders of the activity whose activity code is specified by the parameter.
             </summary>
-            <param name="activityCode">The activity code.</param>
-            <returns>MembershipViewModel IEnumerable. If no records were found, an empty IEnumerable is returned.</returns>
+            <param name="activityCode">The activity code</param>
+            <returns>An IEnumerable of the matching MembershipView objects</returns>
         </member>
-        <member name="M:Gordon360.Services.MembershipService.GetAdvisorMembershipsForActivityAsync(System.String)">
+        <member name="M:Gordon360.Services.MembershipService.GetAdvisorMembershipsForActivity(System.String)">
             <summary>
             Fetches the advisors of the activity whose activity code is specified by the parameter.
             </summary>
-            <param name="activityCode">The activity code.</param>
-            <returns>MembershipViewModel IEnumerable. If no records were found, an empty IEnumerable is returned.</returns>
+            <param name="activityCode">The activity code</param>
+            <returns>An IEnumerable of the matching MembershipView objects</returns>
         </member>
-        <member name="M:Gordon360.Services.MembershipService.GetMembershipsForStudentAsync(System.String)">
+        <member name="M:Gordon360.Services.MembershipService.GetMembershipsByUser(System.String)">
             <summary>
             Fetches all the membership information linked to the student whose id appears as a parameter.
             </summary>
-            <param name="username">The student's AD Username.</param>
-            <returns>A MembershipViewModel IEnumerable. If nothing is found, an empty IEnumerable is returned.</returns>
+            <param name="username">The student's AD Username</param>
+            <returns>An IEnumerable of the matching MembershipView objects</returns>
         </member>
-        <member name="M:Gordon360.Services.MembershipService.GetActivityFollowersCountAsync(System.String)">
-            <summary>
-            Fetches the number of followers associated with the activity whose code is specified by the parameter.
-            </summary>
-            <param name="activityCode">The activity code.</param>
-            <returns>int.</returns>
-        </member>
-        <member name="M:Gordon360.Services.MembershipService.GetActivityMembersCountAsync(System.String)">
-            <summary>
-            Fetches the number of memberships associated with the activity whose code is specified by the parameter.
-            </summary>
-            <param name="activityCode">The activity code.</param>
-            <returns>int.</returns>
-        </member>
-        <member name="M:Gordon360.Services.MembershipService.GetActivityFollowersCountForSessionAsync(System.String,System.String)">
+        <member name="M:Gordon360.Services.MembershipService.GetActivitySubscribersCountForSession(System.String,System.String)">
             <summary>
             Fetches the number of followers associated with the activity and session whose codes are specified by the parameter.
             </summary>
-            <param name="activityCode">The activity code.</param>
+            <param name="activityCode">The activity code</param>
             <param name="sessionCode">The session code</param>
-            <returns>int.</returns>
+            <returns>The count of current guests (aka subscribers) for the activity</returns>
         </member>
-        <member name="M:Gordon360.Services.MembershipService.GetActivityMembersCountForSessionAsync(System.String,System.String)">
+        <member name="M:Gordon360.Services.MembershipService.GetActivityMembersCountForSession(System.String,System.String)">
             <summary>
             Fetches the number of memberships associated with the activity and session whose codes are specified by the parameter.
             </summary>
             <param name="activityCode">The activity code.</param>
             <param name="sessionCode">The session code</param>
-            <returns>int.</returns>
+            <returns>The count of current members for the activity</returns>
         </member>
-        <member name="M:Gordon360.Services.MembershipService.UpdateAsync(System.Int32,Gordon360.Models.CCT.MEMBERSHIP)">
+        <member name="M:Gordon360.Services.MembershipService.UpdateAsync(System.Int32,Gordon360.Models.ViewModels.MembershipUploadViewModel)">
             <summary>
             Updates the membership whose id is given as the first parameter to the contents of the second parameter.
             </summary>
-            <param name="membershipID">The membership id.</param>
-            <param name="membership">The updated membership.</param>
-            <returns>The newly modified membership.</returns>
+            <param name="membershipID">The id of the membership to update</param>
+            <param name="membership">The updated membership</param>
+            <returns>The newly modified membership as a MembershipView object</returns>
         </member>
-        <member name="M:Gordon360.Services.MembershipService.ToggleGroupAdminAsync(System.Int32,Gordon360.Models.CCT.MEMBERSHIP)">
+        <member name="M:Gordon360.Services.MembershipService.SetGroupAdminAsync(System.Int32,System.Boolean)">
             <summary>
             Switches the group-admin property of the person whose membership id is given
             </summary>
-            <param name="membershipID">The membership id.</param>
-            <param name="membership">The corresponding membership object</param>
-            <returns>The newly modified membership.</returns>
+            <param name="membershipID">The corresponding membership object</param>
+            <param name="isGroupAdmin">The new value of group admin</param>
+            <returns>The newly modified membership as a MembershipView object</returns>
         </member>
-        <member name="M:Gordon360.Services.MembershipService.TogglePrivacy(System.Int32,System.Boolean)">
+        <member name="M:Gordon360.Services.MembershipService.SetPrivacyAsync(System.Int32,System.Boolean)">
             <summary>
             Switches the privacy property of the person whose membership id is given
             </summary>
-            <param name="membershipID">The membership id.</param>
-            <param name="isPrivate">membership private or not</param>
-            <returns>The newly modified membership.</returns>
+            <param name="membershipID">The membership object passed</param>
+            <param name="isPrivate">The new value of privacy</param>
+            <returns>The newly modified membership as a MembershipView object</returns>
         </member>
-        <member name="M:Gordon360.Services.MembershipService.ValidateMembershipAsync(Gordon360.Models.CCT.MEMBERSHIP)">
+        <member name="M:Gordon360.Services.MembershipService.ValidateMembership(Gordon360.Models.ViewModels.MembershipUploadViewModel)">
             <summary>
             Helper method to Validate a membership
             </summary>
             <param name="membership">The membership to validate</param>
-            <returns>True if the membership is valid. Throws ResourceNotFoundException if not. Exception is caught in an Exception Filter</returns>
+            <returns>True if the membership is valid. Throws an Exception if not. Exception is caught in an Exception Filter</returns>
         </member>
-        <member name="M:Gordon360.Services.MembershipService.IsGroupAdmin(System.Int32)">
+        <member name="M:Gordon360.Services.MembershipService.IsGroupAdmin(System.String)">
             <summary>	
             Determines whether or not the given user is a Group Admin of some activity	
             </summary>
-            <param name="gordonID">Gordon ID of the user to check</param>	
+            <param name="username">Username of the user to check</param>	
             <returns>true if student is a Group Admin, else false</returns>	
+        </member>
+        <member name="M:Gordon360.Services.MembershipService.GetMembershipViewById(System.Int32)">
+            <summary>	
+            Finds the matching MembershipView object from an existing MEMBERSHIP object
+            </summary>
+            <param name="membershipId">The MEMBERSHIP to match on MembershipID</param>	
+            <returns>The found MembershipView object corresponding to the MEMBERSHIP by ID</returns>	
         </member>
         <member name="T:Gordon360.Services.MyScheduleService">
             <summary>

--- a/Gordon360/Program.cs
+++ b/Gordon360/Program.cs
@@ -52,6 +52,7 @@ builder.Services.AddScoped<IAdministratorService, AdministratorService>();
 builder.Services.AddScoped<IEmailService, EmailService>();
 builder.Services.AddScoped<INewsService, NewsService>();
 builder.Services.AddScoped<ServerUtils, ServerUtils>();
+builder.Services.AddHostedService<EventCacheRefreshService>();
 
 builder.Services.AddMemoryCache();
 

--- a/Gordon360/Services/EventCacheRefreshService.cs
+++ b/Gordon360/Services/EventCacheRefreshService.cs
@@ -1,0 +1,47 @@
+﻿using Gordon360.Static_Classes;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Hosting;
+using System.Threading.Tasks;
+using System.Threading;
+using System;
+using System.Diagnostics;
+
+namespace Gordon360.Services
+{
+    public class EventCacheRefreshService : IHostedService, IDisposable
+    {
+        private readonly IMemoryCache _cache;
+        private Timer? _timer = null;
+
+        public EventCacheRefreshService(IMemoryCache cache)
+        {
+            _cache = cache;
+        }
+
+        public Task StartAsync(CancellationToken stoppingToken)
+        {
+            _timer = new Timer(UpdateEventsCacheAsync, null, TimeSpan.Zero,
+                TimeSpan.FromMinutes(5));
+
+            return Task.CompletedTask;
+        }
+
+        private async void UpdateEventsCacheAsync(object? state)
+        {
+            var events = await EventService.FetchEventsAsync();
+            _cache.Set(CacheKeys.Events, events);
+        }
+
+        public Task StopAsync(CancellationToken stoppingToken)
+        {
+            _timer?.Change(Timeout.Infinite, 0);
+
+            return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            _timer?.Dispose();
+        }
+    }
+}

--- a/Gordon360/Services/EventCacheRefreshService.cs
+++ b/Gordon360/Services/EventCacheRefreshService.cs
@@ -21,7 +21,7 @@ namespace Gordon360.Services
         public Task StartAsync(CancellationToken stoppingToken)
         {
             _timer = new Timer(UpdateEventsCacheAsync, null, TimeSpan.Zero,
-                TimeSpan.FromMinutes(5));
+                TimeSpan.FromMinutes(10));
 
             return Task.CompletedTask;
         }

--- a/Gordon360/Services/EventService.cs
+++ b/Gordon360/Services/EventService.cs
@@ -35,13 +35,8 @@ namespace Gordon360.Services
          * state parameter fetches only confirmed events
          */
         private static readonly string AllEventsURL = "https://25live.collegenet.com/25live/data/gordon/run/events.xml?/&event_type_id=14+57&state=2&end_after=" + GetFirstEventDate() + "&scope=extended";
-        private IEnumerable<EventViewModel> Events => _cache.GetOrCreate(CacheKeys.Events, (entry) =>
-        {
-            entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(30);
-            var task = Task.Run(FetchEventsAsync);
-
-            return task.GetAwaiter().GetResult();
-        });
+        
+        private IEnumerable<EventViewModel> Events => _cache.Get<IEnumerable<EventViewModel>>(CacheKeys.Events);
 
         public EventService(CCTContext context, IMemoryCache cache, IAccountService accountService)
         {

--- a/Gordon360/Services/EventService.cs
+++ b/Gordon360/Services/EventService.cs
@@ -106,8 +106,7 @@ namespace Gordon360.Services
             return attendedEvents;
         }
 
-
-        private static async Task<IEnumerable<EventViewModel>> FetchEventsAsync()
+        public static async Task<IEnumerable<EventViewModel>> FetchEventsAsync()
         {
             using var client = new HttpClient();
             client.DefaultRequestHeaders.Add("User-Agent", "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.2; .NET CLR 1.0.3705;)");
@@ -136,7 +135,7 @@ namespace Gordon360.Services
         ///  Helper function to determine the current academic year
         /// </summary>
         /// <returns></returns>
-        public static string GetFirstEventDate()
+        private static string GetFirstEventDate()
         {
             //Beginning date of fall semester (MM/DD)
             var fallDate = "0815";

--- a/Gordon360/Services/EventService.cs
+++ b/Gordon360/Services/EventService.cs
@@ -37,7 +37,7 @@ namespace Gordon360.Services
         private static readonly string AllEventsURL = "https://25live.collegenet.com/25live/data/gordon/run/events.xml?/&event_type_id=14+57&state=2&end_after=" + GetFirstEventDate() + "&scope=extended";
         private IEnumerable<EventViewModel> Events => _cache.GetOrCreate(CacheKeys.Events, (entry) =>
         {
-            entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5);
+            entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(30);
             var task = Task.Run(FetchEventsAsync);
 
             return task.GetAwaiter().GetResult();


### PR DESCRIPTION
Event data from the 25Live API is cached in-memory because it is slow to load (on the order of multiple minutes), and because it changes infrequently. However, this cache previously only persisted for 5 minutes, after which the next user to view events would have to wait several minutes to see the data.

This PR adds a hosted service (i.e. a long running background task) that will automatically refresh the cached events data from 25Live every 5 minutes, before the previous cache entry expires. This ensures that the data is still reasonably current but that no user will ever have to wait several minutes to see events.