### PR TITLE
[Rec-IM] Completed Lookup Routes

### DIFF
--- a/Gordon360/Controllers/RecIM/ActivitiesController.cs
+++ b/Gordon360/Controllers/RecIM/ActivitiesController.cs
@@ -62,11 +62,8 @@ namespace Gordon360.Controllers.RecIM
         [Route("lookup")]
         public ActionResult<IEnumerable<LookupViewModel>> GetActivityTypes(string type)
         {
-            if ( type == "status")
-            {
-
-            }
-            throw new NotImplementedException();
+            var result = _activityService.GetActivityLookup(type);
+            return Ok(result);
         }
 
         /// <summary>

--- a/Gordon360/Controllers/RecIM/ActivitiesController.cs
+++ b/Gordon360/Controllers/RecIM/ActivitiesController.cs
@@ -62,8 +62,12 @@ namespace Gordon360.Controllers.RecIM
         [Route("lookup")]
         public ActionResult<IEnumerable<LookupViewModel>> GetActivityTypes(string type)
         {
-            var result = _activityService.GetActivityLookup(type);
-            return Ok(result);
+            var res = _activityService.GetActivityLookup(type);
+            if (res is not null)
+            {
+                return Ok(res);
+            }
+            return BadRequest();
         }
 
         /// <summary>

--- a/Gordon360/Controllers/RecIM/MatchesController.cs
+++ b/Gordon360/Controllers/RecIM/MatchesController.cs
@@ -56,19 +56,8 @@ namespace Gordon360.Controllers.RecIM
         [Route("lookup")]
         public ActionResult<IEnumerable<LookupViewModel>> GetMatchTypes(string type)
         {
-            if ( type == "status" )
-            {
-
-            }
-            if ( type == "teamstatus" )
-            {
-
-            }
-            if ( type == "surface")
-            {
-
-            }
-            throw new NotImplementedException();
+            var res = _matchService.GetMatchLookup(type);
+            return Ok(res);
         }
 
         /// <summary>

--- a/Gordon360/Controllers/RecIM/MatchesController.cs
+++ b/Gordon360/Controllers/RecIM/MatchesController.cs
@@ -57,7 +57,11 @@ namespace Gordon360.Controllers.RecIM
         public ActionResult<IEnumerable<LookupViewModel>> GetMatchTypes(string type)
         {
             var res = _matchService.GetMatchLookup(type);
-            return Ok(res);
+            if (res is not null)
+            {
+                return Ok(res);
+            }
+            return BadRequest();
         }
 
         /// <summary>

--- a/Gordon360/Controllers/RecIM/ParticipantsController.cs
+++ b/Gordon360/Controllers/RecIM/ParticipantsController.cs
@@ -61,7 +61,11 @@ namespace Gordon360.Controllers.RecIM
         public ActionResult<IEnumerable<LookupViewModel>> GetParticipantTypes(string type)
         {
             var res = _participantService.GetParticipantLookup(type);
-            return Ok(res);
+            if (res is not null)
+            {
+                return Ok(res);
+            }
+            return BadRequest();
         }
 
         [HttpPut]

--- a/Gordon360/Controllers/RecIM/ParticipantsController.cs
+++ b/Gordon360/Controllers/RecIM/ParticipantsController.cs
@@ -58,17 +58,10 @@ namespace Gordon360.Controllers.RecIM
 
         [HttpGet]
         [Route("lookup")]
-        public ActionResult<IEnumerable<LookupViewModel>> GetTypes(string type)
+        public ActionResult<IEnumerable<LookupViewModel>> GetParticipantTypes(string type)
         {
-            if ( type == "status" )
-            {
-
-            }
-            if ( type == "activitypriv")
-            {
-
-            }
-            throw new NotImplementedException();
+            var res = _participantService.GetParticipantLookup(type);
+            return Ok(res);
         }
 
         [HttpPut]

--- a/Gordon360/Controllers/RecIM/SeriesController.cs
+++ b/Gordon360/Controllers/RecIM/SeriesController.cs
@@ -55,15 +55,12 @@ namespace Gordon360.Controllers.RecIM
         [Route("lookup")]
         public ActionResult<IEnumerable<LookupViewModel>> GetSeriesTypes(string type)
         {
-            if ( type == "series" )
+            var res = _seriesService.GetSeriesLookup(type);
+            if (res is not null)
             {
-
+                return Ok(res);
             }
-            if ( type == "status" )
-            {
-
-            }
-            throw new NotImplementedException();
+            return BadRequest();
         }
 
         /// <summary>

--- a/Gordon360/Controllers/RecIM/TeamsController.cs
+++ b/Gordon360/Controllers/RecIM/TeamsController.cs
@@ -47,17 +47,13 @@ namespace Gordon360.Controllers.RecIM
         [Route("lookup")]
         public ActionResult<IEnumerable<LookupViewModel>> GetTeamTypes(string type)
         {
-            if ( type == "status" )
+            var res = _teamService.GetTeamLookup(type);
+            if (res is not null)
             {
-
+                return Ok(res);
             }
-            if ( type == "role")
-            {
-
-            }
-            throw new NotImplementedException();
+            return BadRequest();
         }
-
 
         /// <summary>
         /// Create a new team with the requesting user set to team captain

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -813,6 +813,7 @@
             <summary>
             
             </summary>
+            <param name="seriesID"></param>
             <param name="updatedSeries"></param>
             <returns>modified series</returns>
         </member>

--- a/Gordon360/Services/RecIM/ActivityService.cs
+++ b/Gordon360/Services/RecIM/ActivityService.cs
@@ -36,10 +36,7 @@ namespace Gordon360.Services.RecIM
                             .AsEnumerable();
                 return res;
             }
-            else
-            {
-                throw new NotImplementedException();
-            }
+            return null;
         }
         public IEnumerable<ActivityViewModel> GetActivities()
         {

--- a/Gordon360/Services/RecIM/ActivityService.cs
+++ b/Gordon360/Services/RecIM/ActivityService.cs
@@ -23,7 +23,24 @@ namespace Gordon360.Services.RecIM
             _seriesService = seriesService;
         }
 
-
+        public IEnumerable<LookupViewModel> GetActivityLookup(string type)
+        {
+            if (type == "status")
+            {
+                var res = _context.ActivityStatus
+                            .Select(s => new LookupViewModel
+                            {
+                                ID = s.ID,
+                                Description = s.Description
+                            })
+                            .AsEnumerable();
+                return res;
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+        }
         public IEnumerable<ActivityViewModel> GetActivities()
         {
             var activities = _context.Activity

--- a/Gordon360/Services/RecIM/MatchService.cs
+++ b/Gordon360/Services/RecIM/MatchService.cs
@@ -26,6 +26,44 @@ namespace Gordon360.Services.RecIM
             _context = context;
             _accountService = accountService;
         }
+
+        public IEnumerable<LookupViewModel> GetMatchLookup(string type)
+        {
+            if (type == "status")
+            {
+                var res = _context.MatchStatus
+                    .Select(s => new LookupViewModel
+                    {
+                        ID = s.ID,
+                        Description = s.Description
+                    })
+                    .AsEnumerable();
+                return res;
+            }
+            if (type == "teamstatus")
+            {
+                var res = _context.MatchTeamStatus
+                    .Select(s => new LookupViewModel
+                    {
+                        ID = s.ID,
+                        Description = s.Description
+                    })
+                    .AsEnumerable();
+                return res;
+            }
+            if (type == "surface")
+            {
+                var res = _context.Surface
+                    .Select(s => new LookupViewModel
+                    {
+                        ID = s.ID,
+                        Description = s.Description
+                    })
+                    .AsEnumerable();
+                return res;
+            }
+            throw new NotImplementedException();
+        }
         public MatchViewModel GetMatchByID(int matchID)
         {
             var match = _context.Match

--- a/Gordon360/Services/RecIM/MatchService.cs
+++ b/Gordon360/Services/RecIM/MatchService.cs
@@ -62,7 +62,7 @@ namespace Gordon360.Services.RecIM
                     .AsEnumerable();
                 return res;
             }
-            throw new NotImplementedException();
+            return null;
         }
         public MatchViewModel GetMatchByID(int matchID)
         {

--- a/Gordon360/Services/RecIM/ParticipantService.cs
+++ b/Gordon360/Services/RecIM/ParticipantService.cs
@@ -46,9 +46,7 @@ namespace Gordon360.Services.RecIM
                             .AsEnumerable();
                 return res;
             }
-
-            throw new NotImplementedException();
-            
+            return null;
         }
         public ACCOUNT GetAccountByParticipantID(int ID)
         {

--- a/Gordon360/Services/RecIM/ParticipantService.cs
+++ b/Gordon360/Services/RecIM/ParticipantService.cs
@@ -22,7 +22,34 @@ namespace Gordon360.Services.RecIM
             _accountService = accountService;
             _context = context;
         }
+        public IEnumerable<LookupViewModel> GetParticipantLookup(string type)
+        {
+            if (type == "status")
+            {
+                var res = _context.ParticipantStatus
+                            .Select(s => new LookupViewModel
+                            {
+                                ID = s.ID,
+                                Description = s.Description
+                            })
+                            .AsEnumerable();
+                return res;
+            }
+            if (type == "activitypriv")
+            {
+                var res = _context.PrivType
+                            .Select(s => new LookupViewModel
+                            {
+                                ID = s.ID,
+                                Description = s.Description
+                            })
+                            .AsEnumerable();
+                return res;
+            }
 
+            throw new NotImplementedException();
+            
+        }
         public ACCOUNT GetAccountByParticipantID(int ID)
         {
             return _context.ACCOUNT

--- a/Gordon360/Services/RecIM/SeriesService.cs
+++ b/Gordon360/Services/RecIM/SeriesService.cs
@@ -22,8 +22,33 @@ namespace Gordon360.Services.RecIM
             _context = context;
             _matchService = matchService;
         }
-
-        public IEnumerable<SeriesViewModel> GetSeries(bool active = false)
+        public IEnumerable<LookupViewModel> GetSeriesLookup(string type)
+        {
+            if (type == "status")
+            {
+                var res = _context.SeriesStatus
+                    .Select(s => new LookupViewModel
+                    {
+                        ID = s.ID,
+                        Description = s.Description
+                    })
+                    .AsEnumerable();
+                return res;
+            }
+            if (type == "series")
+            {
+                var res = _context.SeriesType
+                    .Select(s => new LookupViewModel
+                    {
+                        ID = s.ID,
+                        Description = s.Description
+                    })
+                    .AsEnumerable();
+                return res;
+            }
+            return null;
+        }
+            public IEnumerable<SeriesViewModel> GetSeries(bool active = false)
         {
             var series = _context.Series
                             .Select(s => new SeriesViewModel

--- a/Gordon360/Services/RecIM/SeriesService.cs
+++ b/Gordon360/Services/RecIM/SeriesService.cs
@@ -62,7 +62,7 @@ namespace Gordon360.Services.RecIM
             return series;
         }
         public IEnumerable<SeriesViewModel> GetSeriesByActivityID(int activityID)
-        {
+        { 
             var series = _context.Series
                 .Where(s => s.ActivityID == activityID)
                 .Select(s => new SeriesViewModel

--- a/Gordon360/Services/RecIM/TeamService.cs
+++ b/Gordon360/Services/RecIM/TeamService.cs
@@ -28,7 +28,32 @@ namespace Gordon360.Services.RecIM
             _participantService = participantService;
             _accountService = accountService;
         }
-
+        public IEnumerable<LookupViewModel> GetTeamLookup(string type)
+        {
+            if (type == "status")
+            {
+                var res = _context.TeamStatus
+                    .Select(s => new LookupViewModel
+                    {
+                        ID = s.ID,
+                        Description = s.Description
+                    })
+                    .AsEnumerable();
+                return res;
+            }
+            if (type == "role")
+            {
+                var res = _context.RoleType
+                    .Select(s => new LookupViewModel
+                    {
+                        ID = s.ID,
+                        Description = s.Description
+                    })
+                    .AsEnumerable();
+                return res;
+            }
+            return null;
+        }
         public double GetTeamSportsmanshipScore(int teamID)
         {
             var sportsmanshipScores = _context.Match

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -322,6 +322,7 @@ namespace Gordon360.Services
         }
         public interface ISeriesService
         {
+            IEnumerable<LookupViewModel> GetSeriesLookup(string type);
             IEnumerable<SeriesViewModel> GetSeries(bool active);
             IEnumerable<SeriesViewModel> GetSeriesByActivityID(int activityID);
             SeriesViewModel GetSeriesByID(int seriesID);

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -366,6 +366,7 @@ namespace Gordon360.Services
 
         public interface IMatchService
         {
+            IEnumerable<LookupViewModel> GetMatchLookup(string type);
             MatchViewModel GetMatchByID(int matchID);
             IEnumerable<MatchViewModel> GetMatchBySeriesID(int seriesID);
             Task<MatchCreatedViewModel> PostMatchAsync(MatchUploadViewModel match);

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -333,6 +333,7 @@ namespace Gordon360.Services
 
         public interface ITeamService
         {
+            IEnumerable<LookupViewModel> GetTeamLookup(string type);
             double GetTeamSportsmanshipScore(int teamID);
             TeamViewModel GetTeamByID(int teamID);
             Task<TeamCreatedViewModel> PostTeamAsync(TeamUploadViewModel newTeam, string username);

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -311,6 +311,7 @@ namespace Gordon360.Services
     {
         public interface IActivityService
         {
+            IEnumerable<LookupViewModel> GetActivityLookup(string type);
             IEnumerable<Models.ViewModels.RecIM.ActivityViewModel> GetActivities();
             Models.ViewModels.RecIM.ActivityViewModel? GetActivityByID(int activityID);
             IEnumerable<Models.ViewModels.RecIM.ActivityViewModel> GetActivitiesByTime(DateTime? time);

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -343,6 +343,7 @@ namespace Gordon360.Services
 
         public interface IParticipantService
         {
+            IEnumerable<LookupViewModel> GetParticipantLookup(string type);
             ACCOUNT GetAccountByParticipantID(int ID);
             IEnumerable<ParticipantViewModel> GetParticipants();
             IEnumerable<ParticipantStatusViewModel> GetParticipantStatusHistory(string username);


### PR DESCRIPTION
This PR handles all SQL Lookup Table Types. Type routes have already been defined in the UI and are currently hard coded in the services. Usage of these lookup routes are attributed to Updating/Setting types such as Statuses as well as Privileges/Roles