### PR TITLE
set categoryName and SortOrder to safe variables

### DIFF
--- a/Gordon360/Models/ViewModels/StudentNewsViewModel.cs
+++ b/Gordon360/Models/ViewModels/StudentNewsViewModel.cs
@@ -42,8 +42,8 @@ namespace Gordon360.Models.ViewModels
                 Sent = n.Sent,
                 thisPastMailing = n.thisPastMailing,
                 Entered = n.Entered,
-                categoryName = n.category.categoryName,
-                SortOrder = n.category.SortOrder,
+                categoryName = n.category?.categoryName ?? "",
+                SortOrder = n.category?.SortOrder ?? null,
                 ManualExpirationDate = n.ManualExpirationDate,
             };
 


### PR DESCRIPTION
Because `category` is `null`, it broke the API when parsing `StudentNews` variable to `StudentNewsViewModel`.

Links #755.

PS: Turned out the `Update` button in `Editing` UI is also broken.