### PR TITLE
[Rec-IM] Quality of Life changes

### DIFF
--- a/Gordon360/Models/ViewModels/RecIM/ActivityExtendedViewModel.cs
+++ b/Gordon360/Models/ViewModels/RecIM/ActivityExtendedViewModel.cs
@@ -23,5 +23,22 @@ namespace Gordon360.Models.ViewModels.RecIM
         public IEnumerable<SeriesExtendedViewModel> Series { get; set; }
         public IEnumerable<TeamExtendedViewModel> Team { get; set; }
 
+        public static implicit operator ActivityExtendedViewModel(Activity a)
+        {
+            return new ActivityExtendedViewModel
+            {
+                ID = a.ID,
+                Name = a.Name,
+                RegistrationStart = a.RegistrationStart,
+                RegistrationEnd = a.RegistrationEnd,
+                RegistrationOpen = DateTime.Now > a.RegistrationStart && DateTime.Now < a.RegistrationEnd,
+                MinCapacity = a.MinCapacity,
+                MaxCapacity = a.MaxCapacity,
+                SoloRegistration = a.SoloRegistration,
+                Logo = a.Logo,
+                Completed = a.Completed,
+                TypeID = a.TypeID,
+            };
+        }
     }
 }

--- a/Gordon360/Models/ViewModels/RecIM/TeamExtendedViewModel.cs
+++ b/Gordon360/Models/ViewModels/RecIM/TeamExtendedViewModel.cs
@@ -7,7 +7,7 @@ namespace Gordon360.Models.ViewModels.RecIM
     public class TeamExtendedViewModel
     {
         public int ID { get; set; }
-        public int ActivityID { get; set; }
+        public ActivityExtendedViewModel Activity { get; set; }
         public string? Name { get; set; }
         public string? Status { get; set; }
         public string? Logo { get; set; }

--- a/Gordon360/Services/RecIM/ActivityService.cs
+++ b/Gordon360/Services/RecIM/ActivityService.cs
@@ -123,7 +123,10 @@ namespace Gordon360.Services.RecIM
                                     Status = _context.TeamStatus
                                                 .FirstOrDefault(ts => ts.ID == t.StatusID)
                                                 .Description,
-                                    ActivityID = t.ActivityID,
+                                    Activity = new ActivityExtendedViewModel {
+                                        ID = t.ActivityID, 
+                                        Name = a.Name
+                                    },
                                     Logo = t.Logo
                                 })
                             

--- a/Gordon360/Services/RecIM/ParticipantService.cs
+++ b/Gordon360/Services/RecIM/ParticipantService.cs
@@ -114,6 +114,7 @@ namespace Gordon360.Services.RecIM
         }
         public IEnumerable<TeamExtendedViewModel> GetParticipantTeams(string username)
         {
+       
             //to be handled by teamservice
             var teams = _context.ParticipantTeam
                             .Where(pt => pt.ParticipantUsername == username)
@@ -123,7 +124,7 @@ namespace Gordon360.Services.RecIM
                                     (pt, t) => new TeamExtendedViewModel
                                     {
                                         ID = t.ID,
-                                        ActivityID = t.ActivityID,
+                                        Activity = _context.Activity.FirstOrDefault(a => a.ID == t.ActivityID),
                                         Name = t.Name,
                                         Status = _context.TeamStatus
                                                     .FirstOrDefault(ts => ts.ID == t.StatusID)


### PR DESCRIPTION
- Activity Data needed to be used in other UI pages which was not given. TeamExtendedViewModel now returns an ExtendedActivity type to display ID,Name,RegistrationOpen...
- Team Creation now will automatically add a team to the FIRST existing series (as in the one that has the earliest start date) and will sit in purgatory if there is no series created yet
- Creating a Series with no existing Series before (aka referenceSeriesID is null) already adds all teams in the activity to the Series