### PR TITLE
[RecIM] Fix Edit Match Stats Route by Using Status ID instead of Description

### DIFF
--- a/Gordon360/Controllers/RecIM/MatchesController.cs
+++ b/Gordon360/Controllers/RecIM/MatchesController.cs
@@ -72,7 +72,7 @@ namespace Gordon360.Controllers.RecIM
         /// <returns></returns>
         [HttpPatch]
         [Route("{matchID}/stats")]
-        // [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_MATCH)]
+        [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_MATCH)]
         public async Task<ActionResult<MatchTeamViewModel>> UpdateStats(int matchID, MatchStatsPatchViewModel updatedMatch)
         {
             var stats = await _matchService.UpdateTeamStatsAsync(matchID, updatedMatch);

--- a/Gordon360/Controllers/RecIM/MatchesController.cs
+++ b/Gordon360/Controllers/RecIM/MatchesController.cs
@@ -72,7 +72,7 @@ namespace Gordon360.Controllers.RecIM
         /// <returns></returns>
         [HttpPatch]
         [Route("{matchID}/stats")]
-        [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_MATCH)]
+        // [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_MATCH)]
         public async Task<ActionResult<MatchTeamViewModel>> UpdateStats(int matchID, MatchStatsPatchViewModel updatedMatch)
         {
             var stats = await _matchService.UpdateTeamStatsAsync(matchID, updatedMatch);

--- a/Gordon360/Models/ViewModels/RecIM/MatchStatsPatchViewModel.cs
+++ b/Gordon360/Models/ViewModels/RecIM/MatchStatsPatchViewModel.cs
@@ -6,7 +6,7 @@ namespace Gordon360.Models.ViewModels.RecIM
     public class MatchStatsPatchViewModel
     {
         public int TeamID { get; set; }
-        public string? Status { get; set; }
+        public int? StatusID { get; set; }
         public int? Score { get; set; }
         public int? Sportsmanship { get; set; }
     }

--- a/Gordon360/Services/RecIM/MatchService.cs
+++ b/Gordon360/Services/RecIM/MatchService.cs
@@ -359,13 +359,7 @@ namespace Gordon360.Services.RecIM
             var teamstats = _context.MatchTeam.FirstOrDefault(mt => mt.MatchID == matchID && mt.TeamID == vm.TeamID);
             teamstats.Score = vm.Score ?? teamstats.Score;
             teamstats.Sportsmanship = vm.Sportsmanship ?? teamstats.Sportsmanship;
-
-            if (vm.Status is not null)
-            {
-                teamstats.StatusID = _context.MatchTeamStatus
-                    .FirstOrDefault(mts => mts.Description == vm.Status)
-                    .ID;
-            }
+            teamstats.StatusID = vm.StatusID ?? teamstats.StatusID;
             await _context.SaveChangesAsync();
             return teamstats;
 


### PR DESCRIPTION
Small change to update the match service route for editing a teams stats to allow the status ID to be passed, as it does not make sense to pass description.