### PR TITLE
Student-news posting approval

### DIFF
--- a/Gordon360/Authorization/StateYourBusiness.cs
+++ b/Gordon360/Authorization/StateYourBusiness.cs
@@ -600,8 +600,8 @@ namespace Gordon360.Authorization
                             if (newsItem.Accepted != false)
                                 return false;
 
-                            // can update if user is admin or SNAdmin
-                            if (user_groups.Contains(AuthGroup.SiteAdmin) || user_groups.Contains(AuthGroup.NewsAdmin))
+                            // can update if user is a Student News Admin
+                            if (user_groups.Contains(AuthGroup.NewsAdmin))
                                 return true;
 
                             // can update if user is news item author
@@ -610,6 +610,16 @@ namespace Gordon360.Authorization
                         
                         return false;
                     }
+
+                case Resource.NEWS_APPROVAL:
+                    {
+                        // can approve or deny if user is a Student News Admin
+                        if (user_groups.Contains(AuthGroup.NewsAdmin))
+                            return true;
+
+                        return false;
+                    }
+
                 default: return false;
             }
         }
@@ -707,8 +717,8 @@ namespace Gordon360.Authorization
                                 return false;
                             }
 
-                            // can update if user is admin or SNAdmin
-                            if (user_groups.Contains(AuthGroup.SiteAdmin) || user_groups.Contains(AuthGroup.NewsAdmin))
+                            // can update if user is a Student News Admin
+                            if (user_groups.Contains(AuthGroup.NewsAdmin))
                                 return true;
 
                             // can update if user is news item author

--- a/Gordon360/Authorization/StateYourBusiness.cs
+++ b/Gordon360/Authorization/StateYourBusiness.cs
@@ -600,8 +600,8 @@ namespace Gordon360.Authorization
                             if (newsItem.Accepted != false)
                                 return false;
 
-                            // can update if user is admin
-                            if (user_groups.Contains(AuthGroup.SiteAdmin))
+                            // can update if user is admin or SNAdmin
+                            if (user_groups.Contains(AuthGroup.SiteAdmin) || user_groups.Contains(AuthGroup.NewsAdmin))
                                 return true;
 
                             // can update if user is news item author
@@ -707,8 +707,8 @@ namespace Gordon360.Authorization
                                 return false;
                             }
 
-                            // can update if user is admin
-                            if (user_groups.Contains(AuthGroup.SiteAdmin))
+                            // can update if user is admin or SNAdmin
+                            if (user_groups.Contains(AuthGroup.SiteAdmin) || user_groups.Contains(AuthGroup.NewsAdmin))
                                 return true;
 
                             // can update if user is news item author

--- a/Gordon360/Controllers/NewsController.cs
+++ b/Gordon360/Controllers/NewsController.cs
@@ -204,21 +204,22 @@ namespace Gordon360.Controllers
         ///  Approve a news posting in the database
         /// </summary>
         /// <param name="newsID">The id of the news item to approve</param>
+        /// <param name="newsStatusAccepted">The accept status that will apply to the news item</param>
         /// <returns>The approved news item</returns>
         /// <remarks>The news item must not be expired and must be unapproved</remarks>
         [HttpPut]
-        [Route("approvalStatus")]
+        [Route("{newsID}/accepted")]
         // only SNAdmin is authorized to use this route
         // Can't use SYB UPDATE operation, because the author is not authorized to approve the post
-        public ActionResult<StudentNewsViewModel> ApprovePosting([FromBody] int newsID)
+        public ActionResult<StudentNewsViewModel> ApprovePosting(int newsID, [FromBody] bool newsStatusAccepted)
         {
             if (user_groups.Contains(AuthGroup.SiteAdmin) || user_groups.Contains(AuthGroup.NewsAdmin))
             {
-                var result = _newsService.ApprovePosting(newsID);
+                var result = _newsService.AlterPostAcceptStatus(newsID, newsStatusAccepted);
                 return Ok(result);
             }
             else
-                return Unauthorized("Only Admin and News Admin can approve posting.");
+                return Forbid("Only Admin and News Admin can alter post's accepting status.");
         }
     }
 }

--- a/Gordon360/Controllers/NewsController.cs
+++ b/Gordon360/Controllers/NewsController.cs
@@ -22,7 +22,6 @@ namespace Gordon360.Controllers
     public class NewsController : GordonControllerBase
     {
         private readonly INewsService _newsService;
-        private IEnumerable<AuthGroup> user_groups { get; set; }
 
         public NewsController(INewsService newsService)
         {
@@ -201,25 +200,19 @@ namespace Gordon360.Controllers
         }
 
         /// <summary>
-        ///  Approve a news posting in the database
+        ///  Approve or deny a news posting in the database
         /// </summary>
         /// <param name="newsID">The id of the news item to approve</param>
         /// <param name="newsStatusAccepted">The accept status that will apply to the news item</param>
-        /// <returns>The approved news item</returns>
-        /// <remarks>The news item must not be expired and must be unapproved</remarks>
+        /// <returns>The approved or denied news item</returns>
+        /// <remarks>The news item must not be expired</remarks>
         [HttpPut]
         [Route("{newsID}/accepted")]
-        // only SNAdmin is authorized to use this route
-        // Can't use SYB UPDATE operation, because the author is not authorized to approve the post
-        public ActionResult<StudentNewsViewModel> ApprovePosting(int newsID, [FromBody] bool newsStatusAccepted)
+        [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.NEWS_APPROVAL)]
+        public ActionResult<StudentNewsViewModel> UpdateAcceptedStatus(int newsID, [FromBody] bool newsStatusAccepted)
         {
-            if (user_groups.Contains(AuthGroup.SiteAdmin) || user_groups.Contains(AuthGroup.NewsAdmin))
-            {
-                var result = _newsService.AlterPostAcceptStatus(newsID, newsStatusAccepted);
-                return Ok(result);
-            }
-            else
-                return Forbid("Only Admin and News Admin can alter post's accepting status.");
+            var result = _newsService.AlterPostAcceptStatus(newsID, newsStatusAccepted);
+            return Ok(result);
         }
     }
 }

--- a/Gordon360/Controllers/NewsController.cs
+++ b/Gordon360/Controllers/NewsController.cs
@@ -22,6 +22,7 @@ namespace Gordon360.Controllers
     public class NewsController : GordonControllerBase
     {
         private readonly INewsService _newsService;
+        private IEnumerable<AuthGroup> user_groups { get; set; }
 
         public NewsController(INewsService newsService)
         {
@@ -197,6 +198,27 @@ namespace Gordon360.Controllers
             // StateYourBusiness verifies that user is authenticated
             var result = _newsService.EditPosting(newsID, studentNewsEdit);
             return Ok(result);
+        }
+
+        /// <summary>
+        ///  Approve a news posting in the database
+        /// </summary>
+        /// <param name="newsID">The id of the news item to approve</param>
+        /// <returns>The approved news item</returns>
+        /// <remarks>The news item must not be expired and must be unapproved</remarks>
+        [HttpPut]
+        [Route("approvalStatus")]
+        // only SNAdmin is authorized to use this route
+        // Can't use SYB UPDATE operation, because the author is not authorized to approve the post
+        public ActionResult<StudentNewsViewModel> ApprovePosting([FromBody] int newsID)
+        {
+            if (user_groups.Contains(AuthGroup.SiteAdmin) || user_groups.Contains(AuthGroup.NewsAdmin))
+            {
+                var result = _newsService.ApprovePosting(newsID);
+                return Ok(result);
+            }
+            else
+                return Unauthorized("Only Admin and News Admin can approve posting.");
         }
     }
 }

--- a/Gordon360/Services/NewsService.cs
+++ b/Gordon360/Services/NewsService.cs
@@ -331,7 +331,7 @@ namespace Gordon360.Services
         /// Helper method to verify that a given news item has already been approved
         /// </summary>
         /// <param name="newsItem">The news item to verify</param>
-        /// <returns>true ig approved, otherwise throws some kind of meaningful exception</returns>
+        /// <returns>true if approved, otherwise throws some kind of meaningful exception</returns>
         private static bool VerfiyApproved(StudentNews newsItem)
         {
             // Note: These checks have been duplicated from StateYourBusiness because we do not want

--- a/Gordon360/Services/NewsService.cs
+++ b/Gordon360/Services/NewsService.cs
@@ -189,9 +189,9 @@ namespace Gordon360.Services
             // Service method 'Get' throws its own exceptions
             var newsItem = Get(newsID);
 
-            // Note: This check has been duplicated from StateYourBusiness because we do not SuperAdmins
-            //    to be able to delete expired news, this should be fixed eventually by removing some of
-            //    the SuperAdmin permissions that are not explicitly given
+            // Note: These checks have been duplicated from StateYourBusiness because we do not want
+            //    SuperAdmins to be able to delete expired news, this should be fixed eventually by
+            //    removing some of the SuperAdmin permissions that are not explicitly given
             VerifyUnexpired(newsItem);
 
             if (newsItem.Image != null)
@@ -217,9 +217,9 @@ namespace Gordon360.Services
             // Service method 'Get' throws its own exceptions
             var newsItem = Get(newsID);
 
-            // Note: These checks have been duplicated from StateYourBusiness because we do not SuperAdmins
-            //    to be able to delete expired news, this should be fixed eventually by removing some of
-            //    the SuperAdmin permissions that are not explicitly given
+            // Note: These checks have been duplicated from StateYourBusiness because we do not want
+            //    SuperAdmins to be able to delete expired news, this should be fixed eventually by
+            //    removing some of the SuperAdmin permissions that are not explicitly given
             VerifyUnexpired(newsItem);
             VerifyUnapproved(newsItem);
 
@@ -272,17 +272,21 @@ namespace Gordon360.Services
             return newsItem;
         }
 
-        public StudentNewsViewModel ApprovePosting(int newsID)
+        public StudentNewsViewModel AlterPostAcceptStatus(int newsID, bool isAccepted)
         {
             var newsItem = Get(newsID);
 
-            // Note: These checks have been duplicated from StateYourBusiness because we do not SuperAdmins
-            //    to be able to delete expired news, this should be fixed eventually by removing some of
-            //    the SuperAdmin permissions that are not explicitly given
+            // Note: These checks have been duplicated from StateYourBusiness because we do not want
+            //    SuperAdmins to be able to delete expired news, this should be fixed eventually by
+            //    removing some of the SuperAdmin permissions that are not explicitly given
             VerifyUnexpired(newsItem);
-            VerifyUnapproved(newsItem);
 
-            newsItem.Accepted = true;
+            if (isAccepted)
+                VerifyUnapproved(newsItem);
+            else
+                VerfiyApproved(newsItem);
+
+            newsItem.Accepted = isAccepted;
 
             _context.SaveChanges();
 
@@ -309,9 +313,9 @@ namespace Gordon360.Services
         /// <returns>true if unapproved, otherwise throws some kind of meaningful exception</returns>
         private static bool VerifyUnapproved(StudentNews newsItem)
         {
-            // Note: This check has been duplicated from StateYourBusiness because we do not SuperAdmins
-            //    to be able to delete expired news, this should be fixed eventually by removing some of
-            //    the SuperAdmin permissions that are not explicitly given
+            // Note: These checks have been duplicated from StateYourBusiness because we do not want
+            //    SuperAdmins to be able to delete expired news, this should be fixed eventually by
+            //    removing some of the SuperAdmin permissions that are not explicitly given
             if (newsItem.Accepted == null)
             {
                 throw new ResourceNotFoundException() { ExceptionMessage = "The news item acceptance status could not be verified." };
@@ -319,6 +323,27 @@ namespace Gordon360.Services
             if (newsItem.Accepted == true)
             {
                 throw new BadInputException() { ExceptionMessage = "The news item has already been approved." };
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Helper method to verify that a given news item has already been approved
+        /// </summary>
+        /// <param name="newsItem">The news item to verify</param>
+        /// <returns>true ig approved, otherwise throws some kind of meaningful exception</returns>
+        private static bool VerfiyApproved(StudentNews newsItem)
+        {
+            // Note: These checks have been duplicated from StateYourBusiness because we do not want
+            //    SuperAdmins to be able to delete expired news, this should be fixed eventually by
+            //    removing some of the SuperAdmin permissions that are not explicitly given
+            if (newsItem.Accepted == null)
+            {
+                throw new ResourceNotFoundException() { ExceptionMessage = "The news item acceptance status could not be verified." };
+            }
+            if (newsItem.Accepted == false)
+            {
+                throw new BadInputException() { ExceptionMessage = "The news item has not been approved." };
             }
             return true;
         }

--- a/Gordon360/Services/NewsService.cs
+++ b/Gordon360/Services/NewsService.cs
@@ -272,6 +272,23 @@ namespace Gordon360.Services
             return newsItem;
         }
 
+        public StudentNewsViewModel ApprovePosting(int newsID)
+        {
+            var newsItem = Get(newsID);
+
+            // Note: These checks have been duplicated from StateYourBusiness because we do not SuperAdmins
+            //    to be able to delete expired news, this should be fixed eventually by removing some of
+            //    the SuperAdmin permissions that are not explicitly given
+            VerifyUnexpired(newsItem);
+            VerifyUnapproved(newsItem);
+
+            newsItem.Accepted = true;
+
+            _context.SaveChanges();
+
+            return newsItem;
+        }
+
         private string GetImagePath(string filename)
         {
             return Path.Combine(_webHostEnvironment.ContentRootPath, "browseable", "uploads", "news", filename);

--- a/Gordon360/Services/NewsService.cs
+++ b/Gordon360/Services/NewsService.cs
@@ -272,7 +272,7 @@ namespace Gordon360.Services
             return newsItem;
         }
 
-        public StudentNewsViewModel AlterPostAcceptStatus(int newsID, bool isAccepted)
+        public StudentNewsViewModel AlterPostAcceptStatus(int newsID, bool accepted)
         {
             var newsItem = Get(newsID);
 
@@ -281,12 +281,12 @@ namespace Gordon360.Services
             //    removing some of the SuperAdmin permissions that are not explicitly given
             VerifyUnexpired(newsItem);
 
-            if (isAccepted)
+            if (accepted)
                 VerifyUnapproved(newsItem);
             else
                 VerfiyApproved(newsItem);
 
-            newsItem.Accepted = isAccepted;
+            newsItem.Accepted = accepted;
 
             _context.SaveChanges();
 
@@ -318,7 +318,7 @@ namespace Gordon360.Services
             //    removing some of the SuperAdmin permissions that are not explicitly given
             if (newsItem.Accepted == null)
             {
-                throw new ResourceNotFoundException() { ExceptionMessage = "The news item acceptance status could not be verified." };
+                throw new Exception();
             }
             if (newsItem.Accepted == true)
             {
@@ -337,11 +337,7 @@ namespace Gordon360.Services
             // Note: These checks have been duplicated from StateYourBusiness because we do not want
             //    SuperAdmins to be able to delete expired news, this should be fixed eventually by
             //    removing some of the SuperAdmin permissions that are not explicitly given
-            if (newsItem.Accepted == null)
-            {
-                throw new ResourceNotFoundException() { ExceptionMessage = "The news item acceptance status could not be verified." };
-            }
-            if (newsItem.Accepted == false)
+            if (newsItem.Accepted != true)
             {
                 throw new BadInputException() { ExceptionMessage = "The news item has not been approved." };
             }

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -276,6 +276,7 @@ namespace Gordon360.Services
         StudentNews SubmitNews(StudentNews newsItem, string username);
         StudentNews DeleteNews(int newsID);
         StudentNewsViewModel EditPosting(int newsID, StudentNewsUploadViewModel newsItem);
+        StudentNewsViewModel ApprovePosting(int newsID);
     }
 
     public interface IHousingService

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -276,7 +276,7 @@ namespace Gordon360.Services
         StudentNews SubmitNews(StudentNews newsItem, string username);
         StudentNews DeleteNews(int newsID);
         StudentNewsViewModel EditPosting(int newsID, StudentNewsUploadViewModel newsItem);
-        StudentNewsViewModel ApprovePosting(int newsID);
+        StudentNewsViewModel AlterPostAcceptStatus(int newsID, bool isAccepted);
     }
 
     public interface IHousingService

--- a/Gordon360/Static Classes/Names.cs
+++ b/Gordon360/Static Classes/Names.cs
@@ -23,6 +23,7 @@
         public const string Save_Rides = "A ride resource";
         public const string SCHEDULE = "A course schedule resource";
         public const string NEWS = "A student news resource";
+        public const string NEWS_APPROVAL = "The approval of a student news resource";
         public const string CHECKIN = "Info relating to a student's Academic Check-In";
         public const string SHIFT = "A shift that a student has worked";
         public const string CLIFTON_STRENGTHS = "A student's uploaded clifton strengthsfinder results";


### PR DESCRIPTION
Student News Controller:
 - ADD: `{newsID}/accepted` route that approve or deniess a posting by `newsID`
 - ADD: new method `public StudentNewsViewModel UpdateAcceptedStatus(int newsID, [FromBody] bool newsStatusAccepted)`
 
Student News Service:
 - ADD: new method `public StudentNewsViewModel AlterPostAcceptedStatus(int newsID, bool newsStatusAccepted)`
 - ADD: new private method `VerifyApproved(StudentNews newsItem)`

`StateYourBusiness`:
 - UPDATE: `Operation.UPDATE` and `Operation.DELETE` of `Resource.NEWS` now authorizes the user that's `NewsAdmin` and removed `SiteAdmin`
 - ADD: `Resource.NEWS_APPROVAL` to `Operation.UPDATE`
 
Gordon-360-ui issue: https://github.com/orgs/gordon-cs/projects/15/views/1?pane=issue&itemId=17476452.