### PR TITLE
Add Continuous Deployment for Production

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,4 +1,4 @@
-name: deploy
+name: Deploy Production
 
 on:
   workflow_run:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -10,7 +10,7 @@ jobs:
   deploy:
     runs-on: windows-latest
     environment:
-      name: Train
+      name: Production
       url: https://360Api.gordon.edu
 
     if: ${{ github.event.workflow_run.conclusion == 'success' }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,37 @@
+name: deploy
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [master]
+
+jobs:
+  deploy:
+    runs-on: windows-latest
+    environment:
+      name: Train
+      url: https://360Api.gordon.edu
+
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup .NET Core SDK 6
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: '6.0.x'
+
+      - name: Install dependencies
+        run: dotnet restore
+
+      - name: Publish
+        run: dotnet publish ${{ github.workspace}}\Gordon360.sln -r win-x64 --no-self-contained -o ${{ github.workspace }}\Gordon360\bin\app.publish\ci -p:EnvironmentName=${{ secrets.DEPLOYMENT_ENVIRONMENT }}
+
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v2.2.2
+        with:
+          name: build-${{ secrets.DEPLOYMENT_ENVIRONMENT }}
+          path: ${{ github.workspace }}\Gordon360\bin\app.publish\ci
+          if-no-files-found: error

--- a/.github/workflows/deploy-train.yml
+++ b/.github/workflows/deploy-train.yml
@@ -1,4 +1,4 @@
-name: deploy
+name: Deploy Train
 
 on:
   workflow_run:


### PR DESCRIPTION
Now that Continuous Deployment is working in the Train environment, we can finally add Continuous Deployment back to the Production environment.

Note that the deployment process still depends on the `Deploy360Backend` Powershell task running on the 360API server. Even if this is merged immediately, continuous deployment will not start until that task is enabled for Production.