### PR TITLE
Refactor Memberships for more general `GET` operations

### DIFF
--- a/Gordon360/Authorization/AuthUtils.cs
+++ b/Gordon360/Authorization/AuthUtils.cs
@@ -24,7 +24,7 @@ namespace Gordon360.Authorization
         {
             return User.Claims
                 .Where(x => x.Type == "groups")
-                .Select(g => g.Value.Parse())
+                .Select(g => AuthGroupEnum.FromString(g.Value))
                 .OfType<AuthGroup>();
         }
 
@@ -45,7 +45,7 @@ namespace Gordon360.Authorization
 
             return user.GetAuthorizationGroups()
                                .Where(g => g is GroupPrincipal)
-                               .Select(g => g.SamAccountName.Parse())
+                               .Select(g => AuthGroupEnum.FromString(g.SamAccountName))
                                .OfType<AuthGroup>();
         }
     }

--- a/Gordon360/Authorization/AuthUtils.cs
+++ b/Gordon360/Authorization/AuthUtils.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using Gordon360.Enums;
+using System.Collections.Generic;
 using System.DirectoryServices.AccountManagement;
 using System.Linq;
 using System.Security.Claims;
@@ -23,7 +24,7 @@ namespace Gordon360.Authorization
         {
             return User.Claims
                 .Where(x => x.Type == "groups")
-                .Select(g => AuthGroupEnum.FromString(g.Value))
+                .Select(g => g.Value.Parse())
                 .OfType<AuthGroup>();
         }
 
@@ -44,7 +45,7 @@ namespace Gordon360.Authorization
 
             return user.GetAuthorizationGroups()
                                .Where(g => g is GroupPrincipal)
-                               .Select(g => AuthGroupEnum.FromString(g.SamAccountName))
+                               .Select(g => g.SamAccountName.Parse())
                                .OfType<AuthGroup>();
         }
     }

--- a/Gordon360/Authorization/StateYourBusiness.cs
+++ b/Gordon360/Authorization/StateYourBusiness.cs
@@ -17,728 +17,758 @@ using Gordon360.Extensions.System;
 using static Gordon360.Services.MembershipService;
 using Gordon360.Enums;
 
-namespace Gordon360.Authorization
+namespace Gordon360.Authorization;
+
+/* Authorization Filter.
+ * It is actually an action filter masquerading as an authorization filter. This is because I need access to the 
+ * parameters passed to the controller. Authorization Filters don't have that access. Action Filters do.
+ * 
+ * Because of the nature of how we authorize people, this code might seem very odd, so I'll try to explain. 
+ * Proceed at your own risk. If you can understand this code, you can understand the whole project. 
+ * 
+ * 1st Observation: You can't authorize access to a resource that isn't owned by someone. Resources like Sessions, Participations,
+ * and Activity Definitions are accessibile by anyone.
+ * 2nd Observation: To Authorize someone to perform an action on a resource, you need to know the following:
+ * 1. Who is to be authorized? 2.What resource are they trying to access? 3. What operation are they trying to make on the resource?
+ * This "algorithm" uses those three points and decides through a series of switch statements if the current user
+ * is authorized.
+ */
+public class StateYourBusiness : ActionFilterAttribute
 {
-    /* Authorization Filter.
-     * It is actually an action filter masquerading as an authorization filter. This is because I need access to the 
-     * parameters passed to the controller. Authorization Filters don't have that access. Action Filters do.
-     * 
-     * Because of the nature of how we authorize people, this code might seem very odd, so I'll try to explain. 
-     * Proceed at your own risk. If you can understand this code, you can understand the whole project. 
-     * 
-     * 1st Observation: You can't authorize access to a resource that isn't owned by someone. Resources like Sessions, Participations,
-     * and Activity Definitions are accessibile by anyone.
-     * 2nd Observation: To Authorize someone to perform an action on a resource, you need to know the following:
-     * 1. Who is to be authorized? 2.What resource are they trying to access? 3. What operation are they trying to make on the resource?
-     * This "algorithm" uses those three points and decides through a series of switch statements if the current user
-     * is authorized.
-     */
-    public class StateYourBusiness : ActionFilterAttribute
+    // Resource to be accessed: Will get as parameters to the attribute
+    public string resource { get; set; }
+    // Operation to be performed: Will get as parameters to the attribute
+    public string operation { get; set; }
+
+    private ActionExecutingContext context;
+    private CCTContext _CCTContext;
+    private MyGordonContext _MyGordonContext;
+    private IAccountService _accountService;
+    private IMembershipService _membershipService;
+    private IMembershipRequestService _membershipRequestService;
+    private INewsService _newsService;
+
+    // User position at the college and their id.
+    private IEnumerable<AuthGroup> user_groups { get; set; }
+    private string user_id { get; set; }
+    private string user_name { get; set; }
+
+    public async override Task OnActionExecutionAsync(ActionExecutingContext actionContext, ActionExecutionDelegate next)
     {
-        // Resource to be accessed: Will get as parameters to the attribute
-        public string resource { get; set; }
-        // Operation to be performed: Will get as parameters to the attribute
-        public string operation { get; set; }
+        context = actionContext;
+        // Step 1: Who is to be authorized
+        var authenticatedUser = actionContext.HttpContext.User;
 
-        private ActionExecutingContext context;
-        private CCTContext _CCTContext;
-        private MyGordonContext _MyGordonContext;
-        private IAccountService _accountService;
-        private IMembershipService _membershipService;
-        private IMembershipRequestService _membershipRequestService;
-        private INewsService _newsService;
 
-        // User position at the college and their id.
-        private IEnumerable<AuthGroup> user_groups { get; set; }
-        private string user_id { get; set; }
-        private string user_name { get; set; }
 
-        public async override Task OnActionExecutionAsync(ActionExecutingContext actionContext, ActionExecutionDelegate next)
+        _accountService = context.HttpContext.RequestServices.GetRequiredService<IAccountService>();
+        _membershipService = context.HttpContext.RequestServices.GetRequiredService<IMembershipService>();
+        _membershipRequestService = context.HttpContext.RequestServices.GetRequiredService<IMembershipRequestService>();
+        _newsService = context.HttpContext.RequestServices.GetRequiredService<INewsService>();
+
+        user_name = AuthUtils.GetUsername(authenticatedUser);
+        user_groups = AuthUtils.GetGroups(authenticatedUser);
+        user_id = _accountService.GetAccountByUsername(user_name).GordonID;
+
+        if (user_groups.Contains(AuthGroup.SiteAdmin))
         {
-            context = actionContext;
-            // Step 1: Who is to be authorized
-            var authenticatedUser = actionContext.HttpContext.User;
-
-
-
-            _accountService = context.HttpContext.RequestServices.GetRequiredService<IAccountService>();
-            _membershipService = context.HttpContext.RequestServices.GetRequiredService<IMembershipService>();
-            _membershipRequestService = context.HttpContext.RequestServices.GetRequiredService<IMembershipRequestService>();
-            _newsService = context.HttpContext.RequestServices.GetRequiredService<INewsService>();
-
-            user_name = AuthUtils.GetUsername(authenticatedUser);
-            user_groups = AuthUtils.GetGroups(authenticatedUser);
-            user_id = _accountService.GetAccountByUsername(user_name).GordonID;
-
-            if (user_groups.Contains(AuthGroup.SiteAdmin))
-            {
-                await next();
-                return;
-            }
-
-            bool isAuthorized = await CanPerformOperationAsync(resource, operation);
-            if (!isAuthorized)
-            {
-                throw new UnauthorizedAccessException("Authorization has been denied for this request.");
-            }
-
             await next();
+            return;
         }
 
-
-        private async Task<bool> CanPerformOperationAsync(string resource, string operation)
-            => operation switch
-            {
-                Operation.READ_ONE => await CanReadOneAsync(resource),
-                Operation.READ_ALL => CanReadAll(resource),
-                Operation.READ_PARTIAL => await CanReadPartialAsync(resource),
-                Operation.ADD => await CanAddAsync(resource),
-                Operation.UPDATE => await CanUpdateAsync(resource),
-                Operation.DELETE => await CanDeleteAsync(resource),
-                Operation.READ_PUBLIC => CanReadPublic(resource),
-                _ => false,
-            };
-
-        /*
-         * Operations
-         */
-        private async Task<bool> CanReadOneAsync(string resource)
+        bool isAuthorized = await CanPerformOperationAsync(resource, operation);
+        if (!isAuthorized)
         {
-            // User is admin
-            if (user_groups.Contains(AuthGroup.SiteAdmin))
+            throw new UnauthorizedAccessException("Authorization has been denied for this request.");
+        }
+
+        await next();
+    }
+
+
+    private async Task<bool> CanPerformOperationAsync(string resource, string operation)
+        => operation switch
+        {
+            Operation.READ_ONE => await CanReadOneAsync(resource),
+            Operation.READ_ALL => CanReadAll(resource),
+            Operation.READ_PARTIAL => await CanReadPartialAsync(resource),
+            Operation.ADD => await CanAddAsync(resource),
+            Operation.UPDATE => await CanUpdateAsync(resource),
+            Operation.DELETE => await CanDeleteAsync(resource),
+            Operation.READ_PUBLIC => CanReadPublic(resource),
+            _ => false,
+        };
+
+    /*
+     * Operations
+     */
+    private async Task<bool> CanReadOneAsync(string resource)
+    {
+        // User is admin
+        if (user_groups.Contains(AuthGroup.SiteAdmin))
+            return true;
+
+        switch (resource)
+        {
+            case Resource.PROFILE:
                 return true;
-
-            switch (resource)
-            {
-                case Resource.PROFILE:
-                    return true;
-                case Resource.EMERGENCY_CONTACT:
-                    {
-                        if (user_groups.Contains(AuthGroup.Police))
-                            return true;
-                       
-                        return context.ActionArguments["username"] is string username && username.EqualsIgnoreCase(user_name);
-                    }
-                case Resource.MEMBERSHIP:
-                    return true;
-                case Resource.MEMBERSHIP_REQUEST:
-                    {
-                        // membershipRequest = mr
-                        if (context.ActionArguments["id"] is int mrID)
-                        {
-                            var mrToConsider = _membershipRequestService.Get(mrID);
-                            var is_mrOwner = mrToConsider.Username.EqualsIgnoreCase(user_name); // User_id is an instance variable.
-
-                            if (is_mrOwner) // If user owns the request
-                                return true;
-
-                            var isGroupAdmin = _membershipService.GetGroupAdminMembershipsForActivity(mrToConsider.ActivityCode, mrToConsider.SessionCode).Any(x => x.Username.EqualsIgnoreCase(user_name));
-                            if (isGroupAdmin) // If user is a group admin of the activity that the request is sent to
-                                return true;
-                        }
-
-                        return false;
-                    }
-                case Resource.STUDENT:
-                    // To add a membership for a student, you need to have the students identifier.
-                    // NOTE: I don't believe the 'student' resource is currently being used in API
-                    {
+            case Resource.EMERGENCY_CONTACT:
+                {
+                    if (user_groups.Contains(AuthGroup.Police))
                         return true;
-                    }
-                case Resource.ADVISOR:
-                    return true;
-                case Resource.ACCOUNT:
+
+                    return context.ActionArguments["username"] is string username && username.EqualsIgnoreCase(user_name);
+                }
+            case Resource.MEMBERSHIP:
+                return true;
+            case Resource.MEMBERSHIP_REQUEST:
+                {
+                    // membershipRequest = mr
+                    if (context.ActionArguments["id"] is int mrID)
                     {
-                        // Membership group admins can access ID of members using their email
-                        // NOTE: In the future, probably only email addresses should be stored 
-                        // in memberships, since we would rather not give students access to
-                        // other students' account information
-                        var isGroupAdmin = _membershipService.IsGroupAdmin(user_name);
+                        var mrToConsider = _membershipRequestService.Get(mrID);
+                        var is_mrOwner = mrToConsider.Username.EqualsIgnoreCase(user_name); // User_id is an instance variable.
+
+                        if (is_mrOwner) // If user owns the request
+                            return true;
+
+                        var isGroupAdmin = _membershipService
+                            .GetMembershipsForActivity(
+                                mrToConsider.ActivityCode,
+                                mrToConsider.SessionCode,
+                                new List<string> { Participation.GroupAdmin.GetDescription() })
+                            .Any(x => x.Username.EqualsIgnoreCase(user_name));
                         if (isGroupAdmin) // If user is a group admin of the activity that the request is sent to
                             return true;
-
-                        // faculty and police can access student account information
-                        if (user_groups.Contains(AuthGroup.FacStaff)
-                            || user_groups.Contains(AuthGroup.Police))
-                            return true;
-
-                        return false;
                     }
-                case Resource.HOUSING:
-                    {
-                        // The members of the apartment application can only read their application
-                        var sess_cde = Helpers.GetCurrentSession(_CCTContext);
-                        HousingService housingService = new HousingService(_CCTContext);
-                        int? applicationID = housingService.GetApplicationID(user_name, sess_cde);
-                        if (context.ActionArguments["applicationID"] is int requestedApplicationID && applicationID is not null)
-                        {
-                            return requestedApplicationID == applicationID;
-                        }
-                        return false;
-                    }
-                case Resource.NEWS:
+
+                    return false;
+                }
+            case Resource.STUDENT:
+                // To add a membership for a student, you need to have the students identifier.
+                // NOTE: I don't believe the 'student' resource is currently being used in API
+                {
                     return true;
-                default: return false;
-
-            }
-        }
-        // For reads that access a group of resources filterd in a specific way 
-        private async Task<bool> CanReadPartialAsync(string resource)
-        {
-            // User is admin
-            if (user_groups.Contains(AuthGroup.SiteAdmin))
+                }
+            case Resource.ADVISOR:
                 return true;
-
-            switch (resource)
-            {
-                case Resource.MEMBERSHIP_BY_ACTIVITY:
-                    {
-                        // Only people that are part of the activity should be able to see members
-                        if (context.ActionArguments["activityCode"] is string activityCode)
-                        {
-                                var activityMembers = _membershipService.GetMembershipsForActivity(activityCode);
-                                var is_personAMember = activityMembers.Any(x => x.Username.EqualsIgnoreCase(user_name) && x.Participation != Participation.Guest.GetDescription());
-                            return is_personAMember;
-                        }
-                        return false;
-                    }
-
-                case Resource.EVENTS_BY_STUDENT_ID:
-                    {
-                        // Only the person itself or an admin can see someone's chapel attendance
-                        if (context.ActionArguments["username"] is string username_requested)
-                        {
-                            return username_requested.EqualsIgnoreCase(user_name);
-                        }
-                        return false;
-                    }
-
-
-                case Resource.MEMBERSHIP_REQUEST_BY_ACTIVITY:
-                    {
-                        // An activity leader should be able to see the membership requests that belong to the activity s/he is leading.
-                        if (context.ActionArguments["activityCode"] is string activityCode)
-                        {
-                            var groupAdmins = _membershipService.GetGroupAdminMembershipsForActivity(activityCode);
-                            var isGroupAdmin = groupAdmins.Any(x => x.Username.EqualsIgnoreCase(user_name));
-                            return isGroupAdmin; // If user is a group admin of the activity that the request is sent to
-                        }
-                        return false;
-                    }
-                case Resource.EMAILS_BY_ACTIVITY:
-                    {
-                        // Anyone can view group-admin and advisor emails
-                        if (context.ActionArguments["participationType"] is string participationType
-                            && (participationType.Parse()?.In(Participation.GroupAdmin, Participation.Advisor, Participation.Leader) ?? false))
-                        {
-                            return true;
-                        }
-
-                        // Only leaders, advisors, and group admins
-                        if (context.ActionArguments["activityCode"] is string activityCode)
-                        {
-                           return _membershipService.GetMembershipsForActivity(activityCode)
-                                    .Any(a => 
-                                            a.Username.EqualsIgnoreCase(user_name) 
-                                            && (a.GroupAdmin == true 
-                                                || (a.Participation.Parse()?.In(
-                                                    Participation.Leader, 
-                                                    Participation.Advisor
-                                                    ) ?? false)
-                                               )
-                                         );
-                        }
-
-                        return false;
-                    }
-                case Resource.NEWS:
-                    {
+            case Resource.ACCOUNT:
+                {
+                    // Membership group admins can access ID of members using their email
+                    // NOTE: In the future, probably only email addresses should be stored 
+                    // in memberships, since we would rather not give students access to
+                    // other students' account information
+                    var isGroupAdmin = _membershipService.IsGroupAdmin(user_name);
+                    if (isGroupAdmin) // If user is a group admin of the activity that the request is sent to
                         return true;
+
+                    // faculty and police can access student account information
+                    if (user_groups.Contains(AuthGroup.FacStaff)
+                        || user_groups.Contains(AuthGroup.Police))
+                        return true;
+
+                    return false;
+                }
+            case Resource.HOUSING:
+                {
+                    // The members of the apartment application can only read their application
+                    var sess_cde = Helpers.GetCurrentSession(_CCTContext);
+                    HousingService housingService = new HousingService(_CCTContext);
+                    int? applicationID = housingService.GetApplicationID(user_name, sess_cde);
+                    if (context.ActionArguments["applicationID"] is int requestedApplicationID && applicationID is not null)
+                    {
+                        return requestedApplicationID == applicationID;
                     }
-                default: return false;
-            }
+                    return false;
+                }
+            case Resource.NEWS:
+                return true;
+            default: return false;
+
         }
-        private bool CanReadAll(string resource)
-        {
-            switch (resource)
-            {
-                case Resource.MEMBERSHIP:
-                    // User is admin
-                    if (user_groups.Contains(AuthGroup.SiteAdmin))
-                        return true;
-                    else
-                        return false;
-                case Resource.ChapelEvent:
-                    // User is admin
-                    if (user_groups.Contains(AuthGroup.SiteAdmin))
-                        return true;
-                    else
-                        return false;
-                case Resource.EVENTS_BY_STUDENT_ID:
-                    // User is admin
-                    if (user_groups.Contains(AuthGroup.SiteAdmin))
-                        return true;
-                    else
-                        return false;
+    }
+    // For reads that access a group of resources filterd in a specific way 
+    private async Task<bool> CanReadPartialAsync(string resource)
+    {
+        // User is admin
+        if (user_groups.Contains(AuthGroup.SiteAdmin))
+            return true;
 
-                case Resource.MEMBERSHIP_REQUEST:
-                    // User is admin
-                    if (user_groups.Contains(AuthGroup.SiteAdmin))
-                        return true;
-                    else
-                        return false;
-                case Resource.STUDENT:
-                    // User is admin
-                    if (user_groups.Contains(AuthGroup.SiteAdmin))
-                        return true;
-                    else
-                        return false; // See reasons for this in CanReadOne(). No one (except for super admin) should be able to access student records through
-                                      // our API.
-                case Resource.ADVISOR:
-                    // User is admin
-                    if (user_groups.Contains(AuthGroup.SiteAdmin))
-                        return true;
-                    else
-                        return false;
-                case Resource.GROUP_ADMIN:
-                    // User is site-wide admin
-                    if (user_groups.Contains(AuthGroup.SiteAdmin))
-                        return true;
-                    else
-                        return false;
-                case Resource.ACCOUNT:
-                    return false;
-                case Resource.ADMIN:
-                    return false;
-                case Resource.HOUSING:
+        switch (resource)
+        {
+            case Resource.MEMBERSHIP_BY_ACTIVITY:
+                {
+                    // Only people that are part of the activity should be able to see members
+                    if (context.ActionArguments["activityCode"] is string activityCode)
                     {
-                        // Only the housing admin and super admin can read all of the received applications.
-                        // Super admin has unrestricted access by default, so no need to check.
-                        if (user_groups.Contains(AuthGroup.HousingAdmin))
-                        {
-                            return true;
-                        }
-                        return false;
+                        var activityMembers = _membershipService.GetMembershipsForActivity(activityCode);
+                        var is_personAMember = activityMembers.Any(x => x.Username.EqualsIgnoreCase(user_name) && x.Participation != Participation.Guest.GetDescription());
+                        return is_personAMember;
                     }
-                case Resource.NEWS:
+                    return false;
+                }
+
+            case Resource.EVENTS_BY_STUDENT_ID:
+                {
+                    // Only the person itself or an admin can see someone's chapel attendance
+                    if (context.ActionArguments["username"] is string username_requested)
+                    {
+                        return username_requested.EqualsIgnoreCase(user_name);
+                    }
+                    return false;
+                }
+
+
+            case Resource.MEMBERSHIP_REQUEST_BY_ACTIVITY:
+                {
+                    // An activity leader should be able to see the membership requests that belong to the activity s/he is leading.
+                    if (context.ActionArguments["activityCode"] is string activityCode)
+                    {
+                        var isGroupAdmin = _membershipService
+                            .GetMembershipsForActivity(
+                                activityCode,
+                                participationTypes: new List<string> { Participation.GroupAdmin.GetDescription() })
+                            .Any(x => x.Username.EqualsIgnoreCase(user_name));
+                        return isGroupAdmin; // If user is a group admin of the activity that the request is sent to
+                    }
+                    return false;
+                }
+            case Resource.EMAILS_BY_ACTIVITY:
+                {
+                    // Anyone can view group-admin and advisor emails
+                    if (context.ActionArguments["participationType"] is string participationType
+                        && (participationType
+                            .Parse()?
+                            .In(
+                                Participation.GroupAdmin,
+                                Participation.Advisor,
+                                Participation.Leader
+                            ) == true))
+                    {
+                        return true;
+                    }
+
+                    // Only leaders, advisors, and group admins
+                    if (context.ActionArguments["activityCode"] is string activityCode)
+                    {
+                        return _membershipService
+                            .GetMembershipsForActivity(
+                                activityCode,
+                                sessionCode: context.ActionArguments["sessionCode"] as string ?? null,
+                                participationTypes: new List<string>
+                                {
+                                    Participation.GroupAdmin.GetDescription(),
+                                    Participation.Leader.GetDescription(),
+                                    Participation.Advisor.GetDescription()
+                                })
+                            .Any(a => a.Username.EqualsIgnoreCase(user_name));
+                    }
+
+                    return false;
+                }
+            case Resource.NEWS:
+                {
                     return true;
-                default: return false;
-            }
+                }
+            default: return false;
         }
-
-        private bool CanReadPublic(string resource)
+    }
+    private bool CanReadAll(string resource)
+    {
+        switch (resource)
         {
-            switch (resource)
-            {
-                case Resource.SLIDER:
+            case Resource.MEMBERSHIP:
+                // User is admin
+                if (user_groups.Contains(AuthGroup.SiteAdmin))
                     return true;
-                case Resource.NEWS:
+                else
                     return false;
-                default: return false;
+            case Resource.ChapelEvent:
+                // User is admin
+                if (user_groups.Contains(AuthGroup.SiteAdmin))
+                    return true;
+                else
+                    return false;
+            case Resource.EVENTS_BY_STUDENT_ID:
+                // User is admin
+                if (user_groups.Contains(AuthGroup.SiteAdmin))
+                    return true;
+                else
+                    return false;
 
-            }
-        }
-        private async Task<bool> CanAddAsync(string resource)
-        {
-            switch (resource)
-            {
-                case Resource.SHIFT:
+            case Resource.MEMBERSHIP_REQUEST:
+                // User is admin
+                if (user_groups.Contains(AuthGroup.SiteAdmin))
+                    return true;
+                else
+                    return false;
+            case Resource.STUDENT:
+                // User is admin
+                if (user_groups.Contains(AuthGroup.SiteAdmin))
+                    return true;
+                else
+                    return false; // See reasons for this in CanReadOne(). No one (except for super admin) should be able to access student records through
+                                  // our API.
+            case Resource.ADVISOR:
+                // User is admin
+                if (user_groups.Contains(AuthGroup.SiteAdmin))
+                    return true;
+                else
+                    return false;
+            case Resource.GROUP_ADMIN:
+                // User is site-wide admin
+                if (user_groups.Contains(AuthGroup.SiteAdmin))
+                    return true;
+                else
+                    return false;
+            case Resource.ACCOUNT:
+                return false;
+            case Resource.ADMIN:
+                return false;
+            case Resource.HOUSING:
+                {
+                    // Only the housing admin and super admin can read all of the received applications.
+                    // Super admin has unrestricted access by default, so no need to check.
+                    if (user_groups.Contains(AuthGroup.HousingAdmin))
                     {
-                        if (user_groups.Contains(AuthGroup.Student))
-                            return true;
-                        return false;
-                    }
-                case Resource.CLIFTON_STRENGTHS:
-                    {
-                        return user_groups.Contains(AuthGroup.SiteAdmin);
-                    }
-
-                case Resource.MEMBERSHIP:
-                    {
-                        // User is admin
-                        if (user_groups.Contains(AuthGroup.SiteAdmin))
-                            return true;
-
-                        if (context.ActionArguments["membershipUpload"] is MembershipUploadViewModel membershipToConsider)
-                        {
-
-                            // A membership can always be added if it is of type "GUEST"
-                            var isFollower = membershipToConsider.Participation == Activity_Roles.GUEST
-                                && membershipToConsider.Username.EqualsIgnoreCase(user_name);
-                            if (isFollower)
-                                return true;
-
-                            var activityCode = membershipToConsider.Activity;
-                            var sessionCode = membershipToConsider.Session;
-                            var isGroupAdmin = _membershipService
-                                .GetGroupAdminMembershipsForActivity(activityCode, sessionCode)
-                                .Any(x => x.Username.EqualsIgnoreCase(user_name));
-                            // If user is the advisor of the activity to which the request is sent.
-                            if (isGroupAdmin) 
-                                return true;
-                        }
-                        return false;
-                    }
-
-                case Resource.MEMBERSHIP_REQUEST:
-                    {
-                        // User is admin
-                        if (user_groups.Contains(AuthGroup.SiteAdmin))
-                            return true;
-                        if (context.ActionArguments["membershipRequest"] is RequestUploadViewModel membershipRequestToConsider)
-                        {
-                            // A membership request belonging to the currently logged in student
-                            var is_Owner = membershipRequestToConsider.Username.EqualsIgnoreCase(user_name);
-                            if (is_Owner)
-                                return true;
-                        }
-                        // No one should be able to add requests on behalf of another person.
-                        return false;
-                    }
-                case Resource.STUDENT:
-                    return false; // No one should be able to add students through this API
-                case Resource.ADVISOR:
-                    // User is admin
-                    if (user_groups.Contains(AuthGroup.SiteAdmin))
                         return true;
-                    else
-                        return false; // Only super admin can add Advisors through this API
-                case Resource.HOUSING_ADMIN:
-                    //only superadmins can add a HOUSING_ADMIN
+                    }
                     return false;
-                case Resource.HOUSING:
-                    {
-                        // The user must be a student and not a member of an existing application
-                        if (user_groups.Contains(AuthGroup.Student))
-                        {
-                            var sess_cde = Helpers.GetCurrentSession(_CCTContext);
-                            var housingService = new HousingService(_CCTContext);
-                            int? applicationID = housingService.GetApplicationID(user_name, sess_cde);
-                            if (!applicationID.HasValue)
-                            {
-                                return true;
-                            }
-                            return false;
-                        }
-                        return false;
-                    }
-                case Resource.ADMIN:
-                    return false;
-                case Resource.ERROR_LOG:
-                    return true;
-                case Resource.NEWS:
-                    return true;
-                default: return false;
-            }
+                }
+            case Resource.NEWS:
+                return true;
+            default: return false;
         }
-        private async Task<bool> CanUpdateAsync(string resource)
+    }
+
+    private bool CanReadPublic(string resource)
+    {
+        switch (resource)
         {
-            switch (resource)
-            {
-                case Resource.SHIFT:
-                    {
-                        if (user_groups.Contains(AuthGroup.Student))
-                            return true;
-                        return false;
-                    }
-                case Resource.MEMBERSHIP:
-                    {
-                        // User is admin
-                        if (user_groups.Contains(AuthGroup.SiteAdmin))
-                            return true;
-                        if (context.ActionArguments["membershipID"] is int membershipID)
-                        {
-                            var membershipToConsider = _membershipService.GetMembershipViewById(membershipID);
-                            var activityCode = membershipToConsider.ActivityCode;
-                            var sessionCode = membershipToConsider.SessionCode;
+            case Resource.SLIDER:
+                return true;
+            case Resource.NEWS:
+                return false;
+            default: return false;
 
-
-                            var isGroupAdmin = _membershipService.GetGroupAdminMembershipsForActivity(activityCode, sessionCode).Any(x => x.Username.EqualsIgnoreCase(user_name));
-                            if (membershipToConsider.Participation == Participation.Advisor.GetDescription())
-                            {
-                                var currentUserMembership = _membershipService.GetGroupAdminMembershipsForActivity(activityCode, sessionCode).FirstOrDefault(x => x.Username == user_name);
-                                return currentUserMembership?.Participation == Participation.Advisor.GetDescription();
-                            }
-                            else if (isGroupAdmin && membershipToConsider.Participation != Participation.Advisor.GetDescription())
-                            {
-                                // Activity Advisors can update memberships of people in their activity.
-                                return true;
-                            }
-                                
-
-                            var is_membershipOwner = membershipToConsider.Username.EqualsIgnoreCase(user_name);
-                            if (is_membershipOwner)
-                            {
-                                // Restrict what a regular owner can edit.
-                                var originalMembership = _membershipService.GetSpecificMembership(membershipToConsider.MembershipID);
-                                // If they are not trying to change their participation level, then it is ok
-                                if (originalMembership.Participation == membershipToConsider.Participation)
-                                    return true;
-                            }
-                        }
-
-
-                        return false;
-                    }
-
-                case Resource.MEMBERSHIP_REQUEST:
-                    {
-                        // Once a request is sent, no one is able to edit its contents.
-                        // If a mistake is made in creating the original request, the user can delete it and make a new one.
-                        if (context.ActionArguments["membershipRequestID"] is int mrID)
-                        {
-                            // Get the view model from the repository
-                            var activityCode = _membershipRequestService.Get(mrID).ActivityCode;
-
-                            var is_activityLeader = _membershipService.GetLeaderMembershipsForActivity(activityCode).Any(x => x.Username.EqualsIgnoreCase(user_name));
-                            
-                            // If user is the leader of the activity that the request is sent to.
-                            if (is_activityLeader) 
-                                return true;
-
-                            var is_activityAdvisor = _membershipService.GetAdvisorMembershipsForActivity(activityCode).Any(x => x.Username.EqualsIgnoreCase(user_name));
-                            
-                            // If user is the advisor of the activity that the request is sent to.
-                            if (is_activityAdvisor) 
-                                return true;
-                        }
-                        return false;
-                    }
-                case Resource.MEMBERSHIP_PRIVACY:
-                    {
-                        if (context.ActionArguments["membershipID"] is int membershipID)
-                        {
-                            var membershipToConsider = _membershipService.GetSpecificMembership(membershipID);
-                            var is_membershipOwner = membershipToConsider.Username.EqualsIgnoreCase(user_name);
-                            if (is_membershipOwner)
-                                return true;
-                        }
-
-                        return false;
-                    }
-                case Resource.STUDENT:
-                    return false; // No one should be able to update a student through this API
-                case Resource.HOUSING:
-                    {
-                        // The housing admins can update the application information (i.e. probation, offcampus program, etc.)
-                        // If the user is a student, then the user must be on an application and be an editor to update the application
-                        HousingService housingService = new HousingService(_CCTContext);
-                        if (user_groups.Contains(AuthGroup.HousingAdmin))
-                        {
-                            return true;
-                        }
-                        else if (user_groups.Contains(AuthGroup.Student))
-                        {
-                            var sess_cde = Helpers.GetCurrentSession(_CCTContext);
-                            int? applicationID = housingService.GetApplicationID(user_name, sess_cde);
-                            if (context.ActionArguments["applicationID"] is int requestedApplicationID 
-                                && applicationID is not null 
-                                && applicationID == requestedApplicationID)
-                            {
-                                string editorUsername = housingService.GetEditorUsername(applicationID.Value);
-                                return editorUsername.EqualsIgnoreCase(user_name);
-                            } 
-                        }
-                        return false;
-                    }
-                case Resource.PROFILE:
-                    {
-                        // User is admin
-                        if (user_groups.Contains(AuthGroup.SiteAdmin))
-                            return true;
-
-                        if (context.ActionArguments["username"] is string username)
-                            return username.EqualsIgnoreCase(user_name);
-
-                        return false;
-                    }
-
-                case Resource.ACTIVITY_INFO:
-                    {
-                        // User is admin
-                        if (user_groups.Contains(AuthGroup.SiteAdmin))
-                            return true;
-
-                        if (context.ActionArguments["id"] is string activityCode)
-                        {
-                            var isGroupAdmin = _membershipService.GetGroupAdminMembershipsForActivity(activityCode).Any(x => x.Username.EqualsIgnoreCase(user_name));
-                            return isGroupAdmin;
-                        }
-                        return false;
-
-                    }
-
-                case Resource.ACTIVITY_STATUS:
-                    {
-                        // User is admin
-                        if (user_groups.Contains(AuthGroup.SiteAdmin))
-                            return true;
-
-                        if (context.ActionArguments["id"] is string activityCode)
-                        {
-                            var isGroupAdmin = _membershipService.GetGroupAdminMembershipsForActivity(activityCode).Any(x => x.Username == user_name);
-                            if (isGroupAdmin && context.ActionArguments["sess_cde"] is string sessionCode)
-                            {
-                                var activityService = context.HttpContext.RequestServices.GetRequiredService<IActivityService>();
-                                // If an activity is currently open, then a group admin has the ability to close it
-                                return activityService.IsOpen(activityCode, sessionCode);
-                            }
-                        }
-
-                        // If an activity is currently closed, only super admin has permission to edit its closed/open status   
-                        return false;
-                    }
-                case Resource.EMERGENCY_CONTACT:
-                    {
-                        return context.ActionArguments["username"] is string username && username.EqualsIgnoreCase(user_name);
-                    }
-
-                case Resource.NEWS:
-                    {
-                        if (context.ActionArguments["newsID"] is int newsID)
-                        {
-                            var newsItem = _newsService.Get(newsID);
-                            // only unapproved posts may be updated
-                            if (newsItem.Accepted != false)
-                                return false;
-
-                            // can update if user is a Student News Admin
-                            if (user_groups.Contains(AuthGroup.NewsAdmin))
-                                return true;
-
-                            // can update if user is news item author
-                            return newsItem.ADUN.EqualsIgnoreCase(user_name);
-                        }
-                        
-                        return false;
-                    }
-
-                case Resource.NEWS_APPROVAL:
-                    {
-                        // can approve or deny if user is a Student News Admin
-                        if (user_groups.Contains(AuthGroup.NewsAdmin))
-                            return true;
-
-                        return false;
-                    }
-
-                default: return false;
-            }
         }
-        private async Task<bool> CanDeleteAsync(string resource)
+    }
+    private async Task<bool> CanAddAsync(string resource)
+    {
+        switch (resource)
         {
-            switch (resource)
-            {
-                case Resource.SHIFT:
+            case Resource.SHIFT:
+                {
                     if (user_groups.Contains(AuthGroup.Student))
                         return true;
                     return false;
-                case Resource.MEMBERSHIP:
+                }
+            case Resource.CLIFTON_STRENGTHS:
+                {
+                    return user_groups.Contains(AuthGroup.SiteAdmin);
+                }
+
+            case Resource.MEMBERSHIP:
+                {
+                    // User is admin
+                    if (user_groups.Contains(AuthGroup.SiteAdmin))
+                        return true;
+
+                    if (context.ActionArguments["membershipUpload"] is MembershipUploadViewModel membershipToConsider)
                     {
-                        // User is admin
-                        if (user_groups.Contains(AuthGroup.SiteAdmin))
+
+                        // A membership can always be added if it is of type "GUEST"
+                        var isFollower = membershipToConsider.Participation == Activity_Roles.GUEST
+                            && membershipToConsider.Username.EqualsIgnoreCase(user_name);
+                        if (isFollower)
                             return true;
-                        if (context.ActionArguments["membershipID"] is int membershipID)
-                        {
-                            var membershipToConsider = _membershipService.GetSpecificMembership(membershipID);
-                            var is_membershipOwner = membershipToConsider.Username.EqualsIgnoreCase(user_name);
-                            if (is_membershipOwner)
-                                return true;
 
-                            var isGroupAdmin = _membershipService
-                                                .GetGroupAdminMembershipsForActivity(membershipToConsider.ActivityCode)
-                                                .Any(x => x.Username.EqualsIgnoreCase(user_name));
-                            return isGroupAdmin;
-                        }
-
-                        return false;
-                    }
-                case Resource.MEMBERSHIP_REQUEST:
-                    {
-                        // User is admin
-                        if (user_groups.Contains(AuthGroup.SiteAdmin))
+                        var activityCode = membershipToConsider.Activity;
+                        var sessionCode = membershipToConsider.Session;
+                        var isGroupAdmin = _membershipService
+                            .GetMembershipsForActivity(
+                                activityCode,
+                                sessionCode,
+                                participationTypes: new List<string> { Participation.GroupAdmin.GetDescription() })
+                            .Any(x => x.Username.EqualsIgnoreCase(user_name));
+                        // If user is the advisor of the activity to which the request is sent.
+                        if (isGroupAdmin)
                             return true;
-                        // membershipRequest = mr
-                        if (context.ActionArguments["membershipRequestID"] is int mrID)
-                        {
-                            var mrToConsider = _membershipRequestService.Get(mrID);
-                            var is_mrOwner = mrToConsider.Username.EqualsIgnoreCase(user_name);
-                            if (is_mrOwner)
-                                return true;
-
-                            var activityCode = mrToConsider.ActivityCode;
-
-                            var isGroupAdmin = _membershipService.GetGroupAdminMembershipsForActivity(activityCode).Any(x => x.Username.EqualsIgnoreCase(user_name));
-                            if (isGroupAdmin)
-                                return true;
-                        }
-
-                        return false;
                     }
-                case Resource.STUDENT:
-                    return false; // No one should be able to delete a student through our API
-                case Resource.HOUSING:
-                    {
-                        // The housing admins can update the application information (i.e. probation, offcampus program, etc.)
-                        // If the user is a student, then the user must be on an application and be an editor to update the application
-                        HousingService housingService = new HousingService(_CCTContext);
-                        if (user_groups.Contains(AuthGroup.HousingAdmin))
-                        {
-                            return true;
-                        }
-                        else if (user_groups.Contains(AuthGroup.Student))
-                        {
-                            var sess_cde = Helpers.GetCurrentSession(_CCTContext);
-                            int? applicationID = housingService.GetApplicationID(user_name, sess_cde);
-                            if (context.ActionArguments["applicationID"] is int requestedApplicationID && applicationID is not null && applicationID.Value == requestedApplicationID)
-                            {
-                                var editorUsername = housingService.GetEditorUsername(applicationID.Value);
-                                return editorUsername.EqualsIgnoreCase(user_name);
-                            }
-                        }
-                        return false;
-                    }
-                case Resource.ADMIN:
                     return false;
-                case Resource.HOUSING_ADMIN:
+                }
+
+            case Resource.MEMBERSHIP_REQUEST:
+                {
+                    // User is admin
+                    if (user_groups.Contains(AuthGroup.SiteAdmin))
+                        return true;
+                    if (context.ActionArguments["membershipRequest"] is RequestUploadViewModel membershipRequestToConsider)
                     {
-                        // Only the superadmins can remove a housing admin from the whitelist
-                        // Super admins have unrestricted access by default: no need to check
+                        // A membership request belonging to the currently logged in student
+                        var is_Owner = membershipRequestToConsider.Username.EqualsIgnoreCase(user_name);
+                        if (is_Owner)
+                            return true;
+                    }
+                    // No one should be able to add requests on behalf of another person.
+                    return false;
+                }
+            case Resource.STUDENT:
+                return false; // No one should be able to add students through this API
+            case Resource.ADVISOR:
+                // User is admin
+                if (user_groups.Contains(AuthGroup.SiteAdmin))
+                    return true;
+                else
+                    return false; // Only super admin can add Advisors through this API
+            case Resource.HOUSING_ADMIN:
+                //only superadmins can add a HOUSING_ADMIN
+                return false;
+            case Resource.HOUSING:
+                {
+                    // The user must be a student and not a member of an existing application
+                    if (user_groups.Contains(AuthGroup.Student))
+                    {
+                        var sess_cde = Helpers.GetCurrentSession(_CCTContext);
+                        var housingService = new HousingService(_CCTContext);
+                        int? applicationID = housingService.GetApplicationID(user_name, sess_cde);
+                        if (!applicationID.HasValue)
+                        {
+                            return true;
+                        }
                         return false;
                     }
-                case Resource.NEWS:
+                    return false;
+                }
+            case Resource.ADMIN:
+                return false;
+            case Resource.ERROR_LOG:
+                return true;
+            case Resource.NEWS:
+                return true;
+            default: return false;
+        }
+    }
+    private async Task<bool> CanUpdateAsync(string resource)
+    {
+        switch (resource)
+        {
+            case Resource.SHIFT:
+                {
+                    if (user_groups.Contains(AuthGroup.Student))
+                        return true;
+                    return false;
+                }
+            case Resource.MEMBERSHIP:
+                {
+                    // User is admin
+                    if (user_groups.Contains(AuthGroup.SiteAdmin))
+                        return true;
+                    if (context.ActionArguments["membershipID"] is int membershipID)
                     {
-                        if (context.ActionArguments["newsID"] is int newsID)
+                        var membershipToConsider = _membershipService.GetMembershipViewById(membershipID);
+                        var activityCode = membershipToConsider.ActivityCode;
+                        var sessionCode = membershipToConsider.SessionCode;
+
+
+                        var userMembership = _membershipService
+                            .GetMembershipsForActivity(activityCode, sessionCode)
+                            .FirstOrDefault(x => x.Username.EqualsIgnoreCase(user_name));
+                        if (membershipToConsider.Participation == Participation.Advisor.GetDescription())
                         {
-                            var newsItem = _newsService.Get(newsID);
-
-                            // only expired news items may be deleted
-                            var newsDate = newsItem.Entered;
-                            if (!newsDate.HasValue || DateTime.Now.Subtract(newsDate.Value).Days >= 14)
-                            {
-                                return false;
-                            }
-
-                            // can update if user is a Student News Admin
-                            if (user_groups.Contains(AuthGroup.NewsAdmin))
-                                return true;
-
-                            // can update if user is news item author
-                            return newsItem.ADUN.EqualsIgnoreCase(user_name);
+                            return userMembership?.Participation == Participation.Advisor.GetDescription();
+                        }
+                        else if (userMembership?.GroupAdmin == true && membershipToConsider.Participation != Participation.Advisor.GetDescription())
+                        {
+                            // Activity Advisors can update memberships of people in their activity.
+                            return true;
                         }
 
-                        return false;
+
+                        var is_membershipOwner = membershipToConsider.Username.EqualsIgnoreCase(user_name);
+                        if (is_membershipOwner)
+                        {
+                            // Restrict what a regular owner can edit.
+                            var originalMembership = _membershipService.GetSpecificMembership(membershipToConsider.MembershipID);
+                            // If they are not trying to change their participation level, then it is ok
+                            if (originalMembership.Participation == membershipToConsider.Participation)
+                                return true;
+                        }
                     }
-                case Resource.SLIDER:
+
+
+                    return false;
+                }
+
+            case Resource.MEMBERSHIP_REQUEST:
+                {
+                    // Once a request is sent, no one is able to edit its contents.
+                    // If a mistake is made in creating the original request, the user can delete it and make a new one.
+                    if (context.ActionArguments["membershipRequestID"] is int mrID)
                     {
-                        if (user_groups.Contains(AuthGroup.SiteAdmin))
-                            return true;
-                        return false;
+                        // Get the view model from the repository
+                        var activityCode = _membershipRequestService.Get(mrID).ActivityCode;
+
+                        // If user is a leader or advisor of the activity the request is for
+                        return _membershipService
+                                .GetMembershipsForActivity(activityCode: activityCode,
+                                                           participationTypes: new List<string>
+                                                           {
+                                                               Participation.Leader.GetDescription(),
+                                                               Participation.Advisor.GetDescription()
+                                                           })
+                                .Any(x => x.Username.EqualsIgnoreCase(user_name));
                     }
-                default: return false;
-            }
+                    return false;
+                }
+            case Resource.MEMBERSHIP_PRIVACY:
+                {
+                    if (context.ActionArguments["membershipID"] is int membershipID)
+                    {
+                        var membershipToConsider = _membershipService.GetSpecificMembership(membershipID);
+                        var is_membershipOwner = membershipToConsider.Username.EqualsIgnoreCase(user_name);
+                        if (is_membershipOwner)
+                            return true;
+                    }
+
+                    return false;
+                }
+            case Resource.STUDENT:
+                return false; // No one should be able to update a student through this API
+            case Resource.HOUSING:
+                {
+                    // The housing admins can update the application information (i.e. probation, offcampus program, etc.)
+                    // If the user is a student, then the user must be on an application and be an editor to update the application
+                    HousingService housingService = new HousingService(_CCTContext);
+                    if (user_groups.Contains(AuthGroup.HousingAdmin))
+                    {
+                        return true;
+                    }
+                    else if (user_groups.Contains(AuthGroup.Student))
+                    {
+                        var sess_cde = Helpers.GetCurrentSession(_CCTContext);
+                        int? applicationID = housingService.GetApplicationID(user_name, sess_cde);
+                        if (context.ActionArguments["applicationID"] is int requestedApplicationID
+                            && applicationID is not null
+                            && applicationID == requestedApplicationID)
+                        {
+                            string editorUsername = housingService.GetEditorUsername(applicationID.Value);
+                            return editorUsername.EqualsIgnoreCase(user_name);
+                        }
+                    }
+                    return false;
+                }
+            case Resource.PROFILE:
+                {
+                    // User is admin
+                    if (user_groups.Contains(AuthGroup.SiteAdmin))
+                        return true;
+
+                    if (context.ActionArguments["username"] is string username)
+                        return username.EqualsIgnoreCase(user_name);
+
+                    return false;
+                }
+
+            case Resource.ACTIVITY_INFO:
+                {
+                    // User is admin
+                    if (user_groups.Contains(AuthGroup.SiteAdmin))
+                        return true;
+
+                    if (context.ActionArguments["id"] is string activityCode)
+                    {
+                        var isGroupAdmin = _membershipService
+                            .GetMembershipsForActivity(
+                                activityCode,
+                                participationTypes: new List<string> { Participation.GroupAdmin.GetDescription() })
+                            .Any(x => x.Username.EqualsIgnoreCase(user_name));
+                        return isGroupAdmin;
+                    }
+                    return false;
+
+                }
+
+            case Resource.ACTIVITY_STATUS:
+                {
+                    // User is admin
+                    if (user_groups.Contains(AuthGroup.SiteAdmin))
+                        return true;
+
+                    if (context.ActionArguments["id"] is string activityCode)
+                    {
+                        var isGroupAdmin = _membershipService
+                            .GetMembershipsForActivity(
+                                activityCode,
+                                participationTypes: new List<string> { Participation.GroupAdmin.GetDescription() })
+                            .Any(x => x.Username.EqualsIgnoreCase(user_name));
+                        if (isGroupAdmin && context.ActionArguments["sess_cde"] is string sessionCode)
+                        {
+                            var activityService = context.HttpContext.RequestServices.GetRequiredService<IActivityService>();
+                            // If an activity is currently open, then a group admin has the ability to close it
+                            return activityService.IsOpen(activityCode, sessionCode);
+                        }
+                    }
+
+                    // If an activity is currently closed, only super admin has permission to edit its closed/open status   
+                    return false;
+                }
+            case Resource.EMERGENCY_CONTACT:
+                {
+                    return context.ActionArguments["username"] is string username && username.EqualsIgnoreCase(user_name);
+                }
+
+            case Resource.NEWS:
+                {
+                    if (context.ActionArguments["newsID"] is int newsID)
+                    {
+                        var newsItem = _newsService.Get(newsID);
+                        // only unapproved posts may be updated
+                        if (newsItem.Accepted != false)
+                            return false;
+
+                        // can update if user is a Student News Admin
+                        if (user_groups.Contains(AuthGroup.NewsAdmin))
+                            return true;
+
+                        // can update if user is news item author
+                        return newsItem.ADUN.EqualsIgnoreCase(user_name);
+                    }
+
+                    return false;
+                }
+
+            case Resource.NEWS_APPROVAL:
+                {
+                    // can approve or deny if user is a Student News Admin
+                    if (user_groups.Contains(AuthGroup.NewsAdmin))
+                        return true;
+
+                    return false;
+                }
+
+            default: return false;
         }
-
-
     }
+    private async Task<bool> CanDeleteAsync(string resource)
+    {
+        switch (resource)
+        {
+            case Resource.SHIFT:
+                if (user_groups.Contains(AuthGroup.Student))
+                    return true;
+                return false;
+            case Resource.MEMBERSHIP:
+                {
+                    // User is admin
+                    if (user_groups.Contains(AuthGroup.SiteAdmin))
+                        return true;
+                    if (context.ActionArguments["membershipID"] is int membershipID)
+                    {
+                        var membershipToConsider = _membershipService.GetSpecificMembership(membershipID);
+                        var is_membershipOwner = membershipToConsider.Username.EqualsIgnoreCase(user_name);
+                        if (is_membershipOwner)
+                            return true;
+
+                        var isGroupAdmin = _membershipService
+                            .GetMembershipsForActivity(
+                                membershipToConsider.ActivityCode,
+                                participationTypes: new List<string> { Participation.GroupAdmin.GetDescription() })
+                            .Any(x => x.Username.EqualsIgnoreCase(user_name));
+                        return isGroupAdmin;
+                    }
+
+                    return false;
+                }
+            case Resource.MEMBERSHIP_REQUEST:
+                {
+                    // User is admin
+                    if (user_groups.Contains(AuthGroup.SiteAdmin))
+                        return true;
+                    // membershipRequest = mr
+                    if (context.ActionArguments["membershipRequestID"] is int mrID)
+                    {
+                        var mrToConsider = _membershipRequestService.Get(mrID);
+                        var is_mrOwner = mrToConsider.Username.EqualsIgnoreCase(user_name);
+                        if (is_mrOwner)
+                            return true;
+
+                        var activityCode = mrToConsider.ActivityCode;
+
+                        var isGroupAdmin = _membershipService
+                            .GetMembershipsForActivity(
+                                activityCode,
+                                participationTypes: new List<string> { Participation.GroupAdmin.GetDescription() })
+                            .Any(x => x.Username.EqualsIgnoreCase(user_name));
+                        if (isGroupAdmin)
+                            return true;
+                    }
+
+                    return false;
+                }
+            case Resource.STUDENT:
+                return false; // No one should be able to delete a student through our API
+            case Resource.HOUSING:
+                {
+                    // The housing admins can update the application information (i.e. probation, offcampus program, etc.)
+                    // If the user is a student, then the user must be on an application and be an editor to update the application
+                    HousingService housingService = new HousingService(_CCTContext);
+                    if (user_groups.Contains(AuthGroup.HousingAdmin))
+                    {
+                        return true;
+                    }
+                    else if (user_groups.Contains(AuthGroup.Student))
+                    {
+                        var sess_cde = Helpers.GetCurrentSession(_CCTContext);
+                        int? applicationID = housingService.GetApplicationID(user_name, sess_cde);
+                        if (context.ActionArguments["applicationID"] is int requestedApplicationID && applicationID is not null && applicationID.Value == requestedApplicationID)
+                        {
+                            var editorUsername = housingService.GetEditorUsername(applicationID.Value);
+                            return editorUsername.EqualsIgnoreCase(user_name);
+                        }
+                    }
+                    return false;
+                }
+            case Resource.ADMIN:
+                return false;
+            case Resource.HOUSING_ADMIN:
+                {
+                    // Only the superadmins can remove a housing admin from the whitelist
+                    // Super admins have unrestricted access by default: no need to check
+                    return false;
+                }
+            case Resource.NEWS:
+                {
+                    if (context.ActionArguments["newsID"] is int newsID)
+                    {
+                        var newsItem = _newsService.Get(newsID);
+
+                        // only expired news items may be deleted
+                        var newsDate = newsItem.Entered;
+                        if (!newsDate.HasValue || DateTime.Now.Subtract(newsDate.Value).Days >= 14)
+                        {
+                            return false;
+                        }
+
+                        // can update if user is a Student News Admin
+                        if (user_groups.Contains(AuthGroup.NewsAdmin))
+                            return true;
+
+                        // can update if user is news item author
+                        return newsItem.ADUN.EqualsIgnoreCase(user_name);
+                    }
+
+                    return false;
+                }
+            case Resource.SLIDER:
+                {
+                    if (user_groups.Contains(AuthGroup.SiteAdmin))
+                        return true;
+                    return false;
+                }
+            default: return false;
+        }
+    }
+
+
 }

--- a/Gordon360/Authorization/StateYourBusiness.cs
+++ b/Gordon360/Authorization/StateYourBusiness.cs
@@ -17,800 +17,801 @@ using Gordon360.Extensions.System;
 using static Gordon360.Services.MembershipService;
 using Gordon360.Enums;
 
-namespace Gordon360.Authorization;
-
-/* Authorization Filter.
- * It is actually an action filter masquerading as an authorization filter. This is because I need access to the 
- * parameters passed to the controller. Authorization Filters don't have that access. Action Filters do.
- * 
- * Because of the nature of how we authorize people, this code might seem very odd, so I'll try to explain. 
- * Proceed at your own risk. If you can understand this code, you can understand the whole project. 
- * 
- * 1st Observation: You can't authorize access to a resource that isn't owned by someone. Resources like Sessions, Participations,
- * and Activity Definitions are accessibile by anyone.
- * 2nd Observation: To Authorize someone to perform an action on a resource, you need to know the following:
- * 1. Who is to be authorized? 2.What resource are they trying to access? 3. What operation are they trying to make on the resource?
- * This "algorithm" uses those three points and decides through a series of switch statements if the current user
- * is authorized.
- */
-public class StateYourBusiness : ActionFilterAttribute
+namespace Gordon360.Authorization
 {
-    // Resource to be accessed: Will get as parameters to the attribute
-    public string resource { get; set; }
-    // Operation to be performed: Will get as parameters to the attribute
-    public string operation { get; set; }
-
-    private ActionExecutingContext context;
-    private CCTContext _CCTContext;
-    private IAccountService _accountService;
-    private IMembershipService _membershipService;
-    private IMembershipRequestService _membershipRequestService;
-    private INewsService _newsService;
-
-    // User position at the college and their id.
-    private IEnumerable<AuthGroup> user_groups { get; set; }
-    private string user_id { get; set; }
-    private string user_name { get; set; }
-
-    public async override Task OnActionExecutionAsync(ActionExecutingContext actionContext, ActionExecutionDelegate next)
-    {
-        context = actionContext;
-        // Step 1: Who is to be authorized
-        var authenticatedUser = actionContext.HttpContext.User;
-
-        _accountService = context.HttpContext.RequestServices.GetRequiredService<IAccountService>();
-        _membershipService = context.HttpContext.RequestServices.GetRequiredService<IMembershipService>();
-        _membershipRequestService = context.HttpContext.RequestServices.GetRequiredService<IMembershipRequestService>();
-        _newsService = context.HttpContext.RequestServices.GetRequiredService<INewsService>();
-
-        user_name = AuthUtils.GetUsername(authenticatedUser);
-        user_groups = AuthUtils.GetGroups(authenticatedUser);
-        user_id = _accountService.GetAccountByUsername(user_name).GordonID;
-
-        if (user_groups.Contains(AuthGroup.SiteAdmin))
-        {
-            await next();
-            return;
-        }
-
-        bool isAuthorized = await CanPerformOperationAsync(resource, operation);
-        if (!isAuthorized)
-        {
-            throw new UnauthorizedAccessException("Authorization has been denied for this request.");
-        }
-
-        await next();
-    }
-
-
-    private async Task<bool> CanPerformOperationAsync(string resource, string operation)
-        => operation switch
-        {
-            Operation.READ_ONE => await CanReadOneAsync(resource),
-            Operation.READ_ALL => CanReadAll(resource),
-            Operation.READ_PARTIAL => await CanReadPartialAsync(resource),
-            Operation.ADD => await CanAddAsync(resource),
-            Operation.UPDATE => await CanUpdateAsync(resource),
-            Operation.DELETE => await CanDeleteAsync(resource),
-            Operation.READ_PUBLIC => CanReadPublic(resource),
-            _ => false,
-        };
-
-    /*
-     * Operations
+    /* Authorization Filter.
+     * It is actually an action filter masquerading as an authorization filter. This is because I need access to the 
+     * parameters passed to the controller. Authorization Filters don't have that access. Action Filters do.
+     * 
+     * Because of the nature of how we authorize people, this code might seem very odd, so I'll try to explain. 
+     * Proceed at your own risk. If you can understand this code, you can understand the whole project. 
+     * 
+     * 1st Observation: You can't authorize access to a resource that isn't owned by someone. Resources like Sessions, Participations,
+     * and Activity Definitions are accessibile by anyone.
+     * 2nd Observation: To Authorize someone to perform an action on a resource, you need to know the following:
+     * 1. Who is to be authorized? 2.What resource are they trying to access? 3. What operation are they trying to make on the resource?
+     * This "algorithm" uses those three points and decides through a series of switch statements if the current user
+     * is authorized.
      */
-    private async Task<bool> CanReadOneAsync(string resource)
+    public class StateYourBusiness : ActionFilterAttribute
     {
-        // User is admin
-        if (user_groups.Contains(AuthGroup.SiteAdmin))
-            return true;
+        // Resource to be accessed: Will get as parameters to the attribute
+        public string resource { get; set; }
+        // Operation to be performed: Will get as parameters to the attribute
+        public string operation { get; set; }
 
-        switch (resource)
+        private ActionExecutingContext context;
+        private CCTContext _CCTContext;
+        private IAccountService _accountService;
+        private IMembershipService _membershipService;
+        private IMembershipRequestService _membershipRequestService;
+        private INewsService _newsService;
+
+        // User position at the college and their id.
+        private IEnumerable<AuthGroup> user_groups { get; set; }
+        private string user_id { get; set; }
+        private string user_name { get; set; }
+
+        public async override Task OnActionExecutionAsync(ActionExecutingContext actionContext, ActionExecutionDelegate next)
         {
-            case Resource.PROFILE:
-                return true;
-            case Resource.EMERGENCY_CONTACT:
-                {
-                    if (user_groups.Contains(AuthGroup.Police))
-                        return true;
+            context = actionContext;
+            // Step 1: Who is to be authorized
+            var authenticatedUser = actionContext.HttpContext.User;
 
-                    return context.ActionArguments["username"] is string username && username.EqualsIgnoreCase(user_name);
-                }
-            case Resource.MEMBERSHIP:
+            _accountService = context.HttpContext.RequestServices.GetRequiredService<IAccountService>();
+            _membershipService = context.HttpContext.RequestServices.GetRequiredService<IMembershipService>();
+            _membershipRequestService = context.HttpContext.RequestServices.GetRequiredService<IMembershipRequestService>();
+            _newsService = context.HttpContext.RequestServices.GetRequiredService<INewsService>();
+
+            user_name = AuthUtils.GetUsername(authenticatedUser);
+            user_groups = AuthUtils.GetGroups(authenticatedUser);
+            user_id = _accountService.GetAccountByUsername(user_name).GordonID;
+
+            if (user_groups.Contains(AuthGroup.SiteAdmin))
+            {
+                await next();
+                return;
+            }
+
+            bool isAuthorized = await CanPerformOperationAsync(resource, operation);
+            if (!isAuthorized)
+            {
+                throw new UnauthorizedAccessException("Authorization has been denied for this request.");
+            }
+
+            await next();
+        }
+
+
+        private async Task<bool> CanPerformOperationAsync(string resource, string operation)
+            => operation switch
+            {
+                Operation.READ_ONE => await CanReadOneAsync(resource),
+                Operation.READ_ALL => CanReadAll(resource),
+                Operation.READ_PARTIAL => await CanReadPartialAsync(resource),
+                Operation.ADD => await CanAddAsync(resource),
+                Operation.UPDATE => await CanUpdateAsync(resource),
+                Operation.DELETE => await CanDeleteAsync(resource),
+                Operation.READ_PUBLIC => CanReadPublic(resource),
+                _ => false,
+            };
+
+        /*
+         * Operations
+         */
+        private async Task<bool> CanReadOneAsync(string resource)
+        {
+            // User is admin
+            if (user_groups.Contains(AuthGroup.SiteAdmin))
                 return true;
-            case Resource.MEMBERSHIP_REQUEST:
-                {
-                    // membershipRequest = mr
-                    if (context.ActionArguments["id"] is int mrID)
+
+            switch (resource)
+            {
+                case Resource.PROFILE:
+                    return true;
+                case Resource.EMERGENCY_CONTACT:
                     {
-                        var mrToConsider = _membershipRequestService.Get(mrID);
-                        var is_mrOwner = mrToConsider.Username.EqualsIgnoreCase(user_name); // User_id is an instance variable.
-
-                        if (is_mrOwner) // If user owns the request
+                        if (user_groups.Contains(AuthGroup.Police))
                             return true;
 
-                        var isGroupAdmin = _membershipService
-                            .GetMemberships(
-                                activityCode: mrToConsider.ActivityCode,
-                                username: user_name,
-                                sessionCode: mrToConsider.SessionCode,
-                                participationTypes: new List<string> { Participation.GroupAdmin.GetDescription() })
-                            .Any();
+                        return context.ActionArguments["username"] is string username && username.EqualsIgnoreCase(user_name);
+                    }
+                case Resource.MEMBERSHIP:
+                    return true;
+                case Resource.MEMBERSHIP_REQUEST:
+                    {
+                        // membershipRequest = mr
+                        if (context.ActionArguments["id"] is int mrID)
+                        {
+                            var mrToConsider = _membershipRequestService.Get(mrID);
+                            var is_mrOwner = mrToConsider.Username.EqualsIgnoreCase(user_name); // User_id is an instance variable.
+
+                            if (is_mrOwner) // If user owns the request
+                                return true;
+
+                            var isGroupAdmin = _membershipService
+                                .GetMemberships(
+                                    activityCode: mrToConsider.ActivityCode,
+                                    username: user_name,
+                                    sessionCode: mrToConsider.SessionCode,
+                                    participationTypes: new List<string> { Participation.GroupAdmin.GetDescription() })
+                                .Any();
+                            if (isGroupAdmin) // If user is a group admin of the activity that the request is sent to
+                                return true;
+                        }
+
+                        return false;
+                    }
+                case Resource.STUDENT:
+                    // To add a membership for a student, you need to have the students identifier.
+                    // NOTE: I don't believe the 'student' resource is currently being used in API
+                    {
+                        return true;
+                    }
+                case Resource.ADVISOR:
+                    return true;
+                case Resource.ACCOUNT:
+                    {
+                        // Membership group admins can access ID of members using their email
+                        // NOTE: In the future, probably only email addresses should be stored 
+                        // in memberships, since we would rather not give students access to
+                        // other students' account information
+                        var isGroupAdmin = _membershipService.IsGroupAdmin(user_name);
                         if (isGroupAdmin) // If user is a group admin of the activity that the request is sent to
                             return true;
-                    }
 
-                    return false;
-                }
-            case Resource.STUDENT:
-                // To add a membership for a student, you need to have the students identifier.
-                // NOTE: I don't believe the 'student' resource is currently being used in API
-                {
+                        // faculty and police can access student account information
+                        if (user_groups.Contains(AuthGroup.FacStaff)
+                            || user_groups.Contains(AuthGroup.Police))
+                            return true;
+
+                        return false;
+                    }
+                case Resource.HOUSING:
+                    {
+                        // The members of the apartment application can only read their application
+                        var sess_cde = Helpers.GetCurrentSession(_CCTContext);
+                        HousingService housingService = new HousingService(_CCTContext);
+                        int? applicationID = housingService.GetApplicationID(user_name, sess_cde);
+                        if (context.ActionArguments["applicationID"] is int requestedApplicationID && applicationID is not null)
+                        {
+                            return requestedApplicationID == applicationID;
+                        }
+                        return false;
+                    }
+                case Resource.NEWS:
                     return true;
-                }
-            case Resource.ADVISOR:
-                return true;
-            case Resource.ACCOUNT:
-                {
-                    // Membership group admins can access ID of members using their email
-                    // NOTE: In the future, probably only email addresses should be stored 
-                    // in memberships, since we would rather not give students access to
-                    // other students' account information
-                    var isGroupAdmin = _membershipService.IsGroupAdmin(user_name);
-                    if (isGroupAdmin) // If user is a group admin of the activity that the request is sent to
-                        return true;
+                default: return false;
 
-                    // faculty and police can access student account information
-                    if (user_groups.Contains(AuthGroup.FacStaff)
-                        || user_groups.Contains(AuthGroup.Police))
-                        return true;
-
-                    return false;
-                }
-            case Resource.HOUSING:
-                {
-                    // The members of the apartment application can only read their application
-                    var sess_cde = Helpers.GetCurrentSession(_CCTContext);
-                    HousingService housingService = new HousingService(_CCTContext);
-                    int? applicationID = housingService.GetApplicationID(user_name, sess_cde);
-                    if (context.ActionArguments["applicationID"] is int requestedApplicationID && applicationID is not null)
-                    {
-                        return requestedApplicationID == applicationID;
-                    }
-                    return false;
-                }
-            case Resource.NEWS:
-                return true;
-            default: return false;
-
+            }
         }
-    }
-    // For reads that access a group of resources filterd in a specific way 
-    private async Task<bool> CanReadPartialAsync(string resource)
-    {
-        // User is admin
-        if (user_groups.Contains(AuthGroup.SiteAdmin))
-            return true;
-
-        switch (resource)
+        // For reads that access a group of resources filterd in a specific way 
+        private async Task<bool> CanReadPartialAsync(string resource)
         {
-            case Resource.MEMBERSHIP_BY_ACTIVITY:
-                {
-                    // Only people that are part of the activity should be able to see members
-                    if (context.ActionArguments["activityCode"] is string activityCode)
-                    {
-                        var activityMembers = _membershipService.GetMemberships(activityCode: activityCode, username: user_name);
-                        var is_personAMember = activityMembers.Any(x => x.Participation != Participation.Guest.GetDescription());
-                        return is_personAMember;
-                    }
-                    return false;
-                }
+            // User is admin
+            if (user_groups.Contains(AuthGroup.SiteAdmin))
+                return true;
 
-            case Resource.MEMBERSHIP:
-                {
-                    // Everyone can read a specific user's memberships
-                    // TODO: restrict if user is private?
-                    if (context.ActionArguments.TryGetValue("username", out object? username_object) && username_object is string username)
+            switch (resource)
+            {
+                case Resource.MEMBERSHIP_BY_ACTIVITY:
                     {
-                        return true;
+                        // Only people that are part of the activity should be able to see members
+                        if (context.ActionArguments["activityCode"] is string activityCode)
+                        {
+                            var activityMembers = _membershipService.GetMemberships(activityCode: activityCode, username: user_name);
+                            var is_personAMember = activityMembers.Any(x => x.Participation != Participation.Guest.GetDescription());
+                            return is_personAMember;
+                        }
+                        return false;
                     }
 
-                    // Only members can read a specific activity's memberships
-                    if (context.ActionArguments.TryGetValue("involvementCode", out object? involvementCode_object) && involvementCode_object is string involvementCode)
+                case Resource.MEMBERSHIP:
                     {
-                        var activityMembers = _membershipService.GetMemberships(activityCode: involvementCode, username: user_name);
-                        var is_personAMember = activityMembers.Any(x => x.Participation != Participation.Guest.GetDescription());
-                        return is_personAMember;
+                        // Everyone can read a specific user's memberships
+                        // TODO: restrict if user is private?
+                        if (context.ActionArguments.TryGetValue("username", out object? username_object) && username_object is string username)
+                        {
+                            return true;
+                        }
+
+                        // Only members can read a specific activity's memberships
+                        if (context.ActionArguments.TryGetValue("involvementCode", out object? involvementCode_object) && involvementCode_object is string involvementCode)
+                        {
+                            var activityMembers = _membershipService.GetMemberships(activityCode: involvementCode, username: user_name);
+                            var is_personAMember = activityMembers.Any(x => x.Participation != Participation.Guest.GetDescription());
+                            return is_personAMember;
+                        }
+
+                        return false;
                     }
 
-                    return false;
-                }
-
-            case Resource.EVENTS_BY_STUDENT_ID:
-                {
-                    // Only the person itself or an admin can see someone's chapel attendance
-                    if (context.ActionArguments["username"] is string username_requested)
+                case Resource.EVENTS_BY_STUDENT_ID:
                     {
-                        return username_requested.EqualsIgnoreCase(user_name);
+                        // Only the person itself or an admin can see someone's chapel attendance
+                        if (context.ActionArguments["username"] is string username_requested)
+                        {
+                            return username_requested.EqualsIgnoreCase(user_name);
+                        }
+                        return false;
                     }
-                    return false;
-                }
 
 
-            case Resource.MEMBERSHIP_REQUEST_BY_ACTIVITY:
-                {
-                    // An activity leader should be able to see the membership requests that belong to the activity s/he is leading.
-                    if (context.ActionArguments["activityCode"] is string activityCode)
+                case Resource.MEMBERSHIP_REQUEST_BY_ACTIVITY:
                     {
-                        var isGroupAdmin = _membershipService
-                            .GetMemberships(
-                                activityCode: activityCode,
-                                username: user_name,
-                                participationTypes: new List<string> { Participation.GroupAdmin.GetDescription() })
-                            .Any();
-                        return isGroupAdmin; // If user is a group admin of the activity that the request is sent to
+                        // An activity leader should be able to see the membership requests that belong to the activity s/he is leading.
+                        if (context.ActionArguments["activityCode"] is string activityCode)
+                        {
+                            var isGroupAdmin = _membershipService
+                                .GetMemberships(
+                                    activityCode: activityCode,
+                                    username: user_name,
+                                    participationTypes: new List<string> { Participation.GroupAdmin.GetDescription() })
+                                .Any();
+                            return isGroupAdmin; // If user is a group admin of the activity that the request is sent to
+                        }
+                        return false;
                     }
-                    return false;
-                }
-            case Resource.EMAILS_BY_ACTIVITY:
-                {
-                    var publicParticipantTypes = new List<string>
+                case Resource.EMAILS_BY_ACTIVITY:
+                    {
+                        var publicParticipantTypes = new List<string>
                                 {
                                     Participation.GroupAdmin.GetDescription(),
                                     Participation.Advisor.GetDescription()
                                 };
 
-                    // Anyone can view group-admin and advisor emails
-                    // TODO: Remove once Obsolete EmailsController routes are gone
-                    if (context.ActionArguments.TryGetValue("participationType", out var participationType)
-                        && participationType is string participation
-                        && participation.In(publicParticipantTypes.ToArray())
-                        )
-                    {
-                        return true;
-                    }
+                        // Anyone can view group-admin and advisor emails
+                        // TODO: Remove once Obsolete EmailsController routes are gone
+                        if (context.ActionArguments.TryGetValue("participationType", out var participationType)
+                            && participationType is string participation
+                            && participation.In(publicParticipantTypes.ToArray())
+                            )
+                        {
+                            return true;
+                        }
 
-                    // Anyone can view group-admin and advisor emails
-                    if (context.ActionArguments.TryGetValue("participationTypes", out var p)
-                        && p is List<string> participationTypes
-                        && participationTypes.All(pt => pt.In(publicParticipantTypes.ToArray()))
-                        )
-                    {
-                        return true;
-                    }
+                        // Anyone can view group-admin and advisor emails
+                        if (context.ActionArguments.TryGetValue("participationTypes", out var p)
+                            && p is List<string> participationTypes
+                            && participationTypes.All(pt => pt.In(publicParticipantTypes.ToArray()))
+                            )
+                        {
+                            return true;
+                        }
 
-                    var leaderTypes = new List<string>
+                        var leaderTypes = new List<string>
                                 {
                                     Participation.GroupAdmin.GetDescription(),
                                     Participation.Leader.GetDescription(),
                                     Participation.Advisor.GetDescription()
                                 };
 
-                    // Only leaders, advisors, and group admins
-                    if (context.ActionArguments["activityCode"] is string activityCode)
-                    {
-                        string? sessionCode = context.ActionArguments.TryGetValue("sessionCode", out var sessionCodeObject) ? sessionCodeObject as string : null;
-                        return _membershipService
-                            .GetMemberships(
-                                activityCode: activityCode,
-                                username: user_name,
-                                sessionCode: sessionCode,
-                                participationTypes: leaderTypes)
-                            .Any();
+                        // Only leaders, advisors, and group admins
+                        if (context.ActionArguments["activityCode"] is string activityCode)
+                        {
+                            string? sessionCode = context.ActionArguments.TryGetValue("sessionCode", out var sessionCodeObject) ? sessionCodeObject as string : null;
+                            return _membershipService
+                                .GetMemberships(
+                                    activityCode: activityCode,
+                                    username: user_name,
+                                    sessionCode: sessionCode,
+                                    participationTypes: leaderTypes)
+                                .Any();
+                        }
+
+                        return false;
                     }
-
-                    return false;
-                }
-            case Resource.NEWS:
-                {
-                    return true;
-                }
-            default: return false;
-        }
-    }
-    private bool CanReadAll(string resource)
-    {
-        switch (resource)
-        {
-            case Resource.MEMBERSHIP:
-                // User is admin
-                if (user_groups.Contains(AuthGroup.SiteAdmin))
-                    return true;
-                else
-                    return false;
-            case Resource.ChapelEvent:
-                // User is admin
-                if (user_groups.Contains(AuthGroup.SiteAdmin))
-                    return true;
-                else
-                    return false;
-            case Resource.EVENTS_BY_STUDENT_ID:
-                // User is admin
-                if (user_groups.Contains(AuthGroup.SiteAdmin))
-                    return true;
-                else
-                    return false;
-
-            case Resource.MEMBERSHIP_REQUEST:
-                // User is admin
-                if (user_groups.Contains(AuthGroup.SiteAdmin))
-                    return true;
-                else
-                    return false;
-            case Resource.STUDENT:
-                // User is admin
-                if (user_groups.Contains(AuthGroup.SiteAdmin))
-                    return true;
-                else
-                    return false; // See reasons for this in CanReadOne(). No one (except for super admin) should be able to access student records through
-                                  // our API.
-            case Resource.ADVISOR:
-                // User is admin
-                if (user_groups.Contains(AuthGroup.SiteAdmin))
-                    return true;
-                else
-                    return false;
-            case Resource.GROUP_ADMIN:
-                // User is site-wide admin
-                if (user_groups.Contains(AuthGroup.SiteAdmin))
-                    return true;
-                else
-                    return false;
-            case Resource.ACCOUNT:
-                return false;
-            case Resource.ADMIN:
-                return false;
-            case Resource.HOUSING:
-                {
-                    // Only the housing admin and super admin can read all of the received applications.
-                    // Super admin has unrestricted access by default, so no need to check.
-                    if (user_groups.Contains(AuthGroup.HousingAdmin))
+                case Resource.NEWS:
                     {
                         return true;
                     }
-                    return false;
-                }
-            case Resource.NEWS:
-                return true;
-            default: return false;
+                default: return false;
+            }
         }
-    }
-
-    private bool CanReadPublic(string resource)
-    {
-        switch (resource)
+        private bool CanReadAll(string resource)
         {
-            case Resource.SLIDER:
-                return true;
-            case Resource.NEWS:
-                return false;
-            default: return false;
-
-        }
-    }
-    private async Task<bool> CanAddAsync(string resource)
-    {
-        switch (resource)
-        {
-            case Resource.SHIFT:
-                {
-                    if (user_groups.Contains(AuthGroup.Student))
-                        return true;
-                    return false;
-                }
-            case Resource.CLIFTON_STRENGTHS:
-                {
-                    return user_groups.Contains(AuthGroup.SiteAdmin);
-                }
-
-            case Resource.MEMBERSHIP:
-                {
+            switch (resource)
+            {
+                case Resource.MEMBERSHIP:
                     // User is admin
                     if (user_groups.Contains(AuthGroup.SiteAdmin))
                         return true;
-
-                    if (context.ActionArguments["membershipUpload"] is MembershipUploadViewModel membershipToConsider)
-                    {
-
-                        // A membership can always be added if it is of type "GUEST"
-                        var isFollower = membershipToConsider.Participation == Activity_Roles.GUEST
-                            && membershipToConsider.Username.EqualsIgnoreCase(user_name);
-                        if (isFollower)
-                            return true;
-
-                        var activityCode = membershipToConsider.Activity;
-                        var sessionCode = membershipToConsider.Session;
-                        var isGroupAdmin = _membershipService
-                            .GetMemberships(
-                                activityCode: activityCode,
-                                username: user_name,
-                                sessionCode: sessionCode,
-                                participationTypes: new List<string> { Participation.GroupAdmin.GetDescription() })
-                            .Any();
-                        // If user is the advisor of the activity to which the request is sent.
-                        if (isGroupAdmin)
-                            return true;
-                    }
-                    return false;
-                }
-
-            case Resource.MEMBERSHIP_REQUEST:
-                {
+                    else
+                        return false;
+                case Resource.ChapelEvent:
                     // User is admin
                     if (user_groups.Contains(AuthGroup.SiteAdmin))
                         return true;
-                    if (context.ActionArguments["membershipRequest"] is RequestUploadViewModel membershipRequestToConsider)
-                    {
-                        // A membership request belonging to the currently logged in student
-                        var is_Owner = membershipRequestToConsider.Username.EqualsIgnoreCase(user_name);
-                        if (is_Owner)
-                            return true;
-                    }
-                    // No one should be able to add requests on behalf of another person.
+                    else
+                        return false;
+                case Resource.EVENTS_BY_STUDENT_ID:
+                    // User is admin
+                    if (user_groups.Contains(AuthGroup.SiteAdmin))
+                        return true;
+                    else
+                        return false;
+
+                case Resource.MEMBERSHIP_REQUEST:
+                    // User is admin
+                    if (user_groups.Contains(AuthGroup.SiteAdmin))
+                        return true;
+                    else
+                        return false;
+                case Resource.STUDENT:
+                    // User is admin
+                    if (user_groups.Contains(AuthGroup.SiteAdmin))
+                        return true;
+                    else
+                        return false; // See reasons for this in CanReadOne(). No one (except for super admin) should be able to access student records through
+                                      // our API.
+                case Resource.ADVISOR:
+                    // User is admin
+                    if (user_groups.Contains(AuthGroup.SiteAdmin))
+                        return true;
+                    else
+                        return false;
+                case Resource.GROUP_ADMIN:
+                    // User is site-wide admin
+                    if (user_groups.Contains(AuthGroup.SiteAdmin))
+                        return true;
+                    else
+                        return false;
+                case Resource.ACCOUNT:
                     return false;
-                }
-            case Resource.STUDENT:
-                return false; // No one should be able to add students through this API
-            case Resource.ADVISOR:
-                // User is admin
-                if (user_groups.Contains(AuthGroup.SiteAdmin))
-                    return true;
-                else
-                    return false; // Only super admin can add Advisors through this API
-            case Resource.HOUSING_ADMIN:
-                //only superadmins can add a HOUSING_ADMIN
-                return false;
-            case Resource.HOUSING:
-                {
-                    // The user must be a student and not a member of an existing application
-                    if (user_groups.Contains(AuthGroup.Student))
+                case Resource.ADMIN:
+                    return false;
+                case Resource.HOUSING:
                     {
-                        var sess_cde = Helpers.GetCurrentSession(_CCTContext);
-                        var housingService = new HousingService(_CCTContext);
-                        int? applicationID = housingService.GetApplicationID(user_name, sess_cde);
-                        if (!applicationID.HasValue)
+                        // Only the housing admin and super admin can read all of the received applications.
+                        // Super admin has unrestricted access by default, so no need to check.
+                        if (user_groups.Contains(AuthGroup.HousingAdmin))
                         {
                             return true;
                         }
                         return false;
                     }
-                    return false;
-                }
-            case Resource.ADMIN:
-                return false;
-            case Resource.ERROR_LOG:
-                return true;
-            case Resource.NEWS:
-                return true;
-            default: return false;
+                case Resource.NEWS:
+                    return true;
+                default: return false;
+            }
         }
-    }
-    private async Task<bool> CanUpdateAsync(string resource)
-    {
-        switch (resource)
+
+        private bool CanReadPublic(string resource)
         {
-            case Resource.SHIFT:
-                {
-                    if (user_groups.Contains(AuthGroup.Student))
-                        return true;
+            switch (resource)
+            {
+                case Resource.SLIDER:
+                    return true;
+                case Resource.NEWS:
                     return false;
-                }
-            case Resource.MEMBERSHIP:
-                {
-                    // User is admin
-                    if (user_groups.Contains(AuthGroup.SiteAdmin))
-                        return true;
-                    if (context.ActionArguments["membershipID"] is int membershipID)
+                default: return false;
+
+            }
+        }
+        private async Task<bool> CanAddAsync(string resource)
+        {
+            switch (resource)
+            {
+                case Resource.SHIFT:
                     {
-                        var membershipToConsider = _membershipService.GetMembershipViewById(membershipID);
-                        var activityCode = membershipToConsider.ActivityCode;
-                        var sessionCode = membershipToConsider.SessionCode;
-
-
-                        var userMembership = _membershipService
-                            .GetMemberships(activityCode: activityCode, username: user_name, sessionCode: sessionCode)
-                            .FirstOrDefault();
-                        if (membershipToConsider.Participation == Participation.Advisor.GetDescription())
-                        {
-                            return userMembership?.Participation == Participation.Advisor.GetDescription();
-                        }
-                        else if (userMembership?.GroupAdmin == true && membershipToConsider.Participation != Participation.Advisor.GetDescription())
-                        {
-                            // Activity Advisors can update memberships of people in their activity.
+                        if (user_groups.Contains(AuthGroup.Student))
                             return true;
-                        }
-
-
-                        var is_membershipOwner = membershipToConsider.Username.EqualsIgnoreCase(user_name);
-                        if (is_membershipOwner)
-                        {
-                            // Restrict what a regular owner can edit.
-                            var originalMembership = _membershipService.GetSpecificMembership(membershipToConsider.MembershipID);
-                            // If they are not trying to change their participation level, then it is ok
-                            if (originalMembership.Participation == membershipToConsider.Participation)
-                                return true;
-                        }
+                        return false;
+                    }
+                case Resource.CLIFTON_STRENGTHS:
+                    {
+                        return user_groups.Contains(AuthGroup.SiteAdmin);
                     }
 
-
-                    return false;
-                }
-
-            case Resource.MEMBERSHIP_REQUEST:
-                {
-                    // Once a request is sent, no one is able to edit its contents.
-                    // If a mistake is made in creating the original request, the user can delete it and make a new one.
-                    if (context.ActionArguments["membershipRequestID"] is int mrID)
+                case Resource.MEMBERSHIP:
                     {
-                        // Get the view model from the repository
-                        var activityCode = _membershipRequestService.Get(mrID).ActivityCode;
+                        // User is admin
+                        if (user_groups.Contains(AuthGroup.SiteAdmin))
+                            return true;
 
-                        // If user is a leader or advisor of the activity the request is for
-                        return _membershipService
+                        if (context.ActionArguments["membershipUpload"] is MembershipUploadViewModel membershipToConsider)
+                        {
+
+                            // A membership can always be added if it is of type "GUEST"
+                            var isFollower = membershipToConsider.Participation == Activity_Roles.GUEST
+                                && membershipToConsider.Username.EqualsIgnoreCase(user_name);
+                            if (isFollower)
+                                return true;
+
+                            var activityCode = membershipToConsider.Activity;
+                            var sessionCode = membershipToConsider.Session;
+                            var isGroupAdmin = _membershipService
                                 .GetMemberships(
                                     activityCode: activityCode,
                                     username: user_name,
-                                    participationTypes: new List<string>
-                                       {
+                                    sessionCode: sessionCode,
+                                    participationTypes: new List<string> { Participation.GroupAdmin.GetDescription() })
+                                .Any();
+                            // If user is the advisor of the activity to which the request is sent.
+                            if (isGroupAdmin)
+                                return true;
+                        }
+                        return false;
+                    }
+
+                case Resource.MEMBERSHIP_REQUEST:
+                    {
+                        // User is admin
+                        if (user_groups.Contains(AuthGroup.SiteAdmin))
+                            return true;
+                        if (context.ActionArguments["membershipRequest"] is RequestUploadViewModel membershipRequestToConsider)
+                        {
+                            // A membership request belonging to the currently logged in student
+                            var is_Owner = membershipRequestToConsider.Username.EqualsIgnoreCase(user_name);
+                            if (is_Owner)
+                                return true;
+                        }
+                        // No one should be able to add requests on behalf of another person.
+                        return false;
+                    }
+                case Resource.STUDENT:
+                    return false; // No one should be able to add students through this API
+                case Resource.ADVISOR:
+                    // User is admin
+                    if (user_groups.Contains(AuthGroup.SiteAdmin))
+                        return true;
+                    else
+                        return false; // Only super admin can add Advisors through this API
+                case Resource.HOUSING_ADMIN:
+                    //only superadmins can add a HOUSING_ADMIN
+                    return false;
+                case Resource.HOUSING:
+                    {
+                        // The user must be a student and not a member of an existing application
+                        if (user_groups.Contains(AuthGroup.Student))
+                        {
+                            var sess_cde = Helpers.GetCurrentSession(_CCTContext);
+                            var housingService = new HousingService(_CCTContext);
+                            int? applicationID = housingService.GetApplicationID(user_name, sess_cde);
+                            if (!applicationID.HasValue)
+                            {
+                                return true;
+                            }
+                            return false;
+                        }
+                        return false;
+                    }
+                case Resource.ADMIN:
+                    return false;
+                case Resource.ERROR_LOG:
+                    return true;
+                case Resource.NEWS:
+                    return true;
+                default: return false;
+            }
+        }
+        private async Task<bool> CanUpdateAsync(string resource)
+        {
+            switch (resource)
+            {
+                case Resource.SHIFT:
+                    {
+                        if (user_groups.Contains(AuthGroup.Student))
+                            return true;
+                        return false;
+                    }
+                case Resource.MEMBERSHIP:
+                    {
+                        // User is admin
+                        if (user_groups.Contains(AuthGroup.SiteAdmin))
+                            return true;
+                        if (context.ActionArguments["membershipID"] is int membershipID)
+                        {
+                            var membershipToConsider = _membershipService.GetMembershipViewById(membershipID);
+                            var activityCode = membershipToConsider.ActivityCode;
+                            var sessionCode = membershipToConsider.SessionCode;
+
+
+                            var userMembership = _membershipService
+                                .GetMemberships(activityCode: activityCode, username: user_name, sessionCode: sessionCode)
+                                .FirstOrDefault();
+                            if (membershipToConsider.Participation == Participation.Advisor.GetDescription())
+                            {
+                                return userMembership?.Participation == Participation.Advisor.GetDescription();
+                            }
+                            else if (userMembership?.GroupAdmin == true && membershipToConsider.Participation != Participation.Advisor.GetDescription())
+                            {
+                                // Activity Advisors can update memberships of people in their activity.
+                                return true;
+                            }
+
+
+                            var is_membershipOwner = membershipToConsider.Username.EqualsIgnoreCase(user_name);
+                            if (is_membershipOwner)
+                            {
+                                // Restrict what a regular owner can edit.
+                                var originalMembership = _membershipService.GetSpecificMembership(membershipToConsider.MembershipID);
+                                // If they are not trying to change their participation level, then it is ok
+                                if (originalMembership.Participation == membershipToConsider.Participation)
+                                    return true;
+                            }
+                        }
+
+
+                        return false;
+                    }
+
+                case Resource.MEMBERSHIP_REQUEST:
+                    {
+                        // Once a request is sent, no one is able to edit its contents.
+                        // If a mistake is made in creating the original request, the user can delete it and make a new one.
+                        if (context.ActionArguments["membershipRequestID"] is int mrID)
+                        {
+                            // Get the view model from the repository
+                            var activityCode = _membershipRequestService.Get(mrID).ActivityCode;
+
+                            // If user is a leader or advisor of the activity the request is for
+                            return _membershipService
+                                    .GetMemberships(
+                                        activityCode: activityCode,
+                                        username: user_name,
+                                        participationTypes: new List<string>
+                                           {
                                            Participation.Leader.GetDescription(),
                                            Participation.Advisor.GetDescription()
-                                       })
+                                           })
+                                    .Any();
+                        }
+                        return false;
+                    }
+                case Resource.MEMBERSHIP_PRIVACY:
+                    {
+                        if (context.ActionArguments["membershipID"] is int membershipID)
+                        {
+                            var membershipToConsider = _membershipService.GetSpecificMembership(membershipID);
+                            var is_membershipOwner = membershipToConsider.Username.EqualsIgnoreCase(user_name);
+                            if (is_membershipOwner)
+                                return true;
+                        }
+
+                        return false;
+                    }
+                case Resource.STUDENT:
+                    return false; // No one should be able to update a student through this API
+                case Resource.HOUSING:
+                    {
+                        // The housing admins can update the application information (i.e. probation, offcampus program, etc.)
+                        // If the user is a student, then the user must be on an application and be an editor to update the application
+                        HousingService housingService = new HousingService(_CCTContext);
+                        if (user_groups.Contains(AuthGroup.HousingAdmin))
+                        {
+                            return true;
+                        }
+                        else if (user_groups.Contains(AuthGroup.Student))
+                        {
+                            var sess_cde = Helpers.GetCurrentSession(_CCTContext);
+                            int? applicationID = housingService.GetApplicationID(user_name, sess_cde);
+                            if (context.ActionArguments["applicationID"] is int requestedApplicationID
+                                && applicationID is not null
+                                && applicationID == requestedApplicationID)
+                            {
+                                string editorUsername = housingService.GetEditorUsername(applicationID.Value);
+                                return editorUsername.EqualsIgnoreCase(user_name);
+                            }
+                        }
+                        return false;
+                    }
+                case Resource.PROFILE:
+                    {
+                        // User is admin
+                        if (user_groups.Contains(AuthGroup.SiteAdmin))
+                            return true;
+
+                        if (context.ActionArguments["username"] is string username)
+                            return username.EqualsIgnoreCase(user_name);
+
+                        return false;
+                    }
+
+                case Resource.ACTIVITY_INFO:
+                    {
+                        // User is admin
+                        if (user_groups.Contains(AuthGroup.SiteAdmin))
+                            return true;
+
+                        if (context.ActionArguments["id"] is string activityCode)
+                        {
+                            var isGroupAdmin = _membershipService
+                                .GetMemberships(
+                                    activityCode: activityCode,
+                                    username: user_name,
+                                    participationTypes: new List<string> { Participation.GroupAdmin.GetDescription() })
                                 .Any();
+                            return isGroupAdmin;
+                        }
+                        return false;
+
                     }
-                    return false;
-                }
-            case Resource.MEMBERSHIP_PRIVACY:
-                {
-                    if (context.ActionArguments["membershipID"] is int membershipID)
+
+                case Resource.ACTIVITY_STATUS:
                     {
-                        var membershipToConsider = _membershipService.GetSpecificMembership(membershipID);
-                        var is_membershipOwner = membershipToConsider.Username.EqualsIgnoreCase(user_name);
-                        if (is_membershipOwner)
+                        // User is admin
+                        if (user_groups.Contains(AuthGroup.SiteAdmin))
                             return true;
-                    }
 
-                    return false;
-                }
-            case Resource.STUDENT:
-                return false; // No one should be able to update a student through this API
-            case Resource.HOUSING:
-                {
-                    // The housing admins can update the application information (i.e. probation, offcampus program, etc.)
-                    // If the user is a student, then the user must be on an application and be an editor to update the application
-                    HousingService housingService = new HousingService(_CCTContext);
-                    if (user_groups.Contains(AuthGroup.HousingAdmin))
-                    {
-                        return true;
-                    }
-                    else if (user_groups.Contains(AuthGroup.Student))
-                    {
-                        var sess_cde = Helpers.GetCurrentSession(_CCTContext);
-                        int? applicationID = housingService.GetApplicationID(user_name, sess_cde);
-                        if (context.ActionArguments["applicationID"] is int requestedApplicationID
-                            && applicationID is not null
-                            && applicationID == requestedApplicationID)
+                        if (context.ActionArguments["id"] is string activityCode)
                         {
-                            string editorUsername = housingService.GetEditorUsername(applicationID.Value);
-                            return editorUsername.EqualsIgnoreCase(user_name);
+                            var isGroupAdmin = _membershipService
+                                .GetMemberships(
+                                    activityCode: activityCode,
+                                    username: user_name,
+                                    participationTypes: new List<string> { Participation.GroupAdmin.GetDescription() })
+                                .Any();
+                            if (isGroupAdmin && context.ActionArguments["sess_cde"] is string sessionCode)
+                            {
+                                var activityService = context.HttpContext.RequestServices.GetRequiredService<IActivityService>();
+                                // If an activity is currently open, then a group admin has the ability to close it
+                                return activityService.IsOpen(activityCode, sessionCode);
+                            }
                         }
+
+                        // If an activity is currently closed, only super admin has permission to edit its closed/open status   
+                        return false;
                     }
-                    return false;
-                }
-            case Resource.PROFILE:
-                {
-                    // User is admin
-                    if (user_groups.Contains(AuthGroup.SiteAdmin))
-                        return true;
-
-                    if (context.ActionArguments["username"] is string username)
-                        return username.EqualsIgnoreCase(user_name);
-
-                    return false;
-                }
-
-            case Resource.ACTIVITY_INFO:
-                {
-                    // User is admin
-                    if (user_groups.Contains(AuthGroup.SiteAdmin))
-                        return true;
-
-                    if (context.ActionArguments["id"] is string activityCode)
+                case Resource.EMERGENCY_CONTACT:
                     {
-                        var isGroupAdmin = _membershipService
-                            .GetMemberships(
-                                activityCode: activityCode,
-                                username: user_name,
-                                participationTypes: new List<string> { Participation.GroupAdmin.GetDescription() })
-                            .Any();
-                        return isGroupAdmin;
+                        return context.ActionArguments["username"] is string username && username.EqualsIgnoreCase(user_name);
                     }
-                    return false;
 
-                }
-
-            case Resource.ACTIVITY_STATUS:
-                {
-                    // User is admin
-                    if (user_groups.Contains(AuthGroup.SiteAdmin))
-                        return true;
-
-                    if (context.ActionArguments["id"] is string activityCode)
+                case Resource.NEWS:
                     {
-                        var isGroupAdmin = _membershipService
-                            .GetMemberships(
-                                activityCode: activityCode,
-                                username: user_name,
-                                participationTypes: new List<string> { Participation.GroupAdmin.GetDescription() })
-                            .Any();
-                        if (isGroupAdmin && context.ActionArguments["sess_cde"] is string sessionCode)
+                        if (context.ActionArguments["newsID"] is int newsID)
                         {
-                            var activityService = context.HttpContext.RequestServices.GetRequiredService<IActivityService>();
-                            // If an activity is currently open, then a group admin has the ability to close it
-                            return activityService.IsOpen(activityCode, sessionCode);
+                            var newsItem = _newsService.Get(newsID);
+                            // only unapproved posts may be updated
+                            if (newsItem.Accepted != false)
+                                return false;
+
+                            // can update if user is a Student News Admin
+                            if (user_groups.Contains(AuthGroup.NewsAdmin))
+                                return true;
+
+                            // can update if user is news item author
+                            return newsItem.ADUN.EqualsIgnoreCase(user_name);
                         }
+
+                        return false;
                     }
 
-                    // If an activity is currently closed, only super admin has permission to edit its closed/open status   
-                    return false;
-                }
-            case Resource.EMERGENCY_CONTACT:
-                {
-                    return context.ActionArguments["username"] is string username && username.EqualsIgnoreCase(user_name);
-                }
-
-            case Resource.NEWS:
-                {
-                    if (context.ActionArguments["newsID"] is int newsID)
+                case Resource.NEWS_APPROVAL:
                     {
-                        var newsItem = _newsService.Get(newsID);
-                        // only unapproved posts may be updated
-                        if (newsItem.Accepted != false)
-                            return false;
-
-                        // can update if user is a Student News Admin
+                        // can approve or deny if user is a Student News Admin
                         if (user_groups.Contains(AuthGroup.NewsAdmin))
                             return true;
 
-                        // can update if user is news item author
-                        return newsItem.ADUN.EqualsIgnoreCase(user_name);
+                        return false;
                     }
 
-                    return false;
-                }
-
-            case Resource.NEWS_APPROVAL:
-                {
-                    // can approve or deny if user is a Student News Admin
-                    if (user_groups.Contains(AuthGroup.NewsAdmin))
-                        return true;
-
-                    return false;
-                }
-
-            default: return false;
+                default: return false;
+            }
         }
-    }
-    private async Task<bool> CanDeleteAsync(string resource)
-    {
-        switch (resource)
+        private async Task<bool> CanDeleteAsync(string resource)
         {
-            case Resource.SHIFT:
-                if (user_groups.Contains(AuthGroup.Student))
-                    return true;
-                return false;
-            case Resource.MEMBERSHIP:
-                {
-                    // User is admin
-                    if (user_groups.Contains(AuthGroup.SiteAdmin))
+            switch (resource)
+            {
+                case Resource.SHIFT:
+                    if (user_groups.Contains(AuthGroup.Student))
                         return true;
-                    if (context.ActionArguments["membershipID"] is int membershipID)
-                    {
-                        var membershipToConsider = _membershipService.GetSpecificMembership(membershipID);
-                        var is_membershipOwner = membershipToConsider.Username.EqualsIgnoreCase(user_name);
-                        if (is_membershipOwner)
-                            return true;
-
-                        var isGroupAdmin = _membershipService
-                            .GetMemberships(
-                                activityCode: membershipToConsider.ActivityCode,
-                                username: user_name,
-                                participationTypes: new List<string> { Participation.GroupAdmin.GetDescription() })
-                            .Any();
-                        return isGroupAdmin;
-                    }
-
                     return false;
-                }
-            case Resource.MEMBERSHIP_REQUEST:
-                {
-                    // User is admin
-                    if (user_groups.Contains(AuthGroup.SiteAdmin))
-                        return true;
-                    // membershipRequest = mr
-                    if (context.ActionArguments["membershipRequestID"] is int mrID)
+                case Resource.MEMBERSHIP:
                     {
-                        var mrToConsider = _membershipRequestService.Get(mrID);
-                        var is_mrOwner = mrToConsider.Username.EqualsIgnoreCase(user_name);
-                        if (is_mrOwner)
+                        // User is admin
+                        if (user_groups.Contains(AuthGroup.SiteAdmin))
                             return true;
-
-                        var activityCode = mrToConsider.ActivityCode;
-
-                        var isGroupAdmin = _membershipService
-                            .GetMemberships(
-                                activityCode: activityCode,
-                                username: user_name,
-                                participationTypes: new List<string> { Participation.GroupAdmin.GetDescription() })
-                            .Any();
-                        if (isGroupAdmin)
-                            return true;
-                    }
-
-                    return false;
-                }
-            case Resource.STUDENT:
-                return false; // No one should be able to delete a student through our API
-            case Resource.HOUSING:
-                {
-                    // The housing admins can update the application information (i.e. probation, offcampus program, etc.)
-                    // If the user is a student, then the user must be on an application and be an editor to update the application
-                    HousingService housingService = new HousingService(_CCTContext);
-                    if (user_groups.Contains(AuthGroup.HousingAdmin))
-                    {
-                        return true;
-                    }
-                    else if (user_groups.Contains(AuthGroup.Student))
-                    {
-                        var sess_cde = Helpers.GetCurrentSession(_CCTContext);
-                        int? applicationID = housingService.GetApplicationID(user_name, sess_cde);
-                        if (context.ActionArguments["applicationID"] is int requestedApplicationID && applicationID is not null && applicationID.Value == requestedApplicationID)
+                        if (context.ActionArguments["membershipID"] is int membershipID)
                         {
-                            var editorUsername = housingService.GetEditorUsername(applicationID.Value);
-                            return editorUsername.EqualsIgnoreCase(user_name);
-                        }
-                    }
-                    return false;
-                }
-            case Resource.ADMIN:
-                return false;
-            case Resource.HOUSING_ADMIN:
-                {
-                    // Only the superadmins can remove a housing admin from the whitelist
-                    // Super admins have unrestricted access by default: no need to check
-                    return false;
-                }
-            case Resource.NEWS:
-                {
-                    if (context.ActionArguments["newsID"] is int newsID)
-                    {
-                        var newsItem = _newsService.Get(newsID);
+                            var membershipToConsider = _membershipService.GetSpecificMembership(membershipID);
+                            var is_membershipOwner = membershipToConsider.Username.EqualsIgnoreCase(user_name);
+                            if (is_membershipOwner)
+                                return true;
 
-                        // only expired news items may be deleted
-                        var newsDate = newsItem.Entered;
-                        if (!newsDate.HasValue || DateTime.Now.Subtract(newsDate.Value).Days >= 14)
-                        {
-                            return false;
+                            var isGroupAdmin = _membershipService
+                                .GetMemberships(
+                                    activityCode: membershipToConsider.ActivityCode,
+                                    username: user_name,
+                                    participationTypes: new List<string> { Participation.GroupAdmin.GetDescription() })
+                                .Any();
+                            return isGroupAdmin;
                         }
 
-                        // can update if user is a Student News Admin
-                        if (user_groups.Contains(AuthGroup.NewsAdmin))
-                            return true;
-
-                        // can update if user is news item author
-                        return newsItem.ADUN.EqualsIgnoreCase(user_name);
+                        return false;
                     }
+                case Resource.MEMBERSHIP_REQUEST:
+                    {
+                        // User is admin
+                        if (user_groups.Contains(AuthGroup.SiteAdmin))
+                            return true;
+                        // membershipRequest = mr
+                        if (context.ActionArguments["membershipRequestID"] is int mrID)
+                        {
+                            var mrToConsider = _membershipRequestService.Get(mrID);
+                            var is_mrOwner = mrToConsider.Username.EqualsIgnoreCase(user_name);
+                            if (is_mrOwner)
+                                return true;
 
+                            var activityCode = mrToConsider.ActivityCode;
+
+                            var isGroupAdmin = _membershipService
+                                .GetMemberships(
+                                    activityCode: activityCode,
+                                    username: user_name,
+                                    participationTypes: new List<string> { Participation.GroupAdmin.GetDescription() })
+                                .Any();
+                            if (isGroupAdmin)
+                                return true;
+                        }
+
+                        return false;
+                    }
+                case Resource.STUDENT:
+                    return false; // No one should be able to delete a student through our API
+                case Resource.HOUSING:
+                    {
+                        // The housing admins can update the application information (i.e. probation, offcampus program, etc.)
+                        // If the user is a student, then the user must be on an application and be an editor to update the application
+                        HousingService housingService = new HousingService(_CCTContext);
+                        if (user_groups.Contains(AuthGroup.HousingAdmin))
+                        {
+                            return true;
+                        }
+                        else if (user_groups.Contains(AuthGroup.Student))
+                        {
+                            var sess_cde = Helpers.GetCurrentSession(_CCTContext);
+                            int? applicationID = housingService.GetApplicationID(user_name, sess_cde);
+                            if (context.ActionArguments["applicationID"] is int requestedApplicationID && applicationID is not null && applicationID.Value == requestedApplicationID)
+                            {
+                                var editorUsername = housingService.GetEditorUsername(applicationID.Value);
+                                return editorUsername.EqualsIgnoreCase(user_name);
+                            }
+                        }
+                        return false;
+                    }
+                case Resource.ADMIN:
                     return false;
-                }
-            case Resource.SLIDER:
-                {
-                    if (user_groups.Contains(AuthGroup.SiteAdmin))
-                        return true;
-                    return false;
-                }
-            default: return false;
+                case Resource.HOUSING_ADMIN:
+                    {
+                        // Only the superadmins can remove a housing admin from the whitelist
+                        // Super admins have unrestricted access by default: no need to check
+                        return false;
+                    }
+                case Resource.NEWS:
+                    {
+                        if (context.ActionArguments["newsID"] is int newsID)
+                        {
+                            var newsItem = _newsService.Get(newsID);
+
+                            // only expired news items may be deleted
+                            var newsDate = newsItem.Entered;
+                            if (!newsDate.HasValue || DateTime.Now.Subtract(newsDate.Value).Days >= 14)
+                            {
+                                return false;
+                            }
+
+                            // can update if user is a Student News Admin
+                            if (user_groups.Contains(AuthGroup.NewsAdmin))
+                                return true;
+
+                            // can update if user is news item author
+                            return newsItem.ADUN.EqualsIgnoreCase(user_name);
+                        }
+
+                        return false;
+                    }
+                case Resource.SLIDER:
+                    {
+                        if (user_groups.Contains(AuthGroup.SiteAdmin))
+                            return true;
+                        return false;
+                    }
+                default: return false;
+            }
         }
+
+
     }
-
-
 }

--- a/Gordon360/Authorization/StateYourBusiness.cs
+++ b/Gordon360/Authorization/StateYourBusiness.cs
@@ -134,7 +134,7 @@ namespace Gordon360.Authorization
                                     activityCode: mrToConsider.ActivityCode,
                                     username: user_name,
                                     sessionCode: mrToConsider.SessionCode,
-                                    participationTypes: new List<string> { Participation.GroupAdmin.GetDescription() })
+                                    participationTypes: new List<string> { Participation.GroupAdmin.GetCode() })
                                 .Any();
                             if (isGroupAdmin) // If user is a group admin of the activity that the request is sent to
                                 return true;
@@ -200,7 +200,7 @@ namespace Gordon360.Authorization
                         if (context.ActionArguments["activityCode"] is string activityCode)
                         {
                             var activityMembers = _membershipService.GetMemberships(activityCode: activityCode, username: user_name);
-                            var is_personAMember = activityMembers.Any(x => x.Participation != Participation.Guest.GetDescription());
+                            var is_personAMember = activityMembers.Any(x => x.Participation != Participation.Guest.GetCode());
                             return is_personAMember;
                         }
                         return false;
@@ -219,7 +219,7 @@ namespace Gordon360.Authorization
                         if (context.ActionArguments.TryGetValue("involvementCode", out object? involvementCode_object) && involvementCode_object is string involvementCode)
                         {
                             var activityMembers = _membershipService.GetMemberships(activityCode: involvementCode, username: user_name);
-                            var is_personAMember = activityMembers.Any(x => x.Participation != Participation.Guest.GetDescription());
+                            var is_personAMember = activityMembers.Any(x => x.Participation != Participation.Guest.GetCode());
                             return is_personAMember;
                         }
 
@@ -246,7 +246,7 @@ namespace Gordon360.Authorization
                                 .GetMemberships(
                                     activityCode: activityCode,
                                     username: user_name,
-                                    participationTypes: new List<string> { Participation.GroupAdmin.GetDescription() })
+                                    participationTypes: new List<string> { Participation.GroupAdmin.GetCode() })
                                 .Any();
                             return isGroupAdmin; // If user is a group admin of the activity that the request is sent to
                         }
@@ -256,8 +256,8 @@ namespace Gordon360.Authorization
                     {
                         var publicParticipantTypes = new List<string>
                                 {
-                                    Participation.GroupAdmin.GetDescription(),
-                                    Participation.Advisor.GetDescription()
+                                    Participation.GroupAdmin.GetCode(),
+                                    Participation.Advisor.GetCode()
                                 };
 
                         // Anyone can view group-admin and advisor emails
@@ -281,9 +281,9 @@ namespace Gordon360.Authorization
 
                         var leaderTypes = new List<string>
                                 {
-                                    Participation.GroupAdmin.GetDescription(),
-                                    Participation.Leader.GetDescription(),
-                                    Participation.Advisor.GetDescription()
+                                    Participation.GroupAdmin.GetCode(),
+                                    Participation.Leader.GetCode(),
+                                    Participation.Advisor.GetCode()
                                 };
 
                         // Only leaders, advisors, and group admins
@@ -425,7 +425,7 @@ namespace Gordon360.Authorization
                                     activityCode: activityCode,
                                     username: user_name,
                                     sessionCode: sessionCode,
-                                    participationTypes: new List<string> { Participation.GroupAdmin.GetDescription() })
+                                    participationTypes: new List<string> { Participation.GroupAdmin.GetCode() })
                                 .Any();
                             // If user is the advisor of the activity to which the request is sent.
                             if (isGroupAdmin)
@@ -510,11 +510,11 @@ namespace Gordon360.Authorization
                             var userMembership = _membershipService
                                 .GetMemberships(activityCode: activityCode, username: user_name, sessionCode: sessionCode)
                                 .FirstOrDefault();
-                            if (membershipToConsider.Participation == Participation.Advisor.GetDescription())
+                            if (membershipToConsider.Participation == Participation.Advisor.GetCode())
                             {
-                                return userMembership?.Participation == Participation.Advisor.GetDescription();
+                                return userMembership?.Participation == Participation.Advisor.GetCode();
                             }
-                            else if (userMembership?.GroupAdmin == true && membershipToConsider.Participation != Participation.Advisor.GetDescription())
+                            else if (userMembership?.GroupAdmin == true && membershipToConsider.Participation != Participation.Advisor.GetCode())
                             {
                                 // Activity Advisors can update memberships of people in their activity.
                                 return true;
@@ -552,8 +552,8 @@ namespace Gordon360.Authorization
                                         username: user_name,
                                         participationTypes: new List<string>
                                            {
-                                           Participation.Leader.GetDescription(),
-                                           Participation.Advisor.GetDescription()
+                                           Participation.Leader.GetCode(),
+                                           Participation.Advisor.GetCode()
                                            })
                                     .Any();
                         }
@@ -620,7 +620,7 @@ namespace Gordon360.Authorization
                                 .GetMemberships(
                                     activityCode: activityCode,
                                     username: user_name,
-                                    participationTypes: new List<string> { Participation.GroupAdmin.GetDescription() })
+                                    participationTypes: new List<string> { Participation.GroupAdmin.GetCode() })
                                 .Any();
                             return isGroupAdmin;
                         }
@@ -640,7 +640,7 @@ namespace Gordon360.Authorization
                                 .GetMemberships(
                                     activityCode: activityCode,
                                     username: user_name,
-                                    participationTypes: new List<string> { Participation.GroupAdmin.GetDescription() })
+                                    participationTypes: new List<string> { Participation.GroupAdmin.GetCode() })
                                 .Any();
                             if (isGroupAdmin && context.ActionArguments["sess_cde"] is string sessionCode)
                             {
@@ -714,7 +714,7 @@ namespace Gordon360.Authorization
                                 .GetMemberships(
                                     activityCode: membershipToConsider.ActivityCode,
                                     username: user_name,
-                                    participationTypes: new List<string> { Participation.GroupAdmin.GetDescription() })
+                                    participationTypes: new List<string> { Participation.GroupAdmin.GetCode() })
                                 .Any();
                             return isGroupAdmin;
                         }
@@ -740,7 +740,7 @@ namespace Gordon360.Authorization
                                 .GetMemberships(
                                     activityCode: activityCode,
                                     username: user_name,
-                                    participationTypes: new List<string> { Participation.GroupAdmin.GetDescription() })
+                                    participationTypes: new List<string> { Participation.GroupAdmin.GetCode() })
                                 .Any();
                             if (isGroupAdmin)
                                 return true;

--- a/Gordon360/Controllers/AccountsController.cs
+++ b/Gordon360/Controllers/AccountsController.cs
@@ -1,4 +1,5 @@
 using Gordon360.Authorization;
+using Gordon360.Enums;
 using Gordon360.Models.ViewModels;
 using Gordon360.Services;
 using Gordon360.Static.Names;

--- a/Gordon360/Controllers/EmailsController.cs
+++ b/Gordon360/Controllers/EmailsController.cs
@@ -5,7 +5,6 @@ using Gordon360.Static.Names;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace Gordon360.Controllers
 {
@@ -22,9 +21,9 @@ namespace Gordon360.Controllers
         [HttpGet]
         [Route("involvement/{activityCode}")]
         [StateYourBusiness(operation = Operation.READ_PARTIAL, resource = Resource.EMAILS_BY_ACTIVITY)]
-        public async Task<ActionResult<IEnumerable<EmailViewModel>>> GetEmailsForActivityAsync(string activityCode, string? sessionCode = null, [FromQuery] List<string>? participationTypes = null)
+        public ActionResult<IEnumerable<EmailViewModel>> GetEmailsForActivity(string activityCode, string? sessionCode = null, [FromQuery] List<string>? participationTypes = null)
         {
-            var result = await _emailService.GetEmailsForActivityAsync(activityCode, sessionCode, participationTypes);
+            var result = _emailService.GetEmailsForActivity(activityCode, sessionCode, participationTypes);
 
             return Ok(result);
         }
@@ -33,9 +32,9 @@ namespace Gordon360.Controllers
         [Route("activity/{activityCode}")]
         [StateYourBusiness(operation = Operation.READ_PARTIAL, resource = Resource.EMAILS_BY_ACTIVITY)]
         [Obsolete("Use the new route that accepts a list of participation types instead")]
-        public async Task<ActionResult<IEnumerable<EmailViewModel>>> DEPRECATED_GetEmailsForActivityAsync(string activityCode, string? sessionCode, string? participationType)
+        public ActionResult<IEnumerable<EmailViewModel>> DEPRECATED_GetEmailsForActivity(string activityCode, string? sessionCode, string? participationType)
         {
-            var result = await _emailService.GetEmailsForActivityAsync(activityCode, sessionCode, new List<string> { participationType ?? "" });
+            var result = _emailService.GetEmailsForActivity(activityCode, sessionCode, new List<string> { participationType ?? "" });
 
             return Ok(result);
         }
@@ -52,12 +51,11 @@ namespace Gordon360.Controllers
         [HttpPut]
         [Route("activity/{id}/session/{session}")]
         [StateYourBusiness(operation = Operation.READ_PARTIAL, resource = Resource.EMAILS_BY_ACTIVITY)]
-        public async Task<ActionResult> SendEmailToActivityAsync(string id, string session, [FromBody] EmailContentViewModel email)
+        public ActionResult SendEmailToActivity(string id, string session, [FromBody] EmailContentViewModel email)
         {
-            await _emailService.SendEmailToActivityAsync(id, session, email.FromAddress, email.Subject, email.Content, email.Password);
+            _emailService.SendEmailToActivity(id, session, email.FromAddress, email.Subject, email.Content, email.Password);
 
             return Ok();
-
         }
     }
 }

--- a/Gordon360/Controllers/EmailsController.cs
+++ b/Gordon360/Controllers/EmailsController.cs
@@ -1,4 +1,5 @@
 ﻿using Gordon360.Authorization;
+using Gordon360.Enums;
 using Gordon360.Models.CCT.Context;
 using Gordon360.Models.ViewModels;
 using Gordon360.Services;
@@ -25,16 +26,7 @@ namespace Gordon360.Controllers
         [StateYourBusiness(operation = Operation.READ_PARTIAL, resource = Resource.EMAILS_BY_ACTIVITY)]
         public async Task<ActionResult<IEnumerable<EmailViewModel>>> GetEmailsForActivityAsync(string activityCode, string? sessionCode, string? participationType)
         {
-            var participation = participationType switch
-            {
-                "advisor" => ParticipationType.Advisor,
-                "leader" => ParticipationType.Leader,
-                "group-admin" => ParticipationType.GroupAdmin,
-                "member" => ParticipationType.Member,
-                "guest" => ParticipationType.Guest,
-                _ => null
-            };
-
+            var participation = participationType.Parse(); 
             var result = await _emailService.GetEmailsForActivityAsync(activityCode, sessionCode, participation);
 
             if (result == null)

--- a/Gordon360/Controllers/EmailsController.cs
+++ b/Gordon360/Controllers/EmailsController.cs
@@ -1,13 +1,11 @@
 ﻿using Gordon360.Authorization;
-using Gordon360.Enums;
-using Gordon360.Models.CCT.Context;
 using Gordon360.Models.ViewModels;
 using Gordon360.Services;
 using Gordon360.Static.Names;
 using Microsoft.AspNetCore.Mvc;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using static Gordon360.Services.MembershipService;
 
 namespace Gordon360.Controllers
 {
@@ -16,25 +14,30 @@ namespace Gordon360.Controllers
     {
         private readonly IEmailService _emailService;
 
-        public EmailsController(CCTContext context, IEmailService emailService)
+        public EmailsController(IEmailService emailService)
         {
             _emailService = emailService;
         }
 
         [HttpGet]
+        [Route("involvement/{activityCode}")]
+        [StateYourBusiness(operation = Operation.READ_PARTIAL, resource = Resource.EMAILS_BY_ACTIVITY)]
+        public async Task<ActionResult<IEnumerable<EmailViewModel>>> GetEmailsForActivityAsync(string activityCode, string? sessionCode = null, [FromQuery] List<string>? participationTypes = null)
+        {
+            var result = await _emailService.GetEmailsForActivityAsync(activityCode, sessionCode, participationTypes);
+
+            return Ok(result);
+        }
+
+        [HttpGet]
         [Route("activity/{activityCode}")]
         [StateYourBusiness(operation = Operation.READ_PARTIAL, resource = Resource.EMAILS_BY_ACTIVITY)]
-        public async Task<ActionResult<IEnumerable<EmailViewModel>>> GetEmailsForActivityAsync(string activityCode, string? sessionCode, string? participationType)
+        [Obsolete("Use the new route that accepts a list of participation types instead")]
+        public async Task<ActionResult<IEnumerable<EmailViewModel>>> DEPRECATED_GetEmailsForActivityAsync(string activityCode, string? sessionCode, string? participationType)
         {
-            var participation = participationType.Parse(); 
-            var result = await _emailService.GetEmailsForActivityAsync(activityCode, sessionCode, participation);
+            var result = await _emailService.GetEmailsForActivityAsync(activityCode, sessionCode, new List<string> { participationType ?? "" });
 
-            if (result == null)
-            {
-                NotFound();
-            }
             return Ok(result);
-
         }
 
         [HttpPut]

--- a/Gordon360/Controllers/MembershipsController.cs
+++ b/Gordon360/Controllers/MembershipsController.cs
@@ -116,7 +116,7 @@ namespace Gordon360.Controllers
             var result = _membershipService.GetMemberships(
                 activityCode: activityCode,
                 sessionCode: sessionCode,
-                participationTypes: new List<string> { Participation.GroupAdmin.GetDescription() });
+                participationTypes: new List<string> { Participation.GroupAdmin.GetCode() });
 
             return Ok(result);
         }
@@ -137,7 +137,7 @@ namespace Gordon360.Controllers
                 .GetMemberships(
                     activityCode: activityCode,
                     sessionCode: sessionCode,
-                    participationTypes: new List<string> { Participation.Guest.GetDescription() })
+                    participationTypes: new List<string> { Participation.Guest.GetCode() })
                 .Count();
 
 
@@ -160,7 +160,7 @@ namespace Gordon360.Controllers
                 .GetMemberships(
                     activityCode: activityCode,
                     sessionCode: sessionCode)
-                .Count(m => m.Participation != Participation.Guest.GetDescription());
+                .Count(m => m.Participation != Participation.Guest.GetCode());
 
             return Ok(result);
         }
@@ -260,7 +260,7 @@ namespace Gordon360.Controllers
                             activityCode: m.ActivityCode,
                             username: viewerUsername,
                             sessionCode: m.SessionCode)
-                        .Any(m => m.Participation != Participation.Guest.GetDescription());
+                        .Any(m => m.Participation != Participation.Guest.GetCode());
                     }
                 });
 

--- a/Gordon360/Controllers/MembershipsController.cs
+++ b/Gordon360/Controllers/MembershipsController.cs
@@ -53,24 +53,7 @@ namespace Gordon360.Controllers
                     || viewerGroups.Contains(AuthGroup.Police)
                     ))
                 {
-                    memberships = memberships.Where(m =>
-                    {
-                        var act = _activityService.Get(m.ActivityCode);
-                        var isPublic = !(act.Privacy == true || m.Privacy == true);
-                        if (isPublic)
-                        {
-                            return true;
-                        }
-                        else
-                        {
-                            // If the current authenticated user is an admin of this group, then include the membership
-                            return _membershipService.GetMemberships(
-                                activityCode: m.ActivityCode,
-                                username: authenticatedUserUsername,
-                                sessionCode: m.SessionCode)
-                            .Any(m => m.Participation != Participation.Guest.GetDescription());
-                        }
-                    });
+                    memberships = WithoutPrivateMemberships(memberships, authenticatedUserUsername);
                 }
             }
 
@@ -260,5 +243,26 @@ namespace Gordon360.Controllers
 
             return Ok(result);
         }
+
+        private IEnumerable<MembershipView> WithoutPrivateMemberships(IEnumerable<MembershipView> memberships, string viewerUsername)
+            => memberships.Where(m =>
+                {
+                    var act = _activityService.Get(m.ActivityCode);
+                    var isPublic = !(act.Privacy == true || m.Privacy == true);
+                    if (isPublic)
+                    {
+                        return true;
+                    }
+                    else
+                    {
+                        // If the current authenticated user is an admin of this group, then include the membership
+                        return _membershipService.GetMemberships(
+                            activityCode: m.ActivityCode,
+                            username: viewerUsername,
+                            sessionCode: m.SessionCode)
+                        .Any(m => m.Participation != Participation.Guest.GetDescription());
+                    }
+                });
+
     }
 }

--- a/Gordon360/Controllers/MembershipsController.cs
+++ b/Gordon360/Controllers/MembershipsController.cs
@@ -80,7 +80,7 @@ namespace Gordon360.Controllers
         /// <summary>
         /// Gets the number of memberships matching the specified filters
         /// </summary>
-        /// <param name="activityCode">Optional involvementCode filter</param>
+        /// <param name="activityCode">Optional activityCode filter</param>
         /// <param name="username">Optional username filter</param>
         /// <param name="sessionCode">Optional session code for which session memberships should be retrieved. Defaults to current session. Use "*" for all sessions.</param>
         /// <param name="participationTypes">Optional list of participation types that should be retrieved. Defaults to all participation types.</param>
@@ -109,7 +109,7 @@ namespace Gordon360.Controllers
         /// <param name="sessionCode">Optional code of session to get for</param>
         /// <returns>An IEnumerable of the matching MembershipViews</returns>
         [HttpGet]
-        [Route("activities/{involvementCode}/sessions/{sessionCode}")]
+        [Route("activities/{activityCode}/sessions/{sessionCode}")]
         [StateYourBusiness(operation = Operation.READ_PARTIAL, resource = Resource.MEMBERSHIP_BY_ACTIVITY)]
         [Obsolete("Use the new route at /api/memberships instead")]
         public ActionResult<IEnumerable<MembershipView>> GetMembershipsForActivityAndSession(string activityCode, string sessionCode)
@@ -126,7 +126,7 @@ namespace Gordon360.Controllers
         /// <param name="sessionCode">The session code of the activity.</param>
         /// <returns>An IEnumerable of all leader-type memberships for the specified activity.</returns>
         [HttpGet]
-        [Route("activities/{involvementCode}/sessions/{sessionCode}/admins")]
+        [Route("activities/{activityCode}/sessions/{sessionCode}/admins")]
         [Obsolete("Use the new route at /api/memberships instead")]
         public ActionResult<IEnumerable<MembershipView>> GetGroupAdminsForActivity(string activityCode, string sessionCode)
         {
@@ -145,7 +145,7 @@ namespace Gordon360.Controllers
         /// <param name="sessionCode">The session code</param>
         /// <returns>The number of followers of the activity</returns>
         [HttpGet]
-        [Route("activities/{involvementCode}/sessions/{sessionCode}/subscriber-count")]
+        [Route("activities/{activityCode}/sessions/{sessionCode}/subscriber-count")]
         [StateYourBusiness(operation = Operation.READ_ONE, resource = Resource.MEMBERSHIP)]
         [Obsolete("Use the new route at /api/memberships/count instead")]
         public ActionResult<int> GetActivitySubscribersCountForSession(string activityCode, string sessionCode)
@@ -168,7 +168,7 @@ namespace Gordon360.Controllers
         /// <param name="sessionCode">The session code</param>
         /// <returns>The number of members of the activity</returns>
         [HttpGet]
-        [Route("activities/{involvementCode}/sessions/{sessionCode}/member-count")]
+        [Route("activities/{activityCode}/sessions/{sessionCode}/member-count")]
         [StateYourBusiness(operation = Operation.READ_ONE, resource = Resource.MEMBERSHIP)]
         [Obsolete("Use the new route at /api/memberships/count instead")]
         public ActionResult<int> GetActivityMembersCountForSession(string activityCode, string sessionCode)

--- a/Gordon360/Controllers/ProfilesController.cs
+++ b/Gordon360/Controllers/ProfilesController.cs
@@ -1,6 +1,6 @@
 ﻿using Gordon360.Authorization;
+using Gordon360.Enums;
 using Gordon360.Models.CCT;
-using Gordon360.Models.CCT.Context;
 using Gordon360.Models.ViewModels;
 using Gordon360.Services;
 using Gordon360.Static.Names;
@@ -452,6 +452,7 @@ namespace Gordon360.Controllers
 
             return Ok();
         }
+
         /// <summary>
         /// Posts fields into CCT.dbo.Information_Change_Request 
         /// Sends Alumni Profile Update Email to "devrequest@gordon.edu"
@@ -466,8 +467,6 @@ namespace Gordon360.Controllers
             await _profileService.InformationChangeRequest(authenticatedUserUsername, updatedFields);
             return Ok();
         }
-
-
 
         /// <summary>
         /// Gets the profile image at the given path or, if that file does not exist, the 360 default profile image
@@ -501,40 +500,53 @@ namespace Gordon360.Controllers
         /// @TODO: Move security checks to state your business? Or consider changing implementation here
         /// </summary>
         /// <param name="username">The Student Username</param>
+        /// <param name="sessionCode">Optional session code or "current". If passed, only memberships from that session will be included. </param>
+        /// <param name="participationTypes">Optional participation type. If passed, only memberships of those participation types will be inlcuded</param>
         /// <returns>The membership information that the student is a part of</returns>
         [Route("{username}/memberships")]
         [HttpGet]
-        public ActionResult<List<MembershipView>> GetMembershipsByUser(string username)
+        [Obsolete("Use /api/memberships with username query param instead")]
+        public ActionResult<List<MembershipView>> GetMembershipsByUser(string username, string? sessionCode = null, [FromQuery] List<string>? participationTypes = null)
         {
-            var result = _membershipService.GetMembershipsByUser(username);
+            var memberships = _membershipService.GetMemberships(
+                username: username,
+                sessionCode: sessionCode,
+                participationTypes: participationTypes);
 
-            if (result == null)
-            {
-                return NotFound();
-            }
-            // privacy control of membership view model
             var authenticatedUserUsername = AuthUtils.GetUsername(User);
             var viewerGroups = AuthUtils.GetGroups(User);
 
-            if (username == authenticatedUserUsername || viewerGroups.Contains(AuthGroup.SiteAdmin) || viewerGroups.Contains(AuthGroup.Police))              //super admin and gordon police reads all
-                return Ok(result);
-            else
+            // User can see all their own memberships. SiteAdmin and Police can see all of anyone's memberships
+            if (username == authenticatedUserUsername
+                || viewerGroups.Contains(AuthGroup.SiteAdmin)
+                || viewerGroups.Contains(AuthGroup.Police)
+                )
             {
-                var visibleMemberships = result.Where(m => {
-                    var act = _activityService.Get(m.ActivityCode);
-                    var isPublic = !(act.Privacy == true || m.Privacy == true);
-                    if (isPublic)
-                    {
-                        return true;
-                    } else {
-                        // If the current authenticated user is an admin of this group, then include the membership
-                        var admins = _membershipService.GetMembershipsForActivity(m.ActivityCode, m.SessionCode, new List<string> { Participation.GroupAdmin.GetDescription() });
-
-                        return admins.Any(a => a.Username == authenticatedUserUsername);
-                    }
-                });
-                return Ok(visibleMemberships);
+                return Ok(memberships);
             }
+
+            var visibleMemberships = memberships.Where(m =>
+            {
+                var act = _activityService.Get(m.ActivityCode);
+                var isPublic = !(act.Privacy == true || m.Privacy == true);
+                if (isPublic)
+                {
+                    return true;
+                }
+                else
+                {
+                    // If the current authenticated user is an admin of this group, then include the membership
+                    return _membershipService.GetMemberships(
+                        activityCode: m.ActivityCode,
+                        username: authenticatedUserUsername,
+                        sessionCode: m.SessionCode,
+                        participationTypes: new List<string> { Participation.GroupAdmin.GetDescription() })
+                    .Any();
+
+                }
+            });
+
+            return Ok(visibleMemberships);
         }
     }
 }

--- a/Gordon360/Controllers/ProfilesController.cs
+++ b/Gordon360/Controllers/ProfilesController.cs
@@ -540,7 +540,7 @@ namespace Gordon360.Controllers
                         activityCode: m.ActivityCode,
                         username: authenticatedUserUsername,
                         sessionCode: m.SessionCode,
-                        participationTypes: new List<string> { Participation.GroupAdmin.GetDescription() })
+                        participationTypes: new List<string> { Participation.GroupAdmin.GetCode() })
                     .Any();
 
                 }

--- a/Gordon360/Controllers/ProfilesController.cs
+++ b/Gordon360/Controllers/ProfilesController.cs
@@ -528,7 +528,7 @@ namespace Gordon360.Controllers
                         return true;
                     } else {
                         // If the current authenticated user is an admin of this group, then include the membership
-                        var admins = _membershipService.GetGroupAdminMembershipsForActivity(m.ActivityCode, m.SessionCode);
+                        var admins = _membershipService.GetMembershipsForActivity(m.ActivityCode, m.SessionCode, new List<string> { Participation.GroupAdmin.GetDescription() });
 
                         return admins.Any(a => a.Username == authenticatedUserUsername);
                     }

--- a/Gordon360/Controllers/ScheduleController.cs
+++ b/Gordon360/Controllers/ScheduleController.cs
@@ -1,4 +1,5 @@
 ﻿using Gordon360.Authorization;
+using Gordon360.Enums;
 using Gordon360.Models.CCT.Context;
 using Gordon360.Models.ViewModels;
 using Gordon360.Services;

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -390,14 +390,25 @@
             <returns></returns>
             <remarks>Posts a new error_log to the server to be added into the database. Useful if you want to input the datetime in the front end for greater accuracy</remarks>
         </member>
-        <member name="M:Gordon360.Controllers.MembershipsController.GetMembershipsForActivity(System.String,System.String,System.Collections.Generic.List{System.String})">
+        <member name="M:Gordon360.Controllers.MembershipsController.GetMemberships(System.String,System.String,System.String,System.Collections.Generic.List{System.String})">
             <summary>
             Get all the memberships associated with a given activity
             </summary>
-            <param name="activityCode">The activity ID</param>
-            <param name="sessionCode">Optional session code for which session memberships should be retrieved. Defaults to all sessions.</param>
+            <param name="involvementCode">Optional involvementCode filter</param>
+            <param name="username">Optional username filter</param>
+            <param name="sessionCode">Optional session code for which session memberships should be retrieved. Defaults to current session. Use "*" for all sessions.</param>
             <param name="participationTypes">Optional list of participation types that should be retrieved. Defaults to all participation types.</param>
             <returns>An IEnumerable of the matching MembershipViews</returns>
+        </member>
+        <member name="M:Gordon360.Controllers.MembershipsController.GetMembershipCount(System.String,System.String,System.String,System.Collections.Generic.List{System.String})">
+            <summary>
+            Gets the number of memberships matching the specified filters
+            </summary>
+            <param name="activityCode">Optional involvementCode filter</param>
+            <param name="username">Optional username filter</param>
+            <param name="sessionCode">Optional session code for which session memberships should be retrieved. Defaults to current session. Use "*" for all sessions.</param>
+            <param name="participationTypes">Optional list of participation types that should be retrieved. Defaults to all participation types.</param>
+            <returns>The number of followers of the activity</returns>
         </member>
         <member name="M:Gordon360.Controllers.MembershipsController.GetMembershipsForActivityAndSession(System.String,System.String)">
             <summary>
@@ -677,14 +688,14 @@
             <param name="imagePath">Path to the profile image to load</param>
             <returns></returns>
         </member>
-        <member name="M:Gordon360.Controllers.ProfilesController.GetMembershipsByUser(System.String,System.String,System.String)">
+        <member name="M:Gordon360.Controllers.ProfilesController.GetMembershipsByUser(System.String,System.String,System.Collections.Generic.List{System.String})">
             <summary>
             Fetch memberships that a specific student has been a part of
             @TODO: Move security checks to state your business? Or consider changing implementation here
             </summary>
             <param name="username">The Student Username</param>
             <param name="sessionCode">Optional session code or "current". If passed, only memberships from that session will be included. </param>
-            <param name="participation">Optional participation type. If passed, only memberships of that participation type will be inlcuded</param>
+            <param name="participationTypes">Optional participation type. If passed, only memberships of those participation types will be inlcuded</param>
             <returns>The membership information that the student is a part of</returns>
         </member>
         <member name="M:Gordon360.Controllers.RequestsController.Get">
@@ -1325,7 +1336,7 @@
             Service class to facilitate getting emails for members of an activity.
             </summary>
         </member>
-        <member name="M:Gordon360.Services.EmailService.GetEmailsForActivityAsync(System.String,System.String,System.Collections.Generic.List{System.String})">
+        <member name="M:Gordon360.Services.EmailService.GetEmailsForActivity(System.String,System.String,System.Collections.Generic.List{System.String})">
             <summary>
             Get a list of the emails for all members in the activity during the current session.
             </summary>
@@ -1345,7 +1356,7 @@
             <param name="password">Password of the email sender</param>
             <returns></returns>
         </member>
-        <member name="M:Gordon360.Services.EmailService.SendEmailToActivityAsync(System.String,System.String,System.String,System.String,System.String,System.String)">
+        <member name="M:Gordon360.Services.EmailService.SendEmailToActivity(System.String,System.String,System.String,System.String,System.String,System.String)">
             <summary>
             Send a email to members of an activity
             </summary>
@@ -1607,6 +1618,23 @@
             Service Class that facilitates data transactions between the MembershipsController and the Membership database model.
             </summary>
         </member>
+        <member name="M:Gordon360.Services.MembershipService.GetMemberships(System.String,System.String,System.String,System.Collections.Generic.List{System.String})">
+            <summary>
+            Fetches the memberships associated with the activity whose code is specified by the parameter.
+            </summary>
+            <param name="activityCode">Optional activity code filter</param>
+            <param name="username">Optional username filter</param>
+            <param name="sessionCode">Optional session code, defaults to current session. Use "*" for all sessions</param>
+            <param name="participationTypes">Optional filter for involvement participation types (MEMBR, ADV, LEAD, GUEST, GRP_ADMIN)</param>
+            <returns>An IEnumerable of the matching MembershipView objects</returns>
+        </member>
+        <member name="M:Gordon360.Services.MembershipService.GetSpecificMembership(System.Int32)">
+            <summary>	
+            Fetch the membership whose id is specified by the parameter	
+            </summary>	
+            <param name="membershipID">The membership id</param>	
+            <returns>The found membership as a MembershipView</returns>	
+        </member>
         <member name="M:Gordon360.Services.MembershipService.AddAsync(Gordon360.Models.ViewModels.MembershipUploadViewModel)">
             <summary>
             Adds a new Membership record to storage. Since we can't establish foreign key constraints and relationships on the database side,
@@ -1621,45 +1649,6 @@
             </summary>
             <param name="membershipID">The membership id</param>
             <returns>The membership that was just deleted as a MembershipView</returns>
-        </member>
-        <member name="M:Gordon360.Services.MembershipService.GetSpecificMembership(System.Int32)">
-            <summary>	
-            Fetch the membership whose id is specified by the parameter	
-            </summary>	
-            <param name="membershipID">The membership id</param>	
-            <returns>The found membership as a MembershipView</returns>	
-        </member>
-        <member name="M:Gordon360.Services.MembershipService.GetMembershipsForActivity(System.String,System.String,System.Collections.Generic.List{System.String})">
-            <summary>
-            Fetches the memberships associated with the activity whose code is specified by the parameter.
-            </summary>
-            <param name="activityCode">The activity code</param>
-            <param name="sessionCode">Optional code of session to get memberships for</param>
-            <param name="participationTypes">Optional filter for involvement participation type (MEMBR, ADV, LEAD, GUEST)</param>
-            <returns>An IEnumerable of the matching MembershipView objects</returns>
-        </member>
-        <member name="M:Gordon360.Services.MembershipService.GetMembershipsByUser(System.String)">
-            <summary>
-            Fetches all the membership information linked to the student whose id appears as a parameter.
-            </summary>
-            <param name="username">The student's AD Username</param>
-            <returns>An IEnumerable of the matching MembershipView objects</returns>
-        </member>
-        <member name="M:Gordon360.Services.MembershipService.GetActivitySubscribersCountForSession(System.String,System.String)">
-            <summary>
-            Fetches the number of followers associated with the activity and session whose codes are specified by the parameter.
-            </summary>
-            <param name="activityCode">The activity code</param>
-            <param name="sessionCode">The session code</param>
-            <returns>The count of current guests (aka subscribers) for the activity</returns>
-        </member>
-        <member name="M:Gordon360.Services.MembershipService.GetActivityMembersCountForSession(System.String,System.String)">
-            <summary>
-            Fetches the number of memberships associated with the activity and session whose codes are specified by the parameter.
-            </summary>
-            <param name="activityCode">The activity code.</param>
-            <param name="sessionCode">The session code</param>
-            <returns>The count of current members for the activity</returns>
         </member>
         <member name="M:Gordon360.Services.MembershipService.UpdateAsync(System.Int32,Gordon360.Models.ViewModels.MembershipUploadViewModel)">
             <summary>

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -404,7 +404,7 @@
             <summary>
             Gets the number of memberships matching the specified filters
             </summary>
-            <param name="activityCode">Optional involvementCode filter</param>
+            <param name="activityCode">Optional activityCode filter</param>
             <param name="username">Optional username filter</param>
             <param name="sessionCode">Optional session code for which session memberships should be retrieved. Defaults to current session. Use "*" for all sessions.</param>
             <param name="participationTypes">Optional list of participation types that should be retrieved. Defaults to all participation types.</param>

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -534,7 +534,7 @@
             @TODO: Remove redundant username/id from this and service
             @TODO: fix documentation comments
         </member>
-        <member name="M:Gordon360.Controllers.NewsController.Post(System.String,System.Int32,System.String,System.String)">
+        <member name="M:Gordon360.Controllers.NewsController.Post(Gordon360.Models.ViewModels.StudentNewsUploadViewModel)">
             Create a new news item to be added to the database
             @TODO: Remove redundant username/id from this and service
             @TODO: fix documentation comments
@@ -545,14 +545,23 @@
             <returns>The deleted news item</returns>
             <remarks>The news item must be authored by the user and must not be expired</remarks>
         </member>
-        <member name="M:Gordon360.Controllers.NewsController.EditPosting(System.Int32,Gordon360.Models.MyGordon.StudentNews)">
+        <member name="M:Gordon360.Controllers.NewsController.EditPosting(System.Int32,Gordon360.Models.ViewModels.StudentNewsUploadViewModel)">
             <summary>
             (Controller) Edits a news item in the database
             </summary>
             <param name="newsID">The id of the news item to edit</param>
-            <param name="newData">The news object that contains updated values</param>
+            <param name="studentNewsEdit">The news object that contains updated values</param>
             <returns>The updated news item</returns>
             <remarks>The news item must be authored by the user and must not be expired and must be unapproved</remarks>
+        </member>
+        <member name="M:Gordon360.Controllers.NewsController.UpdateAcceptedStatus(System.Int32,System.Boolean)">
+            <summary>
+             Approve or deny a news posting in the database
+            </summary>
+            <param name="newsID">The id of the news item to approve</param>
+            <param name="newsStatusAccepted">The accept status that will apply to the news item</param>
+            <returns>The approved or denied news item</returns>
+            <remarks>The news item must not be expired</remarks>
         </member>
         <member name="M:Gordon360.Controllers.ProfilesController.Get">
             <summary>Get profile info of currently logged in user</summary>
@@ -673,12 +682,14 @@
             <param name="imagePath">Path to the profile image to load</param>
             <returns></returns>
         </member>
-        <member name="M:Gordon360.Controllers.ProfilesController.GetMembershipsByUser(System.String)">
+        <member name="M:Gordon360.Controllers.ProfilesController.GetMembershipsByUser(System.String,System.String,System.String)">
             <summary>
             Fetch memberships that a specific student has been a part of
             @TODO: Move security checks to state your business? Or consider changing implementation here
             </summary>
             <param name="username">The Student Username</param>
+            <param name="sessionCode">Optional session code or "current". If passed, only memberships from that session will be included. </param>
+            <param name="participation">Optional participation type. If passed, only memberships of that participation type will be inlcuded</param>
             <returns>The membership information that the student is a part of</returns>
         </member>
         <member name="M:Gordon360.Controllers.RequestsController.Get">
@@ -896,6 +907,13 @@
             <param name="status">The current status of the user to post, of type WellnessStatusColor</param>
             <returns>The status that was stored in the database</returns>
         </member>
+        <member name="F:Gordon360.Enums.Participation.GroupAdmin">
+            <summary>
+            NOTE: Group admin is not strictly a participation type. 
+            It's a separate role that Advisors and Leaders can have, with a separate flag in the database 
+            BUT, it's convenient to treat it as a participation type in several places throughout the API
+            </summary>
+        </member>
         <member name="P:Gordon360.Models.CCT.Clifton_Strengths.Private">
             <summary>
             Whether the user wants their strengths to be private (not shown to other users)
@@ -1079,7 +1097,7 @@
             <param name="building">The building search param</param>
             <returns>The accounts from the provided list that match the given search params</returns>
         </member>
-        <member name="M:Gordon360.Services.AccountService.GetAccountsToSearch(System.Collections.Generic.List{System.String},System.Collections.Generic.IEnumerable{Gordon360.Authorization.AuthGroup},System.String)">
+        <member name="M:Gordon360.Services.AccountService.GetAccountsToSearch(System.Collections.Generic.List{System.String},System.Collections.Generic.IEnumerable{Gordon360.Enums.AuthGroup},System.String)">
             <summary>
             Get the list of accounts a user can search, based on the types of accounts they want to search, their authorization, and whether they're searching sensitive info.
             </summary>
@@ -1312,7 +1330,7 @@
             Service class to facilitate getting emails for members of an activity.
             </summary>
         </member>
-        <member name="M:Gordon360.Services.EmailService.GetEmailsForActivityAsync(System.String,System.String,Gordon360.Services.MembershipService.ParticipationType)">
+        <member name="M:Gordon360.Services.EmailService.GetEmailsForActivityAsync(System.String,System.String,System.Nullable{Gordon360.Enums.Participation})">
             <summary>
             Get a list of the emails for all members in the activity during the current session.
             </summary>
@@ -1791,7 +1809,7 @@
             <returns>The deleted news item</returns>
             <remarks>The news item must be authored by the user and must not be expired</remarks>
         </member>
-        <member name="M:Gordon360.Services.NewsService.EditPosting(System.Int32,Gordon360.Models.MyGordon.StudentNews)">
+        <member name="M:Gordon360.Services.NewsService.EditPosting(System.Int32,Gordon360.Models.ViewModels.StudentNewsUploadViewModel)">
             <summary>
             (Service) Edits a news item in the database
             </summary>
@@ -1806,6 +1824,13 @@
             </summary>
             <param name="newsItem">The news item to verify</param>
             <returns>true if unapproved, otherwise throws some kind of meaningful exception</returns>
+        </member>
+        <member name="M:Gordon360.Services.NewsService.VerfiyApproved(Gordon360.Models.MyGordon.StudentNews)">
+            <summary>
+            Helper method to verify that a given news item has already been approved
+            </summary>
+            <param name="newsItem">The news item to verify</param>
+            <returns>true if approved, otherwise throws some kind of meaningful exception</returns>
         </member>
         <member name="M:Gordon360.Services.NewsService.VerifyUnexpired(Gordon360.Models.MyGordon.StudentNews)">
             <summary>

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -390,7 +390,16 @@
             <returns></returns>
             <remarks>Posts a new error_log to the server to be added into the database. Useful if you want to input the datetime in the front end for greater accuracy</remarks>
         </member>
-        <member name="M:Gordon360.Controllers.MembershipsController.GetMembershipsForActivity(System.String,System.String)">
+        <member name="M:Gordon360.Controllers.MembershipsController.GetMembershipsForActivity(System.String,System.String,System.Collections.Generic.List{System.String})">
+            <summary>
+            Get all the memberships associated with a given activity
+            </summary>
+            <param name="activityCode">The activity ID</param>
+            <param name="sessionCode">Optional session code for which session memberships should be retrieved. Defaults to all sessions.</param>
+            <param name="participationTypes">Optional list of participation types that should be retrieved. Defaults to all participation types.</param>
+            <returns>An IEnumerable of the matching MembershipViews</returns>
+        </member>
+        <member name="M:Gordon360.Controllers.MembershipsController.GetMembershipsForActivityAndSession(System.String,System.String)">
             <summary>
             Get all the memberships associated with a given activity
             </summary>
@@ -405,20 +414,6 @@
             <param name="activityCode">The activity ID.</param>
             <param name="sessionCode">The session code of the activity.</param>
             <returns>An IEnumerable of all leader-type memberships for the specified activity.</returns>
-        </member>
-        <member name="M:Gordon360.Controllers.MembershipsController.GetLeadersForActivity(System.String)">
-            <summary>
-            Gets the leader-type memberships associated with a given activity.
-            </summary>
-            <param name="activityCode">The activity ID.</param>
-            <returns>An IEnumerable of all leader-type memberships for the specified activity.</returns>
-        </member>
-        <member name="M:Gordon360.Controllers.MembershipsController.GetAdvisorsForActivityAsync(System.String)">
-            <summary>
-            Gets the advisor-type memberships associated with a given activity.
-            </summary>
-            <param name="activityCode">The activity ID.</param>
-            <returns>An IEnumerable of all advisor-type memberships for the specified activity.</returns>
         </member>
         <member name="M:Gordon360.Controllers.MembershipsController.GetActivitySubscribersCountForSession(System.String,System.String)">
             <summary>
@@ -1330,13 +1325,13 @@
             Service class to facilitate getting emails for members of an activity.
             </summary>
         </member>
-        <member name="M:Gordon360.Services.EmailService.GetEmailsForActivityAsync(System.String,System.String,System.Nullable{Gordon360.Enums.Participation})">
+        <member name="M:Gordon360.Services.EmailService.GetEmailsForActivityAsync(System.String,System.String,System.Collections.Generic.List{System.String})">
             <summary>
             Get a list of the emails for all members in the activity during the current session.
             </summary>
             <param name="activityCode">The code of the activity to get emails for.</param>
             <param name="sessionCode">Optionally, the session to get emails for. Defaults to the current session</param>
-            <param name="participationType">The participation type to get emails of. If unspecified, gets emails of all participation types.</param>
+            <param name="participationTypes">The participation types to get emails of. If unspecified, gets emails of all participation types.</param>
             <returns>A list of emails (along with first and last name) associated with that activity</returns>
         </member>
         <member name="M:Gordon360.Services.EmailService.SendEmails(System.String[],System.String,System.String,System.String,System.String)">

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -1634,36 +1634,13 @@
             <param name="membershipID">The membership id</param>	
             <returns>The found membership as a MembershipView</returns>	
         </member>
-        <member name="M:Gordon360.Services.MembershipService.GetMembershipsForActivity(System.String,System.String,System.Nullable{System.Boolean},System.String[])">
+        <member name="M:Gordon360.Services.MembershipService.GetMembershipsForActivity(System.String,System.String,System.Collections.Generic.List{System.String})">
             <summary>
             Fetches the memberships associated with the activity whose code is specified by the parameter.
             </summary>
             <param name="activityCode">The activity code</param>
             <param name="sessionCode">Optional code of session to get memberships for</param>
-            <param name="groupAdmin">Optional filter for group admins</param>
             <param name="participationTypes">Optional filter for involvement participation type (MEMBR, ADV, LEAD, GUEST)</param>
-            <returns>An IEnumerable of the matching MembershipView objects</returns>
-        </member>
-        <member name="M:Gordon360.Services.MembershipService.GetGroupAdminMembershipsForActivity(System.String,System.String)">
-            <summary>
-            Fetches the group admin (who have edit privileges of the page) of the activity whose activity code is specified by the parameter.
-            </summary>
-            <param name="activityCode">The activity code</param>
-            <param name="sessionCode">The session code</param>
-            <returns>An IEnumerable of the matching MembershipView objects</returns>
-        </member>
-        <member name="M:Gordon360.Services.MembershipService.GetLeaderMembershipsForActivity(System.String)">
-            <summary>
-            Fetches the leaders of the activity whose activity code is specified by the parameter.
-            </summary>
-            <param name="activityCode">The activity code</param>
-            <returns>An IEnumerable of the matching MembershipView objects</returns>
-        </member>
-        <member name="M:Gordon360.Services.MembershipService.GetAdvisorMembershipsForActivity(System.String)">
-            <summary>
-            Fetches the advisors of the activity whose activity code is specified by the parameter.
-            </summary>
-            <param name="activityCode">The activity code</param>
             <returns>An IEnumerable of the matching MembershipView objects</returns>
         </member>
         <member name="M:Gordon360.Services.MembershipService.GetMembershipsByUser(System.String)">

--- a/Gordon360/Enums/AuthGroup.cs
+++ b/Gordon360/Enums/AuthGroup.cs
@@ -1,4 +1,4 @@
-﻿namespace Gordon360.Authorization
+﻿namespace Gordon360.Enums
 {
     public enum AuthGroup
     {
@@ -14,7 +14,7 @@
         Student
     }
 
-    public static class AuthGroupEnum
+    public static class AuthGroupExtensions
     {
         public static AuthGroup? FromString(string groupName) => groupName switch
         {

--- a/Gordon360/Enums/AuthGroup.cs
+++ b/Gordon360/Enums/AuthGroup.cs
@@ -14,7 +14,7 @@
         Student
     }
 
-    public static class AuthGroupExtensions
+    public static class AuthGroupEnum
     {
         public static AuthGroup? FromString(string groupName) => groupName switch
         {

--- a/Gordon360/Enums/Participation.cs
+++ b/Gordon360/Enums/Participation.cs
@@ -1,0 +1,39 @@
+﻿namespace Gordon360.Enums
+{
+    public enum Participation
+    {
+            Leader,
+            Guest,
+            Member,
+            Advisor,
+            /// <summary>
+            /// NOTE: Group admin is not strictly a participation type. 
+            /// It's a separate role that Advisors and Leaders can have, with a separate flag in the database 
+            /// BUT, it's convenient to treat it as a participation type in several places throughout the API
+            /// </summary>
+            GroupAdmin
+    }
+
+    public static class ParticipationExtensions
+    {
+        public static Participation? Parse(this string? participationType) => participationType switch
+        {
+            "LEAD" => Participation.Leader,
+            "GUEST" => Participation.Guest,
+            "MEMBR" => Participation.Member,
+            "ADV" => Participation.Advisor,
+            "GRP_ADMIN" => Participation.GroupAdmin,
+            _ => null
+        };
+
+        public static string GetDescription(this Participation participation) => participation switch
+        {
+            Participation.Leader => "LEAD",
+            Participation.Guest => "GUEST",
+            Participation.Member => "MEMBR",
+            Participation.Advisor => "ADV",
+            Participation.GroupAdmin => "GRP_ADMIN",
+            _ => throw new System.NotImplementedException(),
+        };
+    }
+}

--- a/Gordon360/Enums/Participation.cs
+++ b/Gordon360/Enums/Participation.cs
@@ -16,7 +16,7 @@
 
     public static class ParticipationExtensions
     {
-        public static string GetDescription(this Participation participation) => participation switch
+        public static string GetCode(this Participation participation) => participation switch
         {
             Participation.Leader => "LEAD",
             Participation.Guest => "GUEST",

--- a/Gordon360/Enums/Participation.cs
+++ b/Gordon360/Enums/Participation.cs
@@ -16,16 +16,6 @@
 
     public static class ParticipationExtensions
     {
-        public static Participation? Parse(this string? participationType) => participationType switch
-        {
-            "LEAD" => Participation.Leader,
-            "GUEST" => Participation.Guest,
-            "MEMBR" => Participation.Member,
-            "ADV" => Participation.Advisor,
-            "GRP_ADMIN" => Participation.GroupAdmin,
-            _ => null
-        };
-
         public static string GetDescription(this Participation participation) => participation switch
         {
             Participation.Leader => "LEAD",

--- a/Gordon360/Gordon360.csproj
+++ b/Gordon360/Gordon360.csproj
@@ -36,9 +36,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.DirectoryServices.AccountManagement" Version="6.0.0" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Static Classes\Enums\" />
-  </ItemGroup>
   <PropertyGroup>
     <StartupObject></StartupObject>
   </PropertyGroup>

--- a/Gordon360/Program.cs
+++ b/Gordon360/Program.cs
@@ -51,6 +51,7 @@ builder.Services.AddScoped<IMembershipRequestService, MembershipRequestService>(
 builder.Services.AddScoped<IAdministratorService, AdministratorService>();
 builder.Services.AddScoped<IEmailService, EmailService>();
 builder.Services.AddScoped<INewsService, NewsService>();
+builder.Services.AddScoped<ISessionService, SessionService>();
 builder.Services.AddScoped<ServerUtils, ServerUtils>();
 builder.Services.AddHostedService<EventCacheRefreshService>();
 

--- a/Gordon360/Properties/launchSettings.json
+++ b/Gordon360/Properties/launchSettings.json
@@ -8,7 +8,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "sqlDebugging": true,
-      "applicationUrl": "https://localhost:51627;http://172.28.208.1:51626"
+      "applicationUrl": "https://localhost:51627;http://localhost:51626"
     },
     "Train": {
       "commandName": "Project",

--- a/Gordon360/Properties/launchSettings.json
+++ b/Gordon360/Properties/launchSettings.json
@@ -8,7 +8,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "sqlDebugging": true,
-      "applicationUrl": "https://localhost:51627;http://localhost:51626"
+      "applicationUrl": "https://localhost:51627;http://172.28.208.1:51626"
     },
     "Train": {
       "commandName": "Project",

--- a/Gordon360/Services/AccountService.cs
+++ b/Gordon360/Services/AccountService.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Gordon360.Extensions.System;
+using Gordon360.Enums;
 
 namespace Gordon360.Services
 {

--- a/Gordon360/Services/EmailService.cs
+++ b/Gordon360/Services/EmailService.cs
@@ -33,11 +33,14 @@ namespace Gordon360.Services
         /// <param name="sessionCode">Optionally, the session to get emails for. Defaults to the current session</param>
         /// <param name="participationTypes">The participation types to get emails of. If unspecified, gets emails of all participation types.</param>
         /// <returns>A list of emails (along with first and last name) associated with that activity</returns>
-        public async Task<IEnumerable<EmailViewModel>> GetEmailsForActivityAsync(string activityCode, string? sessionCode = null, List<string>? participationTypes = null)
+        public IEnumerable<EmailViewModel> GetEmailsForActivity(string activityCode, string? sessionCode = null, List<string>? participationTypes = null)
         {
             sessionCode ??= Helpers.GetCurrentSession(_context);
 
-            var memberships = _membershipService.GetMembershipsForActivity(activityCode, sessionCode, participationTypes);
+            var memberships = _membershipService.GetMemberships(
+                activityCode: activityCode,
+                sessionCode: sessionCode,
+                participationTypes: participationTypes);
 
             return memberships.Join(_context.ACCOUNT, m => m.Username, a => a.AD_Username, (m, a) => new EmailViewModel
             {
@@ -59,30 +62,31 @@ namespace Gordon360.Services
         /// <returns></returns>
         public void SendEmails(string[] to_emails, string from_email, string subject, string email_content, string password)
         {
-            using (var smtp = new SmtpClient())
+            using var smtp = new SmtpClient();
+            var credential = new NetworkCredential
             {
-                var credential = new NetworkCredential
-                {
-                    UserName = from_email,
-                    Password = password
-                };
-                smtp.Credentials = credential;
-                smtp.Host = "smtp.office365.com";
-                smtp.Port = 587;
-                smtp.EnableSsl = true;
-                var message = new MailMessage();
-                message.From = new MailAddress(from_email);
-                message.Bcc.Add(new MailAddress(from_email));
-                foreach (string to_email in to_emails)
-                {
-                    message.To.Add(new MailAddress(to_email));
-                }
-                message.Subject = subject;
-                message.Body = email_content;
-                message.IsBodyHtml = true;
+                UserName = from_email,
+                Password = password
+            };
+            smtp.Credentials = credential;
+            smtp.Host = "smtp.office365.com";
+            smtp.Port = 587;
+            smtp.EnableSsl = true;
 
-                smtp.Send(message);
+            var message = new MailMessage
+            {
+                From = new MailAddress(from_email),
+                Subject = subject,
+                Body = email_content,
+                IsBodyHtml = true
+            };
+            message.Bcc.Add(new MailAddress(from_email));
+            foreach (string to_email in to_emails)
+            {
+                message.To.Add(new MailAddress(to_email));
             }
+
+            smtp.Send(message);
         }
 
         /// <summary>
@@ -95,7 +99,7 @@ namespace Gordon360.Services
         /// <param name="email_content">The content of the email to be sent</param>
         /// <param name="password">Password of the email sender</param>
         /// <returns></returns>
-        public async Task SendEmailToActivityAsync(string activityCode, string sessionCode, string from_email, string subject, string email_content, string password)
+        public void SendEmailToActivity(string activityCode, string sessionCode, string from_email, string subject, string email_content, string password)
         {
             var credential = new NetworkCredential
             {
@@ -120,7 +124,7 @@ namespace Gordon360.Services
             };
             message.To.Add(new MailAddress(from_email));
 
-            var to_emails = (await GetEmailsForActivityAsync(activityCode, sessionCode)).Select(x => x.Email);
+            var to_emails = GetEmailsForActivity(activityCode, sessionCode).Select(x => x.Email);
             foreach (string to_email in to_emails)
             {
                 message.Bcc.Add(new MailAddress(to_email));

--- a/Gordon360/Services/EmailService.cs
+++ b/Gordon360/Services/EmailService.cs
@@ -1,4 +1,5 @@
-﻿using Gordon360.Exceptions;
+﻿using Gordon360.Enums;
+using Gordon360.Exceptions;
 using Gordon360.Models.CCT.Context;
 using Gordon360.Models.ViewModels;
 using Gordon360.Static.Methods;
@@ -32,7 +33,7 @@ namespace Gordon360.Services
         /// <param name="sessionCode">Optionally, the session to get emails for. Defaults to the current session</param>
         /// <param name="participationType">The participation type to get emails of. If unspecified, gets emails of all participation types.</param>
         /// <returns>A list of emails (along with first and last name) associated with that activity</returns>
-        public async Task<IEnumerable<EmailViewModel>> GetEmailsForActivityAsync(string activityCode, string? sessionCode = null, ParticipationType? participationType = null)
+        public async Task<IEnumerable<EmailViewModel>> GetEmailsForActivityAsync(string activityCode, string? sessionCode = null, Participation? participationType = null)
         {
             sessionCode ??= Helpers.GetCurrentSession(_context);
 

--- a/Gordon360/Services/EmailService.cs
+++ b/Gordon360/Services/EmailService.cs
@@ -31,20 +31,21 @@ namespace Gordon360.Services
         /// </summary>
         /// <param name="activityCode">The code of the activity to get emails for.</param>
         /// <param name="sessionCode">Optionally, the session to get emails for. Defaults to the current session</param>
-        /// <param name="participationType">The participation type to get emails of. If unspecified, gets emails of all participation types.</param>
+        /// <param name="participationTypes">The participation types to get emails of. If unspecified, gets emails of all participation types.</param>
         /// <returns>A list of emails (along with first and last name) associated with that activity</returns>
-        public async Task<IEnumerable<EmailViewModel>> GetEmailsForActivityAsync(string activityCode, string? sessionCode = null, Participation? participationType = null)
+        public async Task<IEnumerable<EmailViewModel>> GetEmailsForActivityAsync(string activityCode, string? sessionCode = null, List<string>? participationTypes = null)
         {
             sessionCode ??= Helpers.GetCurrentSession(_context);
 
-            var result = _membershipService.MembershipEmails(activityCode, sessionCode, participationType);
+            var memberships = _membershipService.GetMembershipsForActivity(activityCode, sessionCode, participationTypes);
 
-            if (result == null)
+            return memberships.Join(_context.ACCOUNT, m => m.Username, a => a.AD_Username, (m, a) => new EmailViewModel
             {
-                throw new ResourceNotFoundException() { ExceptionMessage = "The Activity was not found." };
-            }
-
-            return result;
+                Email = a.email,
+                FirstName = a.firstname,
+                LastName = a.lastname,
+                Description = m.Description
+            });
         }
 
         /// <summary>

--- a/Gordon360/Services/MembershipService.cs
+++ b/Gordon360/Services/MembershipService.cs
@@ -58,7 +58,7 @@ namespace Gordon360.Services
 
             if (participationTypes?.Count > 0)
             {
-                var groupAdmin = Participation.GroupAdmin.GetDescription();
+                var groupAdmin = Participation.GroupAdmin.GetCode();
                 var includesGroupAdmin = participationTypes.Contains(groupAdmin) == true;
                 if (includesGroupAdmin) participationTypes.Remove(groupAdmin);
 
@@ -156,7 +156,7 @@ namespace Gordon360.Services
             original.COMMENT_TXT = membership.CommentText;
             original.PART_CDE = membership.Participation;
 
-            if (membership.Participation == Participation.Guest.GetDescription())
+            if (membership.Participation == Participation.Guest.GetCode())
             {
                 await SetGroupAdminAsync(membershipID, false);
             }

--- a/Gordon360/Services/MembershipService.cs
+++ b/Gordon360/Services/MembershipService.cs
@@ -297,31 +297,6 @@ namespace Gordon360.Services
             return _context.MembershipView.Any(membership => membership.Username == username && membership.GroupAdmin == true);
         }
 
-        public IEnumerable<EmailViewModel> MembershipEmails(string activityCode, string sessionCode, Participation? participationCode = null)
-        {
-            var memberships = _context.MembershipView.Where(m => m.ActivityCode == activityCode && m.SessionCode == sessionCode);
-
-            if (participationCode is Participation participation)
-            {
-                if (participationCode == Participation.GroupAdmin)
-                {
-                    memberships = memberships.Where(m => m.GroupAdmin == true);
-                }
-                else
-                {
-                    memberships = memberships.Where(m => m.Participation == participation.GetDescription());
-                }
-            }
-
-            return memberships.Join(_context.ACCOUNT, m => m.Username, a => a.AD_Username, (m, a) => new EmailViewModel
-            {
-                Email = a.email,
-                FirstName = a.firstname,
-                LastName = a.lastname,
-                Description = m.Description
-            });
-        }
-
         /// <summary>	
         /// Finds the matching MembershipView object from an existing MEMBERSHIP object
         /// </summary>

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -166,14 +166,10 @@ namespace Gordon360.Services
 
     public interface IMembershipService
     {
-        IEnumerable<MembershipView> GetLeaderMembershipsForActivity(string activityCode);
-        IEnumerable<MembershipView> GetAdvisorMembershipsForActivity(string activityCode);
-        IEnumerable<MembershipView> GetGroupAdminMembershipsForActivity(string activityCode, string? sessionCode = null);
         IEnumerable<MembershipView> GetMembershipsForActivity(
             string activityCode,
             string? sessionCode = null,
-            bool? groupAdmin = null,
-            string[]? participationTypes = null
+            List<string>? participationTypes = null
         );
         IEnumerable<MembershipView> GetMembershipsByUser(string username);
         int GetActivitySubscribersCountForSession(string activityCode, string? sessionCode);

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -145,7 +145,7 @@ namespace Gordon360.Services
 
     public interface IEmailService
     {
-        Task<IEnumerable<EmailViewModel>> GetEmailsForActivityAsync(string activityCode, string? sessionCode, Participation? participationType);
+        Task<IEnumerable<EmailViewModel>> GetEmailsForActivityAsync(string activityCode, string? sessionCode = null, List<string>? participationTypes = null);
         void SendEmails(string[] to_emails, string to_email, string subject, string email_content, string password);
         Task SendEmailToActivityAsync(string activityCode, string sessionCode, string from_email, string subject, string email_content, string password);
     }
@@ -181,7 +181,6 @@ namespace Gordon360.Services
         Task<MembershipView> SetPrivacyAsync(int membershipID, bool isPrivate);
         MembershipView Delete(int membershipID);
         bool IsGroupAdmin(string username);
-        IEnumerable<EmailViewModel> MembershipEmails(string activityCode, string sessionCode, Participation? participationCode = null);
         MembershipView GetMembershipViewById(int membershipId);
         bool ValidateMembership(MembershipUploadViewModel membership);
         bool IsPersonAlreadyInActivity(MembershipUploadViewModel membershipRequest);

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -145,9 +145,9 @@ namespace Gordon360.Services
 
     public interface IEmailService
     {
-        Task<IEnumerable<EmailViewModel>> GetEmailsForActivityAsync(string activityCode, string? sessionCode = null, List<string>? participationTypes = null);
+        IEnumerable<EmailViewModel> GetEmailsForActivity(string activityCode, string? sessionCode = null, List<string>? participationTypes = null);
         void SendEmails(string[] to_emails, string to_email, string subject, string email_content, string password);
-        Task SendEmailToActivityAsync(string activityCode, string sessionCode, string from_email, string subject, string email_content, string password);
+        void SendEmailToActivity(string activityCode, string sessionCode, string from_email, string subject, string email_content, string password);
     }
 
     public interface IErrorLogService
@@ -166,14 +166,12 @@ namespace Gordon360.Services
 
     public interface IMembershipService
     {
-        IEnumerable<MembershipView> GetMembershipsForActivity(
-            string activityCode,
+        IEnumerable<MembershipView> GetMemberships(
+            string? activityCode = null,
+            string? username = null,
             string? sessionCode = null,
             List<string>? participationTypes = null
         );
-        IEnumerable<MembershipView> GetMembershipsByUser(string username);
-        int GetActivitySubscribersCountForSession(string activityCode, string? sessionCode);
-        int GetActivityMembersCountForSession(string activityCode, string? sessionCode);
         MembershipView GetSpecificMembership(int membershipID);
         Task<MembershipView> AddAsync(MembershipUploadViewModel membership);
         Task<MembershipView> UpdateAsync(int membershipID, MembershipUploadViewModel membership);

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -1,4 +1,4 @@
-﻿using Gordon360.Authorization;
+﻿using Gordon360.Enums;
 using Gordon360.Models.CCT;
 using Gordon360.Models.MyGordon;
 using Gordon360.Models.ViewModels;
@@ -145,7 +145,7 @@ namespace Gordon360.Services
 
     public interface IEmailService
     {
-        Task<IEnumerable<EmailViewModel>> GetEmailsForActivityAsync(string activityCode, string? sessionCode, ParticipationType? participationType);
+        Task<IEnumerable<EmailViewModel>> GetEmailsForActivityAsync(string activityCode, string? sessionCode, Participation? participationType);
         void SendEmails(string[] to_emails, string to_email, string subject, string email_content, string password);
         Task SendEmailToActivityAsync(string activityCode, string sessionCode, string from_email, string subject, string email_content, string password);
     }
@@ -185,7 +185,7 @@ namespace Gordon360.Services
         Task<MembershipView> SetPrivacyAsync(int membershipID, bool isPrivate);
         MembershipView Delete(int membershipID);
         bool IsGroupAdmin(string username);
-        IEnumerable<EmailViewModel> MembershipEmails(string activityCode, string sessionCode, ParticipationType? participationCode = null);
+        IEnumerable<EmailViewModel> MembershipEmails(string activityCode, string sessionCode, Participation? participationCode = null);
         MembershipView GetMembershipViewById(int membershipId);
         bool ValidateMembership(MembershipUploadViewModel membership);
         bool IsPersonAlreadyInActivity(MembershipUploadViewModel membershipRequest);

--- a/Gordon360/Static Classes/Helpers.cs
+++ b/Gordon360/Static Classes/Helpers.cs
@@ -17,21 +17,5 @@ namespace Gordon360.Static.Methods
         {
             return context.CM_SESSION_MSTR.Where(s => DateTime.Now > s.SESS_BEGN_DTE).OrderByDescending(s => s.SESS_BEGN_DTE).Select(s => s.SESS_CDE).First();
         }
-
-        public static string GetLeaderRoleCodes()
-        {
-            return "LEAD";
-        }
-
-        public static string GetAdvisorRoleCodes()
-        {
-            return "ADV";
-        }
-
-        public static string GetTranscriptWorthyRoles()
-        {
-            //string[] transcriptWorthyRoles = { "CAPT", "CODIR", "CORD", "DIREC", "PRES", "VICEC", "VICEP", "AC", "RA1", "RA2","RA3", "SEC" };
-            return "LEAD";
-        }
     }
 }

--- a/Gordon360/Static Classes/Names.cs
+++ b/Gordon360/Static Classes/Names.cs
@@ -1,4 +1,6 @@
-﻿namespace Gordon360.Static.Names
+﻿using System;
+
+namespace Gordon360.Static.Names
 {
     public static class Resource
     {
@@ -31,6 +33,7 @@
         // Partial resources, to be targetted by Operation.READ_PARTIAL
         public const string MEMBERSHIP_REQUEST_BY_ACTIVITY = "Membership Request Resources associated with an activity";
         public const string MEMBERSHIP_REQUEST_BY_STUDENT = "Membership Request Resources associated with a student";
+        [Obsolete("Unused once obsolete routes are removed")]
         public const string MEMBERSHIP_BY_ACTIVITY = "Membership Resources associated with an activity";
         public const string MEMBERSHIP_BY_ACCOUNT = "Membership Resources associated with a student";
         public const string EMAILS_BY_ACTIVITY = "Emails for activity members";


### PR DESCRIPTION
This PR is a significant refactor of the `Memberships` resource in the API, building off of @bennettforkner's great work in #720.

The main change is combining `MembershipsService.GetMembershipsByActivity` and `MembershipsService.GetMembershipsByUser` into a single unified `MembershipsService.GetMemberships`.

I was motivated to do this because, while working on a separate feature for the frontend, I noticed that the API exposed very little flexibility when fetching a user's memberships. You pass in the username and get back that user's full list of memberships. This resulted in the frontend doing lots of filtering to accommodate different subsets of the data that different components needed. Meanwhile, the API exposed a relatively flexible endpoint for getting memberships by activity code, allowing the client to filter using optional sessionCode and participationType parameters.

When trying to clean up the frontend logic, I realized that the frontend processing could be made completely obsolete if the API exposed the same set of filters for memberships whether you fetched them by activityCode or by username.

To accomplish that, I made both `username` and `activityCode` optional filter parameters, and added a StateYourBusiness check to ensure that client's can't access more memberships than they could before (e.g. by passing null for both username and activityCode). I also had to add a special case where `sessionCode` of `"*"` is treated as filtering for all sessions (i.e. not filtering on session at all), because the MembershipsByActivity treated null sessionCode as meaning the current session, but the one case where MembershipsByUser sent a null sessionCode, it expected all sessions.

The end result is one `GetMemberships` method that is not significantly longer than either of the two methods it was intended to replace. In addition to the aforementioned, `GetMemberships` also subsumes the following methods in `MembershipService`:
- `GetGroupAdminMembershipsForActivity`
- `GetLeaderMembershipsForActivity`
- `GetAdvisorMembershipsForActivity`
- `GetActivitySubscribersCountForSession`
- `GetActivityMembersCountForSession`

This streamlining simplified a lot of API internals that referenced Memberships, and resulted in a simple API surface. The new functionality is exposed by the endpoint `/api/memberships` and makes obsolete the following endpoints:
- `/api/profiles/{username}/memberships`
- `/api/memberships/activities/{activityCode}/sessions/{sessionCode}`
- `/api/memberships/activities/{activityCode}/sessions/{sessionCode}/admins`
- `/api/memberships/activity/{activityCode}/leaders`
- `/api/memberships/activity/{activityCode}/advisors`
- `/api/memberships/activities/{activityCode}/sessions/{sessionCode}/subscriber-count`
- `/api/memberships/activities/{activityCode}/sessions/{sessionCode}/member-count`

These obsolete endpoints are still fully functional. They have been marked with the `Obsolete` attribute so that we can cleanup them up in the future once the client is updated to use the new endpoints exclusively.

The matching frontend PR, gordon-cs/gordon-360-ui#1666, demonstrates how this streamlined logic greatly simplifies the frontend membership logic as well. Overall, the handling of memberships across the system is - in my opinion - significantly simpler and more consistent. The reduced repetition of logic also reduces the room for bugs.