### PR TITLE
[Rec-IM] Series/Match Delete Routes, Fix Match Edit

### DIFF
--- a/Gordon360/Controllers/RecIM/MatchesController.cs
+++ b/Gordon360/Controllers/RecIM/MatchesController.cs
@@ -123,5 +123,18 @@ namespace Gordon360.Controllers.RecIM
             return CreatedAtAction("AddAttendance", attendance);
         }
 
+        /// <summary>
+        /// Cascade deletes all DBobjects related to given Match ID
+        /// </summary>
+        /// <param name="matchID"></param>
+        /// <returns></returns>
+        [HttpDelete]
+        [Route("{matchID}")]
+        public async Task<ActionResult> DeleteMatchCascade(int matchID)
+        {
+            await _matchService.DeleteMatchCascadeAsync(matchID);
+            return Ok();
+        }
+
     }
 }

--- a/Gordon360/Controllers/RecIM/SeriesController.cs
+++ b/Gordon360/Controllers/RecIM/SeriesController.cs
@@ -110,6 +110,20 @@ namespace Gordon360.Controllers.RecIM
         }
 
         /// <summary>
+        /// Cascade deletes all DBobjects related to given Series ID
+        /// </summary>
+        /// <param name="seriesID"></param>
+        /// <returns></returns>
+        [HttpDelete]
+        [Route("{seriesID}")]
+        public async Task<ActionResult> DeleteSeriesCascade(int seriesID)
+        {
+            await _seriesService.DeleteSeriesCascadeAsync(seriesID);
+            return Ok();
+        }
+
+
+        /// <summary>
         /// Automatically creates Matches based on given Series
         /// </summary>
         /// <param name="seriesID"></param>

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -795,6 +795,13 @@
             <param name="matchID"></param>
             <returns></returns>
         </member>
+        <member name="M:Gordon360.Controllers.RecIM.MatchesController.DeleteMatchCascade(System.Int32)">
+            <summary>
+            Cascade deletes all DBobjects related to given Match ID
+            </summary>
+            <param name="matchID"></param>
+            <returns></returns>
+        </member>
         <member name="M:Gordon360.Controllers.RecIM.SeriesController.GetSeries(System.Boolean)">
             <summary>
             Queries all Series with an optional active tag
@@ -831,6 +838,13 @@
             </summary>
             <param name="seriesSchedule">created schedule for series</param>
             <returns>created series schedule</returns>
+        </member>
+        <member name="M:Gordon360.Controllers.RecIM.SeriesController.DeleteSeriesCascade(System.Int32)">
+            <summary>
+            Cascade deletes all DBobjects related to given Series ID
+            </summary>
+            <param name="seriesID"></param>
+            <returns></returns>
         </member>
         <member name="M:Gordon360.Controllers.RecIM.SeriesController.ScheduleMatches(System.Int32)">
             <summary>

--- a/Gordon360/Models/ViewModels/RecIM/MatchPatchViewModel.cs
+++ b/Gordon360/Models/ViewModels/RecIM/MatchPatchViewModel.cs
@@ -9,5 +9,6 @@ namespace Gordon360.Models.ViewModels.RecIM
         public DateTime? Time { get; set; }
         public int? SurfaceID { get; set; }
         public int? StatusID { get; set; }
+        public IEnumerable<int>? TeamIDs { get; set; }
     }
 }

--- a/Gordon360/Services/RecIM/MatchService.cs
+++ b/Gordon360/Services/RecIM/MatchService.cs
@@ -393,6 +393,21 @@ namespace Gordon360.Services.RecIM
             await _context.SaveChangesAsync();
             return match;
         }
+
+        public async Task DeleteMatchCascadeAsync(int matchID)
+        {
+            //delete matchteam
+            var matchteam = _context.MatchTeam.Where(mt => mt.MatchID == matchID);
+            _context.MatchTeam.RemoveRange(matchteam);
+            //delete matchparticipant
+            var matchparticipant = _context.MatchParticipant.Where(mp => mp.MatchID == matchID);
+            _context.MatchParticipant.RemoveRange(matchparticipant);
+            //deletematch
+            var match = _context.Match.FirstOrDefault(m => m.ID == matchID);
+            _context.Match.Remove(match);
+
+            await _context.SaveChangesAsync();
+        }
     }
 
 }

--- a/Gordon360/Services/RecIM/SeriesService.cs
+++ b/Gordon360/Services/RecIM/SeriesService.cs
@@ -254,6 +254,27 @@ namespace Gordon360.Services.RecIM
             await _context.SaveChangesAsync();
         }
 
+        public async Task DeleteSeriesCascadeAsync(int seriesID)
+        {
+            //delete series teams
+            var seriesTeam = _context.SeriesTeam.Where(st => st.SeriesID == seriesID);
+            _context.SeriesTeam.RemoveRange(seriesTeam);
+            //delete series surfaces
+            var seriesSurface = _context.SeriesSurface.Where(ss => ss.SeriesID == seriesID);
+            _context.SeriesSurface.RemoveRange(seriesSurface);
+            //delete matches
+            var matchIDs = _context.Match.Where(m => m.SeriesID == seriesID).Select(m => m.ID).ToList();
+            foreach (var matchID in matchIDs)
+            {
+                await _matchService.DeleteMatchCascadeAsync(matchID);
+            }
+            //delete series
+            var series = _context.Series.FirstOrDefault(s => s.ID == seriesID);
+            _context.Series.Remove(series);
+
+            await _context.SaveChangesAsync();
+        }
+
         // Scheduler does not currently handle overlaps
         // eventually:
         // - ensure that matches that occur within 1 hour do not share the same surface

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -330,6 +330,7 @@ namespace Gordon360.Services
             Task<SeriesViewModel> PostSeriesAsync(SeriesUploadViewModel newSeries, int? referenceSeriesID);
             Task<SeriesViewModel> UpdateSeriesAsync(int seriesID, SeriesPatchViewModel series);
             Task<SeriesScheduleViewModel> PutSeriesScheduleAsync(SeriesScheduleUploadViewModel seriesSchedule);
+            Task DeleteSeriesCascadeAsync(int seriesID);
             Task<IEnumerable<MatchViewModel>?> ScheduleMatchesAsync(int seriesID);
         }
 
@@ -390,6 +391,7 @@ namespace Gordon360.Services
             Task CreateMatchTeamMappingAsync(int teamID, int matchID);
             Task<MatchParticipantViewModel> AddParticipantAttendanceAsync(string username, int matchID);
             IEnumerable<TeamMatchHistoryViewModel> GetMatchHistoryByTeamID(int teamID);
+            Task DeleteMatchCascadeAsync(int matchID);
         }
     }
 


### PR DESCRIPTION
PR Handles the following:

**NEW** True Deletes
--
- Series Delete will delete the Series along with it's associated SeriesTeams (Series W:L:T Record), SeriesSurfaces, and Matches (see below)
- Match Delete will delete the Match along with it's associated MatchTeams (Scorecard) and MatchParticipants (Attendance)

Match Edits _fixed_
--
MatchPatch has a set of TeamID's within the Patch
- If the TeamIDs are null, no edits will be made to the teams on the match
- If TeamIDs are **not** null, the patch will assume that the TeamIDs in the patch are the teams that need to be associated with the match.
_to clarify, this means that if Match originally had Team A & Team B and the Patch only has Team A, the patch will delete Team B from the match. If the Patch has Team A  & Team C, the route will make a new MatchTeam for Team C and delete Team B's MatchTeam. This is fully scalable to however many teams desired for a single match._