### PR TITLE
[Rec-IM] Auto Scheduling Part 2 - Single Elimination 

### DIFF
--- a/Gordon360/Controllers/ProfilesController.cs
+++ b/Gordon360/Controllers/ProfilesController.cs
@@ -212,33 +212,9 @@ namespace Gordon360.Controllers
             var photoModel = await _profileService.GetPhotoPathAsync(username);
             JObject result = new JObject();
 
-            if (photoModel == null) //There is no preferred or ID image
-            {
-                var unapprovedFileName = username + "_" + _accountService.GetAccountByUsername(username).account_id;
-                var unapprovedFilePath = _config["DEFAULT_ID_SUBMISSION_PATH"];
-                string extension = "";
-                foreach (var file in Directory.GetFiles(unapprovedFilePath, unapprovedFileName + ".*"))
-                {
-                    extension = Path.GetExtension(file);
-                }
-                string unapproved_img = await GetProfileImageOrDefault(unapprovedFilePath + unapprovedFileName + extension);
-                result.Add("def", unapproved_img);
-                return Ok(result);
-            }
-
-            string prefImgPath = _config["PREFERRED_IMAGE_PATH"] + photoModel.Pref_Img_Name;
-
-            if (string.IsNullOrEmpty(photoModel.Pref_Img_Name) || !System.IO.File.Exists(prefImgPath)) //check file existence for prefferred image.
-            {
-                var defaultImgPath = _config["DEFAULT_IMAGE_PATH"] + photoModel.Img_Name;
-                result.Add("def", await GetProfileImageOrDefault(defaultImgPath));
-                return Ok(result);
-            }
-            else
-            {
-                result.Add("pref", await GetProfileImageOrDefault(prefImgPath));
-                return Ok(result);
-            }
+            var defaultImgPath = _config["DEFAULT_IMAGE_PATH"] + photoModel.Img_Name;
+            result.Add("def", await GetProfileImageOrDefault(defaultImgPath));
+            return Ok(result);
         }
 
         /// <summary>Get the profile image of the given user</summary>

--- a/Gordon360/Controllers/RecIM/SeriesController.cs
+++ b/Gordon360/Controllers/RecIM/SeriesController.cs
@@ -128,7 +128,7 @@ namespace Gordon360.Controllers.RecIM
         /// </summary>
         /// <param name="seriesID"></param>
         [HttpPost]
-        [Route("schedule/{seriesID}")]
+        [Route("{seriesID}/schedule")]
         public async Task<ActionResult<IEnumerable<MatchViewModel>>> ScheduleMatches(int seriesID)
         {
             var createdMatches = await _seriesService.ScheduleMatchesAsync(seriesID);

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -2209,13 +2209,14 @@
         </member>
         <member name="M:Gordon360.Services.RecIM.SeriesService.ScheduleElimRoundAsync(System.Collections.Generic.IEnumerable{Gordon360.Models.CCT.SeriesTeam})">
             <summary>
-            Goal of this function is to be able to either create and initialize the elimination bracket
-            if none exists already, and will overload with a matches enumerable to update existing matches
-            to produce a next round
+            Goal of this function is to generate a single elimination round.
+            On the first possible round, this would imply handling teams with buys to ensure
+            that the second round will be in a power of 2 (so that no further rounds need buys). 
             
             These functions may need to be modified later as there may be more efficient ways to handle scheduling
             with the context that surfaces need to be booked ahead of time on 25Live
             </summary>
+            <returns>Matches created as well as number of teams in the next round</returns>
         </member>
         <member name="M:Gordon360.Services.SaveService.GetUpcoming(System.String)">
             <summary>

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -2207,7 +2207,7 @@
             <param name="username">AD Username</param>
             <param name="value">Y or N</param>
         </member>
-        <member name="M:Gordon360.Services.RecIM.SeriesService.ScheduleElimRound(System.Collections.Generic.IEnumerable{Gordon360.Models.CCT.SeriesTeam})">
+        <member name="M:Gordon360.Services.RecIM.SeriesService.ScheduleElimRoundAsync(System.Collections.Generic.IEnumerable{Gordon360.Models.CCT.SeriesTeam})">
             <summary>
             Goal of this function is to be able to either create and initialize the elimination bracket
             if none exists already, and will overload with a matches enumerable to update existing matches

--- a/Gordon360/Models/ViewModels/RecIM/Scheduler.cs
+++ b/Gordon360/Models/ViewModels/RecIM/Scheduler.cs
@@ -7,7 +7,7 @@ namespace Gordon360.Models.ViewModels.RecIM
     public class EliminationRound
     {
         public int TeamsInNextRound { get; set; }
-        public IEnumerable<int> MatchID { get; set; }
+        public IEnumerable<MatchViewModel> Match { get; set; }
 
     }
 }

--- a/Gordon360/Services/RecIM/SeriesService.cs
+++ b/Gordon360/Services/RecIM/SeriesService.cs
@@ -412,66 +412,6 @@ namespace Gordon360.Services.RecIM
         private async Task<IEnumerable<MatchViewModel>> ScheduleDoubleElimination(int seriesID)
         {
             throw new NotImplementedException();
-            var series = _context.Series.FirstOrDefault(s => s.ID == seriesID);
-            //Teams are defaulted to be ordered by Wins if there was a reference series
-            var teams = _context.SeriesTeam
-               .Where(st => st.ID == seriesID);
-
-            //schedule first round
-            var elimScheduler = await ScheduleElimRoundAsync(teams);
-            int teamsInWinners = elimScheduler.TeamsInNextRound;
-            int teamsInLosers = teams.Count() - teamsInWinners;
-
-            //create matches for losers bracket
-            int numBuys = 0;
-            int teamCount = (int)teamsInLosers; //casting to avoid reference value
-            while (!(((teamsInLosers + numBuys) != 0) && (((teamsInLosers + numBuys) & ((teamsInLosers + numBuys) - 1)) == 0))) //while not power of 2
-            {
-                await _matchService.PostMatchAsync(new MatchUploadViewModel
-                {
-                    StartTime = series.StartDate, //temporary before autoscheduling
-                    SeriesID = series.ID,
-                    SurfaceID = 1, //temporary before 25live integration
-                    TeamIDs = new List<int>().AsEnumerable() //no teams
-                });
-                teamCount--;
-                numBuys++;
-            }
-            //teams in losers has weird logic where each team actually represents a match that needs to be made
-            //since each team will be paired with a team from the upper bracket
-            teamsInLosers = teamCount + numBuys;
-            while (teamsInLosers > 1)
-            {
-                for (int i = 0; i < teamsInLosers; i++)
-                {
-                    await _matchService.PostMatchAsync(new MatchUploadViewModel
-                    {
-                        StartTime = series.StartDate, //temporary before autoscheduling
-                        SeriesID = series.ID,
-                        SurfaceID = 1, //temporary before 25live integration
-                        TeamIDs = new List<int>().AsEnumerable() //no teams
-                    });
-                }
-                teamsInLosers /= 2;
-            }
-            //create matches for winners bracket
-            while (teamsInWinners > 0)
-            {
-                for (int i = 0; i < teamsInWinners / 2; i++)
-                {
-                    await _matchService.PostMatchAsync(new MatchUploadViewModel
-                    {
-                        StartTime = series.StartDate, //temporary before autoscheduling
-                        SeriesID = series.ID,
-                        SurfaceID = 1, //temporary before 25live integration
-                        TeamIDs = new List<int>().AsEnumerable() //no teams
-                    });
-                }
-                teamsInWinners /= 2;
-            }
-
-            //silence error
-            return new List<MatchViewModel>();
         }
         private async Task<IEnumerable<MatchViewModel>> ScheduleSingleElimination(int seriesID)
         {

--- a/Gordon360/Services/RecIM/SeriesService.cs
+++ b/Gordon360/Services/RecIM/SeriesService.cs
@@ -271,7 +271,6 @@ namespace Gordon360.Services.RecIM
             //delete series
             var series = _context.Series.FirstOrDefault(s => s.ID == seriesID);
             _context.Series.Remove(series);
-
             await _context.SaveChangesAsync();
         }
 
@@ -407,15 +406,155 @@ namespace Gordon360.Services.RecIM
             createdMatches.Add(res);
             return createdMatches;
         }
+
+        //2nd Part of Autoscheduling
+
         private async Task<IEnumerable<MatchViewModel>> ScheduleDoubleElimination(int seriesID)
         {
-            throw new NotImplementedException();
+            var series = _context.Series.FirstOrDefault(s => s.ID == seriesID);
+            //Teams are defaulted to be ordered by Wins if there was a reference series
+            var teams = _context.SeriesTeam
+               .Where(st => st.ID == seriesID);
+
+            //schedule first round
+            var elimScheduler = await ScheduleElimRoundAsync(teams);
+            int teamsInWinners = elimScheduler.TeamsInNextRound;
+            int teamsInLosers = teams.Count() - teamsInWinners;
+
+            //create matches for losers bracket
+            int numBuys = 0;
+            int teamCount = (int)teamsInLosers; //casting to avoid reference value
+            while (!(((teamsInLosers + numBuys) != 0) && (((teamsInLosers + numBuys) & ((teamsInLosers + numBuys) - 1)) == 0))) //while not power of 2
+            {
+                await _matchService.PostMatchAsync(new MatchUploadViewModel
+                {
+                    StartTime = series.StartDate, //temporary before autoscheduling
+                    SeriesID = series.ID,
+                    SurfaceID = 1, //temporary before 25live integration
+                    TeamIDs = new List<int>().AsEnumerable() //no teams
+                });
+                teamCount--;
+                numBuys++;
+            }
+            //teams in losers has weird logic where each team actually represents a match that needs to be made
+            //since each team will be paired with a team from the upper bracket
+            teamsInLosers = teamCount + numBuys;
+            while (teamsInLosers > 1)
+            {
+                for (int i = 0; i < teamsInLosers; i++)
+                {
+                    await _matchService.PostMatchAsync(new MatchUploadViewModel
+                    {
+                        StartTime = series.StartDate, //temporary before autoscheduling
+                        SeriesID = series.ID,
+                        SurfaceID = 1, //temporary before 25live integration
+                        TeamIDs = new List<int>().AsEnumerable() //no teams
+                    });
+                }
+                teamsInLosers /= 2;
+            }
+            //create matches for winners bracket
+            while (teamsInWinners > 0)
+            {
+                for (int i = 0; i < teamsInWinners / 2; i++)
+                {
+                    await _matchService.PostMatchAsync(new MatchUploadViewModel
+                    {
+                        StartTime = series.StartDate, //temporary before autoscheduling
+                        SeriesID = series.ID,
+                        SurfaceID = 1, //temporary before 25live integration
+                        TeamIDs = new List<int>().AsEnumerable() //no teams
+                    });
+                }
+                teamsInWinners /= 2;
+            }
+
+            //silence error
+            return new List<MatchViewModel>();
+        }
+        private async Task<IEnumerable<MatchViewModel>> ScheduleSingleElimination(int seriesID)
+        {
+            var series = _context.Series.FirstOrDefault(s => s.ID == seriesID);
+            var teams = _context.SeriesTeam
+               .Where(st => st.SeriesID == seriesID)
+               .OrderByDescending(st => st.Win);
+
+            SeriesScheduleViewModel schedule = _context.SeriesSchedule
+                            .FirstOrDefault(ss => ss.ID ==
+                                _context.Series
+                                    .FirstOrDefault(s => s.ID == seriesID)
+                                    .ScheduleID);
+            var availableSurfaces = _context.SeriesSurface
+                                        .Where(ss => ss.SeriesID == seriesID)
+                                        .ToArray();
+            var day = series.StartDate;
+            day = new DateTime(day.Year, day.Month, day.Day, schedule.StartTime.Hour, schedule.StartTime.Minute, schedule.StartTime.Second);
+            string dayOfWeek = day.DayOfWeek.ToString();
+            int surfaceIndex = 0;
+
+            //schedule first round
+            var elimScheduler = await ScheduleElimRoundAsync(teams);
+            int teamsInNextRound = elimScheduler.TeamsInNextRound;
+            foreach (var matchID in elimScheduler.MatchID)
+            {
+                if (surfaceIndex == availableSurfaces.Length)
+                {
+                    surfaceIndex = 0;
+                    day.AddMinutes(schedule.EstMatchTime + 15);
+                }
+                while (!schedule.AvailableDays[dayOfWeek] ||
+                    day.AddMinutes(schedule.EstMatchTime + 15).TimeOfDay > schedule.EndTime.TimeOfDay
+                    )
+                {
+                    day = day.AddDays(1);
+                    day = new DateTime(day.Year, day.Month, day.Day, schedule.StartTime.Hour, schedule.StartTime.Minute, schedule.StartTime.Second);
+                    dayOfWeek = day.DayOfWeek.ToString();
+                    surfaceIndex = 0;
+                }
+                await _matchService.UpdateMatchAsync(matchID,
+                    new MatchPatchViewModel
+                    {
+                        Time = day,
+                        SurfaceID = availableSurfaces[surfaceIndex].SurfaceID
+                    });
+                surfaceIndex++;
+            }
+            //create matches for remaining rounds (possible implementation of including round number optional field)
+            while (teamsInNextRound > 1)
+            {
+                for (int i = 0; i < teamsInNextRound / 2; i++)
+                {
+                    if (surfaceIndex == availableSurfaces.Length)
+                    {
+                        surfaceIndex = 0;
+                        day.AddMinutes(schedule.EstMatchTime + 15);
+                    }
+                    while (!schedule.AvailableDays[dayOfWeek] || day.AddMinutes(schedule.EstMatchTime + 15).TimeOfDay > schedule.EndTime.TimeOfDay)
+                    {
+                        day = day.AddDays(1);
+                        day = new DateTime(day.Year, day.Month, day.Day, schedule.StartTime.Hour, schedule.StartTime.Minute, schedule.StartTime.Second);
+                        dayOfWeek = day.DayOfWeek.ToString();
+                        surfaceIndex = 0;
+                    }
+                    await _matchService.PostMatchAsync(new MatchUploadViewModel
+                    {
+                        StartTime = day,
+                        SeriesID = series.ID,
+                        SurfaceID = availableSurfaces[surfaceIndex].SurfaceID, //temporary before 25live integration
+                        TeamIDs = new List<int>().AsEnumerable() //no teams
+                    });
+                }
+                teamsInNextRound /= 2;
+                //reset between rounds
+                day = day.AddDays(1);
+                day = new DateTime(day.Year, day.Month, day.Day, schedule.StartTime.Hour, schedule.StartTime.Minute, schedule.StartTime.Second);
+                dayOfWeek = day.DayOfWeek.ToString();
+                surfaceIndex = 0;
+            }
+            //silence error
+            return new List<MatchViewModel>();
         }
 
-        public async Task<IEnumerable<MatchViewModel>> ScheduleSingleElimination (int seriesID)
-        {
-            throw new NotImplementedException();
-        }
         /// <summary>
         /// Goal of this function is to be able to either create and initialize the elimination bracket
         /// if none exists already, and will overload with a matches enumerable to update existing matches
@@ -424,19 +563,69 @@ namespace Gordon360.Services.RecIM
         /// These functions may need to be modified later as there may be more efficient ways to handle scheduling
         /// with the context that surfaces need to be booked ahead of time on 25Live
         /// </summary>
-        public async Task<EliminationRound> ScheduleElimRound(IEnumerable<SeriesTeam> involvedTeams)
+        public async Task<EliminationRound> ScheduleElimRoundAsync(IEnumerable<SeriesTeam> involvedTeams)
         {
-            throw new NotImplementedException();
+            int numTeams = involvedTeams.Count();
+            int remainingTeamCount = involvedTeams.Count();
+            int numBuys = 0;
+            var series = _context.Series.FirstOrDefault(s => s.ID == involvedTeams.First().SeriesID);
+
+            var teams = involvedTeams.Reverse();
+
+            while (!(((numTeams + numBuys) != 0) && (((numTeams + numBuys) & ((numTeams + numBuys) - 1)) == 0))) //while not power of 2
+            {
+                await UpdateSeriesTeamStats(new SeriesTeamPatchViewModel
+                {
+                    ID = teams.Last().ID,
+                    Win = 1 //Buy round
+                });
+                teams = teams.Take(--remainingTeamCount);
+                numBuys++;
+            }
+
+            var teamPairings = EliminationRoundTeamPairsAsync(teams);
+            var matchIDs = new List<int>();
+
+            foreach (var teamPair in teamPairings)
+            {
+                var createdMatch = await _matchService.PostMatchAsync(new MatchUploadViewModel
+                {
+                    StartTime = series.StartDate, //temporary before autoscheduling
+                    SeriesID = series.ID,
+                    SurfaceID = 1, //temporary before 25live integration
+                    TeamIDs = teamPair
+                });
+                matchIDs.Add(createdMatch.ID);
+            }
+            return new EliminationRound
+            {
+                TeamsInNextRound = teamPairings.Count() + numBuys,
+                MatchID = matchIDs
+            };
         }
-        public async Task<EliminationRound> ScheduleElimRound(IEnumerable<Match>? matches)
+        public async Task<EliminationRound> ScheduleElimRoundAsync(IEnumerable<Match>? matches)
         {
             throw new NotImplementedException();
         }
 
-        private static IEnumerable<IEnumerable<int>> EliminationRoundTeamPairs(IEnumerable<SeriesTeam> teams)
+        private static IEnumerable<IEnumerable<int>> EliminationRoundTeamPairsAsync(IEnumerable<SeriesTeam> teams)
         {
-            throw new NotImplementedException();
+            var res = new List<IEnumerable<int>>();
+            var teamsArr = teams.ToArray();
+            int i = 0;
+            int j = teamsArr.Length - 1;
+
+            while (i < j)
+            {
+                res.Add(new List<int>
+                {
+                    teamsArr[i].TeamID,
+                    teamsArr[j].TeamID
+                }.AsEnumerable());
+                i++;
+                j--;
+            }
+            return res.AsEnumerable();
         }
     }
 }
-


### PR DESCRIPTION
PR Tackles Single Elimination Automatic Scheduling

Single Elimination 
--
Visual will do the best to explain:
say the order of teams by wins is [A,B,C,D,E,F]

A -> bye
B -> bye
C --
‎ ‎ ‎ ‎ ‎ ‎ | - C
F--
D--
‎ ‎ ‎ ‎ ‎ ‎ | - D
E--

Two matches will be created with teams filled out. All remaining matches will be **MADE** but with no teams. This **could** implementation will have to come in the next iteration of auto-scheduling, but with the ability to edit matches and add teams to each match. This should be easy enough to handle via UI. 