### PR TITLE
[Rec-IM] Team function renaming hotfix

### DIFF
--- a/Gordon360/Controllers/RecIM/TeamsController.cs
+++ b/Gordon360/Controllers/RecIM/TeamsController.cs
@@ -251,7 +251,7 @@ namespace Gordon360.Controllers.RecIM
                             );
                         return CreatedAtAction("AcceptTeamInvite", joinedParticipantTeam);
                     case "rejected":
-                        await _teamService.DeleteTeamParticipantAsync(invite.TeamID, username);
+                        await _teamService.DeleteParticipantTeamAsync(invite.TeamID, username);
                         return Ok();
                     default:
                         return BadRequest("Request does not specify valid invite action");


### PR DESCRIPTION
There's the `DeleteTeamParticipantAsync` in `TeamController` I forgot to rename as `DeleteParticipantTeamAsync`.