### PR TITLE
Refactoring news service methods

### DIFF
--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -534,7 +534,7 @@
             @TODO: Remove redundant username/id from this and service
             @TODO: fix documentation comments
         </member>
-        <member name="M:Gordon360.Controllers.NewsController.Post(System.String,System.Int32,System.String,System.String)">
+        <member name="M:Gordon360.Controllers.NewsController.Post(Gordon360.Models.ViewModels.StudentNewsUploadViewModel)">
             Create a new news item to be added to the database
             @TODO: Remove redundant username/id from this and service
             @TODO: fix documentation comments
@@ -545,12 +545,12 @@
             <returns>The deleted news item</returns>
             <remarks>The news item must be authored by the user and must not be expired</remarks>
         </member>
-        <member name="M:Gordon360.Controllers.NewsController.EditPosting(System.Int32,Gordon360.Models.MyGordon.StudentNews)">
+        <member name="M:Gordon360.Controllers.NewsController.EditPosting(System.Int32,Gordon360.Models.ViewModels.StudentNewsUploadViewModel)">
             <summary>
             (Controller) Edits a news item in the database
             </summary>
             <param name="newsID">The id of the news item to edit</param>
-            <param name="newData">The news object that contains updated values</param>
+            <param name="studentNewsEdit">The news object that contains updated values</param>
             <returns>The updated news item</returns>
             <remarks>The news item must be authored by the user and must not be expired and must be unapproved</remarks>
         </member>
@@ -1791,7 +1791,7 @@
             <returns>The deleted news item</returns>
             <remarks>The news item must be authored by the user and must not be expired</remarks>
         </member>
-        <member name="M:Gordon360.Services.NewsService.EditPosting(System.Int32,Gordon360.Models.MyGordon.StudentNews)">
+        <member name="M:Gordon360.Services.NewsService.EditPosting(System.Int32,Gordon360.Models.ViewModels.StudentNewsUploadViewModel)">
             <summary>
             (Service) Edits a news item in the database
             </summary>

--- a/Gordon360/Models/ViewModels/StudentNewsViewModel.cs
+++ b/Gordon360/Models/ViewModels/StudentNewsViewModel.cs
@@ -49,5 +49,33 @@ namespace Gordon360.Models.ViewModels
 
             return vm;
         }
+
+        /// <summary>
+        /// Returns StudentNewsViewModel from StudentNews and StudentNewsCategory
+        /// </summary>
+        /// <param name="sn">The StudentNews table</param>
+        /// <param name="snc">The StudentNewsCategory table</param>
+        /// <returns> StudentNewsViewModel </returns>
+        public static StudentNewsViewModel From(StudentNews sn, StudentNewsCategory snc)
+        {
+            StudentNewsViewModel vm = new StudentNewsViewModel
+            {
+                SNID = sn.SNID,
+                ADUN = sn.ADUN,
+                categoryID = sn.categoryID,
+                Subject = sn.Subject,
+                Body = sn.Body,
+                Image = sn.Image,
+                Accepted = true,
+                Sent = sn.Sent,
+                thisPastMailing = sn.thisPastMailing,
+                Entered = sn.Entered,
+                categoryName = snc.categoryName,
+                SortOrder = snc.SortOrder,
+                ManualExpirationDate = sn.ManualExpirationDate,
+            };
+
+            return vm;
+        }
     }
 }

--- a/Gordon360/Services/NewsService.cs
+++ b/Gordon360/Services/NewsService.cs
@@ -55,11 +55,11 @@ namespace Gordon360.Services
             var news = (from sn in _context.StudentNews
                         join snc in _context.StudentNewsCategory
                         on sn.categoryID equals snc.categoryID
-                        where sn.Accepted ?? false
+                        where sn.Accepted == true
                         && ((sn.ManualExpirationDate == null
-                               && (sn.Entered ?? DateTime.Today).AddDays(14).Date >= (DateTime.Today).Date)
+                               && EF.Functions.DateDiffDay(sn.Entered ?? DateTime.Today, DateTime.Today) < 14)
                            || (sn.ManualExpirationDate != null
-                           && (sn.ManualExpirationDate ?? DateTime.Today).Date >= (DateTime.Today).Date))
+                           && EF.Functions.DateDiffDay(sn.ManualExpirationDate ?? DateTime.Today, DateTime.Today) < 1))
                         orderby sn.Entered descending
                         select new StudentNewsViewModel
                         {
@@ -87,7 +87,7 @@ namespace Gordon360.Services
                          join snc in _context.StudentNewsCategory
                          on sn.categoryID equals snc.categoryID
                          where sn.Accepted ?? false
-                         && ((DateTime.Today).AddDays(-1).Date < ((DateTime)sn.Entered).Date)
+                         && (EF.Functions.DateDiffDay(sn.Entered ?? DateTime.Today, DateTime.Today) < 1)
                          && (sn.ManualExpirationDate == null || (DateTime.Today).Date < ((DateTime)sn.Entered).Date)
                          orderby snc.SortOrder
                          select new StudentNewsViewModel
@@ -135,7 +135,7 @@ namespace Gordon360.Services
                          where sn.Accepted ?? true
                          && (sn.ADUN == username)
                          && ((sn.ManualExpirationDate == null
-                               && (sn.Entered ?? DateTime.Today).AddDays(14).Date >= (DateTime.Today).Date)
+                               && EF.Functions.DateDiffDay(sn.Entered ?? DateTime.Today, DateTime.Today) < 14)
                            || (sn.ManualExpirationDate != null
                            && (sn.ManualExpirationDate ?? DateTime.Today).Date >= (DateTime.Today).Date))
                         orderby sn.SNID descending

--- a/Gordon360/Services/NewsService.cs
+++ b/Gordon360/Services/NewsService.cs
@@ -57,9 +57,9 @@ namespace Gordon360.Services
                         on sn.categoryID equals snc.categoryID
                         where sn.Accepted ?? false
                         && ((sn.ManualExpirationDate == null
-                               && DateOnly.FromDateTime(sn.Entered ?? DateTime.Today).AddDays(14) >= DateOnly.FromDateTime(DateTime.Today))
+                               && (sn.Entered ?? DateTime.Today).AddDays(14).Date >= (DateTime.Today).Date)
                            || (sn.ManualExpirationDate != null
-                           && DateOnly.FromDateTime(sn.ManualExpirationDate ?? DateTime.Today) >= DateOnly.FromDateTime(DateTime.Today)))
+                           && (sn.ManualExpirationDate ?? DateTime.Today).Date >= (DateTime.Today).Date))
                         orderby sn.Entered descending
                         select new StudentNewsViewModel
                         {

--- a/Gordon360/Services/NewsService.cs
+++ b/Gordon360/Services/NewsService.cs
@@ -129,23 +129,33 @@ namespace Gordon360.Services
                 throw new ResourceNotFoundException() { ExceptionMessage = "The account was not found." };
             }
 
-            var news = await _contextCCT.Procedures.NEWS_PERSONAL_UNAPPROVEDAsync(username);
-            return news.Select(n => new StudentNewsViewModel
-            {
-                SNID = n.SNID,
-                ADUN = n.ADUN,
-                categoryID = n.categoryID,
-                Subject = n.Subject,
-                Body = n.Body,
-                Image = n.Image,
-                Accepted = true,
-                Sent = n.Sent,
-                thisPastMailing = n.thisPastMailing,
-                Entered = n.Entered,
-                categoryName = n.categoryName,
-                SortOrder = n.SortOrder,
-                ManualExpirationDate = n.ManualExpirationDate,
-            });
+            var news = ((from sn in _context.StudentNews
+                         join snc in _context.StudentNewsCategory
+                         on sn.categoryID equals snc.categoryID
+                         where sn.Accepted ?? true
+                         && (sn.ADUN == username)
+                         && ((sn.ManualExpirationDate == null
+                               && DateOnly.FromDateTime(sn.Entered ?? DateTime.Today).AddDays(14) >= DateOnly.FromDateTime(DateTime.Today))
+                           || (sn.ManualExpirationDate != null
+                           && DateOnly.FromDateTime(sn.ManualExpirationDate ?? DateTime.Today) >= DateOnly.FromDateTime(DateTime.Today)))
+                        orderby sn.SNID descending
+                         select new StudentNewsViewModel
+                         {
+                             SNID = sn.SNID,
+                             ADUN = sn.ADUN,
+                             categoryID = sn.categoryID,
+                             Subject = sn.Subject,
+                             Body = sn.Body,
+                             Image = sn.Image,
+                             Accepted = true,
+                             Sent = sn.Sent,
+                             thisPastMailing = sn.thisPastMailing,
+                             Entered = sn.Entered,
+                             categoryName = snc.categoryName,
+                             SortOrder = snc.SortOrder,
+                             ManualExpirationDate = sn.ManualExpirationDate,
+                         })).ToList(); 
+            return news;
         }
 
         /// <summary>

--- a/Gordon360/Services/NewsService.cs
+++ b/Gordon360/Services/NewsService.cs
@@ -135,9 +135,9 @@ namespace Gordon360.Services
                          where sn.Accepted ?? true
                          && (sn.ADUN == username)
                          && ((sn.ManualExpirationDate == null
-                               && DateOnly.FromDateTime(sn.Entered ?? DateTime.Today).AddDays(14) >= DateOnly.FromDateTime(DateTime.Today))
+                               && (sn.Entered ?? DateTime.Today).AddDays(14).Date >= (DateTime.Today).Date)
                            || (sn.ManualExpirationDate != null
-                           && DateOnly.FromDateTime(sn.ManualExpirationDate ?? DateTime.Today) >= DateOnly.FromDateTime(DateTime.Today)))
+                           && (sn.ManualExpirationDate ?? DateTime.Today).Date >= (DateTime.Today).Date))
                         orderby sn.SNID descending
                          select new StudentNewsViewModel
                          {

--- a/Gordon360/Services/NewsService.cs
+++ b/Gordon360/Services/NewsService.cs
@@ -61,22 +61,7 @@ namespace Gordon360.Services
                            || (sn.ManualExpirationDate != null
                            && EF.Functions.DateDiffDay(sn.ManualExpirationDate ?? DateTime.Today, DateTime.Today) < 1))
                         orderby sn.Entered descending
-                        select new StudentNewsViewModel
-                        {
-                            SNID = sn.SNID,
-                            ADUN = sn.ADUN,
-                            categoryID = sn.categoryID,
-                            Subject = sn.Subject,
-                            Body = sn.Body,
-                            Image = sn.Image,
-                            Accepted = true,
-                            Sent = sn.Sent,
-                            thisPastMailing = sn.thisPastMailing,
-                            Entered = sn.Entered,
-                            categoryName = snc.categoryName,
-                            SortOrder = snc.SortOrder,
-                            ManualExpirationDate = sn.ManualExpirationDate,
-                        });
+                        select StudentNewsViewModel.From(sn, snc));
 
             return news;
         }
@@ -86,26 +71,11 @@ namespace Gordon360.Services
             var news = (from sn in _context.StudentNews
                          join snc in _context.StudentNewsCategory
                          on sn.categoryID equals snc.categoryID
-                         where sn.Accepted ?? false
+                         where sn.Accepted == true
                          && (EF.Functions.DateDiffDay(sn.Entered ?? DateTime.Today, DateTime.Today) < 1)
                          && (sn.ManualExpirationDate == null || (DateTime.Today).Date < ((DateTime)sn.Entered).Date)
                          orderby snc.SortOrder
-                         select new StudentNewsViewModel
-                         {
-                             SNID = sn.SNID,
-                             ADUN = sn.ADUN,
-                             categoryID = sn.categoryID,
-                             Subject = sn.Subject,
-                             Body = sn.Body,
-                             Image = sn.Image,
-                             Accepted = true,
-                             Sent = sn.Sent,
-                             thisPastMailing = sn.thisPastMailing,
-                             Entered = sn.Entered,
-                             categoryName = snc.categoryName,
-                             SortOrder = snc.SortOrder,
-                             ManualExpirationDate = sn.ManualExpirationDate,
-                         });
+                         select StudentNewsViewModel.From(sn, snc));
                          
             return news;
         }
@@ -132,29 +102,14 @@ namespace Gordon360.Services
             var news = (from sn in _context.StudentNews
                          join snc in _context.StudentNewsCategory
                          on sn.categoryID equals snc.categoryID
-                         where sn.Accepted ?? true
+                         where sn.Accepted != true
                          && (sn.ADUN == username)
                          && ((sn.ManualExpirationDate == null
                                && EF.Functions.DateDiffDay(sn.Entered ?? DateTime.Today, DateTime.Today) < 14)
                            || (sn.ManualExpirationDate != null
                            && (sn.ManualExpirationDate ?? DateTime.Today).Date >= (DateTime.Today).Date))
                         orderby sn.SNID descending
-                         select new StudentNewsViewModel
-                         {
-                             SNID = sn.SNID,
-                             ADUN = sn.ADUN,
-                             categoryID = sn.categoryID,
-                             Subject = sn.Subject,
-                             Body = sn.Body,
-                             Image = sn.Image,
-                             Accepted = true,
-                             Sent = sn.Sent,
-                             thisPastMailing = sn.thisPastMailing,
-                             Entered = sn.Entered,
-                             categoryName = snc.categoryName,
-                             SortOrder = snc.SortOrder,
-                             ManualExpirationDate = sn.ManualExpirationDate,
-                         }); 
+                         select StudentNewsViewModel.From(sn, snc)); 
             return news;
         }
 

--- a/Gordon360/Services/NewsService.cs
+++ b/Gordon360/Services/NewsService.cs
@@ -76,14 +76,14 @@ namespace Gordon360.Services
                             categoryName = snc.categoryName,
                             SortOrder = snc.SortOrder,
                             ManualExpirationDate = sn.ManualExpirationDate,
-                        }).ToList();
+                        });
 
             return news;
         }
 
         public async Task<IEnumerable<StudentNewsViewModel>> GetNewsNewAsync()
         {
-            var news = ((from sn in _context.StudentNews
+            var news = (from sn in _context.StudentNews
                          join snc in _context.StudentNewsCategory
                          on sn.categoryID equals snc.categoryID
                          where sn.Accepted ?? false
@@ -105,7 +105,7 @@ namespace Gordon360.Services
                              categoryName = snc.categoryName,
                              SortOrder = snc.SortOrder,
                              ManualExpirationDate = sn.ManualExpirationDate,
-                         })).ToList();
+                         });
                          
             return news;
         }
@@ -129,7 +129,7 @@ namespace Gordon360.Services
                 throw new ResourceNotFoundException() { ExceptionMessage = "The account was not found." };
             }
 
-            var news = ((from sn in _context.StudentNews
+            var news = (from sn in _context.StudentNews
                          join snc in _context.StudentNewsCategory
                          on sn.categoryID equals snc.categoryID
                          where sn.Accepted ?? true
@@ -154,7 +154,7 @@ namespace Gordon360.Services
                              categoryName = snc.categoryName,
                              SortOrder = snc.SortOrder,
                              ManualExpirationDate = sn.ManualExpirationDate,
-                         })).ToList(); 
+                         }); 
             return news;
         }
 

--- a/Gordon360/Services/NewsService.cs
+++ b/Gordon360/Services/NewsService.cs
@@ -87,8 +87,8 @@ namespace Gordon360.Services
                          join snc in _context.StudentNewsCategory
                          on sn.categoryID equals snc.categoryID
                          where sn.Accepted ?? false
-                         && (DateOnly.FromDateTime(DateTime.Today).AddDays(-1) < DateOnly.FromDateTime((DateTime)sn.Entered))
-                         && (sn.ManualExpirationDate == null || DateOnly.FromDateTime(DateTime.Today) < DateOnly.FromDateTime((DateTime)sn.Entered))
+                         && ((DateTime.Today).AddDays(-1).Date < ((DateTime)sn.Entered).Date)
+                         && (sn.ManualExpirationDate == null || (DateTime.Today).Date < ((DateTime)sn.Entered).Date)
                          orderby snc.SortOrder
                          select new StudentNewsViewModel
                          {


### PR DESCRIPTION
This PR updates three student news calls to database stored procedures to instead use LINQ with Entity Framework Core for writing C#-based queries. It uses the LINQ query syntax for clarity of the complex operations and filters.

Closes #367 