### PR TITLE
Hotfix: Student News Images broken.

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup .NET Core SDK 6
         uses: actions/setup-dotnet@v2
@@ -20,19 +20,19 @@ jobs:
       - name: Build
         run: dotnet build
     
-  deploy:
+  deploy-train:
     runs-on: windows-latest
-    if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' }}
+    if: ${{ github.ref == 'refs/heads/develop' }}
     needs: build
     environment:
-      name: fromJSON('{"false":"Train", "true":"Production"}')[github.ref == 'refs/heads/master']
-      url: format('https://360Api{0}.gordon.edu', fromJSON('{"false":"Train", "true":""}')[github.ref == 'refs/heads/master'])
+      name: Train
+      url: https://360ApiTrain.gordon.edu
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup .NET Core SDK 6
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.x'
 
@@ -43,8 +43,38 @@ jobs:
         run: dotnet publish ${{ github.workspace}}\Gordon360.sln -r win-x64 --no-self-contained -o ${{ github.workspace }}\Gordon360\bin\app.publish\ci -p:EnvironmentName=${{ secrets.DEPLOYMENT_ENVIRONMENT }}
 
       - name: Upload Build Artifact
-        uses: actions/upload-artifact@v2.2.2
+        uses: actions/upload-artifact@v3
         with:
           name: build-${{ secrets.DEPLOYMENT_ENVIRONMENT }}
           path: ${{ github.workspace }}\Gordon360\bin\app.publish\ci
           if-no-files-found: error
+          
+  deploy-prod:
+    runs-on: windows-latest
+    if: ${{ github.ref == 'refs/heads/master' }}
+    needs: build
+    environment:
+      name: Production
+      url: https://360Api.gordon.edu
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup .NET Core SDK 6
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '6.0.x'
+
+      - name: Install dependencies
+        run: dotnet restore
+
+      - name: Publish
+        run: dotnet publish ${{ github.workspace}}\Gordon360.sln -r win-x64 --no-self-contained -o ${{ github.workspace }}\Gordon360\bin\app.publish\ci -p:EnvironmentName=${{ secrets.DEPLOYMENT_ENVIRONMENT }}
+
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-${{ secrets.DEPLOYMENT_ENVIRONMENT }}
+          path: ${{ github.workspace }}\Gordon360\bin\app.publish\ci
+          if-no-files-found: error
+


### PR DESCRIPTION
`_serverUtils.GetAddress` returns a URL with a trailing slash in production, but the `NewsService.GetImageURL` method added a slash immediately after, creating an invalid URL which broke images for student news.