### PR TITLE
[Rec-IM] Get Attendance route

### DIFF
--- a/Gordon360/Controllers/RecIM/MatchesController.cs
+++ b/Gordon360/Controllers/RecIM/MatchesController.cs
@@ -42,6 +42,19 @@ namespace Gordon360.Controllers.RecIM
             throw new NotImplementedException();
         }
 
+       /// <summary>
+       /// Get's current match attendance for a specified match
+       /// </summary>
+       /// <param name="matchID"></param>
+       /// <returns></returns>
+        [HttpGet]
+        [Route("{matchID}/attendance")]
+        public ActionResult<IEnumerable<ParticipantAttendanceViewModel>> GetMatchAttendance(int matchID)
+        {
+            var res = _matchService.GetMatchAttendance(matchID);
+            return Ok(res);
+        }
+
         /// <summary>
         /// Fetches Match by MatchID
         /// </summary>

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -744,6 +744,13 @@
             <returns></returns>
             <exception cref="T:System.NotImplementedException"></exception>
         </member>
+        <member name="M:Gordon360.Controllers.RecIM.MatchesController.GetMatchAttendance(System.Int32)">
+            <summary>
+            Get's current match attendance for a specified match
+            </summary>
+            <param name="matchID"></param>
+            <returns></returns>
+        </member>
         <member name="M:Gordon360.Controllers.RecIM.MatchesController.GetMatchByID(System.Int32)">
             <summary>
             Fetches Match by MatchID
@@ -2200,6 +2207,13 @@
             <param name="username">AD Username</param>
             <param name="value">Y or N</param>
         </member>
+        <member name="M:Gordon360.Services.RecIM.MatchService.GetMatchForTeamByMatchID(System.Int32)">
+            <summary>
+            this function is used because ASP somehow refuses to cast IEnumerables or recognize IEnumerables
+            within other queries. The only solution is to return each individual instance and have the original
+            query handle the enumeration.
+            </summary>
+        </member>
         <member name="M:Gordon360.Services.RecIM.SeriesService.ScheduleMatchesAsync(System.Int32)">
             <summary>
             Scheduler does not currently handle overlaps
@@ -2213,8 +2227,8 @@
         <member name="M:Gordon360.Services.RecIM.SeriesService.ScheduleElimRoundAsync(System.Collections.Generic.IEnumerable{Gordon360.Models.CCT.SeriesTeam})">
             <summary>
             Goal of this function is to generate a single elimination round.
-            On the first possible round, this would imply handling teams with buys to ensure
-            that the second round will be in a power of 2 (so that no further rounds need buys). 
+            On the first possible round, this would imply handling teams with byes to ensure
+            that the second round will be in a power of 2 (so that no further rounds need byes). 
             
             These functions may need to be modified later as there may be more efficient ways to handle scheduling
             with the context that surfaces need to be booked ahead of time on 25Live

--- a/Gordon360/Services/RecIM/MatchService.cs
+++ b/Gordon360/Services/RecIM/MatchService.cs
@@ -276,7 +276,7 @@ namespace Gordon360.Services.RecIM
             foreach(MatchTeam mt in match.MatchTeam)
             {
                 var attendance = _context.MatchParticipant
-                    .Where(mp => mp.TeamID == mt.TeamID && mp.MatchID == mt.TeamID)
+                    .Where(mp => mp.TeamID == mt.TeamID && mp.MatchID == mt.MatchID)
                     .Select(a => (MatchAttendance)a);
 
                 res.Add(new ParticipantAttendanceViewModel

--- a/Gordon360/Services/RecIM/MatchService.cs
+++ b/Gordon360/Services/RecIM/MatchService.cs
@@ -267,6 +267,28 @@ namespace Gordon360.Services.RecIM
             return match;
         }
 
+        public IEnumerable<ParticipantAttendanceViewModel> GetMatchAttendance(int matchID)
+        {
+            var match = _context.Match.Find(matchID);
+            var res = new List<ParticipantAttendanceViewModel>();
+            if (match is null) return res;
+
+            foreach(MatchTeam mt in match.MatchTeam)
+            {
+                var attendance = _context.MatchParticipant
+                    .Where(mp => mp.TeamID == mt.TeamID && mp.MatchID == mt.TeamID)
+                    .Select(a => (MatchAttendance)a);
+
+                res.Add(new ParticipantAttendanceViewModel
+                {
+                    TeamID = mt.TeamID,
+                    Attendance = attendance,
+                });
+
+            }
+            return res;
+        }
+
         public async Task<MatchViewModel> DeleteMatchCascadeAsync(int matchID)
         {
             //deletematch

--- a/Gordon360/Services/RecIM/TeamService.cs
+++ b/Gordon360/Services/RecIM/TeamService.cs
@@ -267,7 +267,7 @@ namespace Gordon360.Services.RecIM
         public async Task<ParticipantTeamViewModel> UpdateParticipantRoleAsync(int teamID, ParticipantTeamUploadViewModel participant)
         {
             var participantTeam = _context.ParticipantTeam.FirstOrDefault(pt => pt.ParticipantUsername == participant.Username && pt.TeamID == teamID);
-            var roleID = participant.RoleTypeID ?? 3;
+            var roleID = participant.RoleTypeID ?? 3; //update or default to member
 
             //if user is currently requested to join and have just accepted to join the team, user should have other instances of themselves removed from other teams
             if (participantTeam.RoleTypeID == 2 && roleID == 3)

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -381,6 +381,7 @@ namespace Gordon360.Services
         public interface IMatchService
         {
             MatchViewModel GetSimpleMatchViewByID(int matchID);
+            IEnumerable<ParticipantAttendanceViewModel> GetMatchAttendance(int matchID);
             IEnumerable<LookupViewModel>? GetMatchLookup(string type);
             MatchExtendedViewModel GetMatchForTeamByMatchID(int matchID);
             MatchExtendedViewModel GetMatchByID(int matchID);


### PR DESCRIPTION
Route:
GET `api/recim/matches/{matchID}/attendance`
returns a very nice enumerable object (sorted by teamID)

<img width="221" alt="Screen Shot 2023-03-06 at 11 35 16 PM" src="https://user-images.githubusercontent.com/78386128/223321646-706203b8-d3a9-49f1-8a18-fbf1129a3aa0.png">


