### PR TITLE
Update workflow for .NET 7 CLI semantics

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -40,7 +40,7 @@ jobs:
         run: dotnet restore
 
       - name: Publish
-        run: dotnet publish ${{ github.workspace}}\Gordon360.sln -r win-x64 --no-self-contained -o ${{ github.workspace }}\Gordon360\bin\app.publish\ci -p:EnvironmentName=${{ secrets.DEPLOYMENT_ENVIRONMENT }}
+        run: dotnet publish ${{ github.workspace}}\Gordon360.sln -r win-x64 --no-self-contained -p:PublishDir=${{ github.workspace }}\Gordon360\bin\app.publish\ci -p:EnvironmentName=${{ secrets.DEPLOYMENT_ENVIRONMENT }}
 
       - name: Upload Build Artifact
         uses: actions/upload-artifact@v3
@@ -69,7 +69,7 @@ jobs:
         run: dotnet restore
 
       - name: Publish
-        run: dotnet publish ${{ github.workspace}}\Gordon360.sln -r win-x64 --no-self-contained -o ${{ github.workspace }}\Gordon360\bin\app.publish\ci -p:EnvironmentName=${{ secrets.DEPLOYMENT_ENVIRONMENT }}
+        run: dotnet publish ${{ github.workspace}}\Gordon360.sln -r win-x64 --no-self-contained -p:PublishDir=${{ github.workspace }}\Gordon360\bin\app.publish\ci -p:EnvironmentName=${{ secrets.DEPLOYMENT_ENVIRONMENT }}
 
       - name: Upload Build Artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
As of .NET 7.0.200, the `dotnet publish` command was updated (alongside several other `dotnet` commands) to no longer accept the `--output/-o` option for specifying the output of the command.

For full details of the change, including motivation and recommended fixes, see the [Microsoft Breaking Changes documentation for the change](https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid).

The simplest solution for our purposes is to specify the `PublishPath` property for MsBuild, which has equivalent functionality to the old `--output` option.