### PR TITLE
[Rec-IM] Surfaces routes

### DIFF
--- a/Gordon360/Authorization/StateYourBusiness.cs
+++ b/Gordon360/Authorization/StateYourBusiness.cs
@@ -510,6 +510,8 @@ namespace Gordon360.Authorization
                     //fallthrough
                 case Resource.RECIM_MATCH:
                     //fallthrough
+                case Resource.RECIM_SURFACE:
+                    //fallthrough
                 case Resource.RECIM_SPORT:
                     {
                         return _participantService.IsAdmin(user_name);
@@ -725,6 +727,8 @@ namespace Gordon360.Authorization
                     //fallthrough
                 case Resource.RECIM_SERIES:
                     //fallthrough
+                case Resource.RECIM_SURFACE:
+                    //fallthrough
                 case Resource.RECIM_SPORT:
                     {
                         return _participantService.IsAdmin(user_name);
@@ -880,6 +884,8 @@ namespace Gordon360.Authorization
                 case Resource.RECIM_SPORT:
                     //fallthrough
                 case Resource.RECIM_TEAM:
+                    //fallthrough
+                case Resource.RECIM_SURFACE:
                     //fallthrough
                 case Resource.RECIM_MATCH:
                     return _participantService.IsAdmin(user_name);

--- a/Gordon360/Controllers/RecIM/MatchesController.cs
+++ b/Gordon360/Controllers/RecIM/MatchesController.cs
@@ -68,6 +68,11 @@ namespace Gordon360.Controllers.RecIM
             return Ok(match);
         }
 
+        /// <summary>
+        /// Match lookup
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
         [HttpGet]
         [Route("lookup")]
         public ActionResult<IEnumerable<LookupViewModel>> GetMatchTypes(string type)
@@ -78,6 +83,62 @@ namespace Gordon360.Controllers.RecIM
                 return Ok(res);
             }
             return NotFound();
+        }
+
+        /// <summary>
+        /// Gets all surfaces
+        /// </summary>
+        /// <returns></returns>
+        [HttpGet]
+        [Route("surface")]
+        public ActionResult<IEnumerable<SurfaceViewModel>> GetSurfaces()
+        {
+            return Ok(_matchService.GetSurfaces());
+        }
+
+        /// <summary>
+        /// Creates a new match/series surface
+        /// </summary>
+        /// <param name="newSurface"></param>
+        /// <returns></returns>
+        [HttpPost]
+        [Route("surface")]
+        [StateYourBusiness(operation = Operation.ADD, resource = Resource.RECIM_MATCH)]
+        public async Task<ActionResult<SurfaceViewModel>> PostSurface(SurfaceUploadViewModel newSurface)
+        {
+            if (newSurface.Name is null && newSurface.Description is null) return BadRequest("Surface has to have name or description filled out");
+            var res = await _matchService.PostSurfaceAsync(newSurface);
+            return CreatedAtAction(nameof(UpdateSurface), new { surfaceID = res.ID }, res);
+        }
+
+        /// <summary>
+        /// Updates a given surface
+        /// </summary>
+        /// <param name="surfaceID"></param>
+        /// <param name="updatedSurface"></param>
+        /// <returns></returns>
+        [HttpPatch]
+        [Route("surface/{surfaceID}")]
+        [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_MATCH)]
+        public async Task<ActionResult<SurfaceViewModel>> UpdateSurface(int surfaceID, SurfaceUploadViewModel updatedSurface)
+        {
+            if (updatedSurface.Name is null && updatedSurface.Description is null) return BadRequest("Surface has to have name or description filled out");
+            var res = await _matchService.UpdateSurfaceAsync(surfaceID, updatedSurface);
+            return CreatedAtAction(nameof(UpdateSurface), new { surfaceID = res.ID }, res);
+        }
+
+        /// <summary>
+        /// Deletes surface, points all foreign keys to an unknown surface
+        /// to prevent corrupted data
+        /// </summary>
+        /// <param name="surfaceID"></param>
+        /// <returns></returns>
+        [HttpDelete]
+        [Route("surface/{surfaceID}")]
+        [StateYourBusiness(operation = Operation.DELETE, resource = Resource.RECIM_MATCH)]
+        public ActionResult DeleteSurface(int surfaceID)
+        {
+            return NoContent();
         }
 
         /// <summary>

--- a/Gordon360/Controllers/RecIM/MatchesController.cs
+++ b/Gordon360/Controllers/RecIM/MatchesController.cs
@@ -90,7 +90,7 @@ namespace Gordon360.Controllers.RecIM
         /// </summary>
         /// <returns></returns>
         [HttpGet]
-        [Route("surface")]
+        [Route("surfaces")]
         public ActionResult<IEnumerable<SurfaceViewModel>> GetSurfaces()
         {
             return Ok(_matchService.GetSurfaces());
@@ -102,7 +102,7 @@ namespace Gordon360.Controllers.RecIM
         /// <param name="newSurface"></param>
         /// <returns></returns>
         [HttpPost]
-        [Route("surface")]
+        [Route("surfaces")]
         [StateYourBusiness(operation = Operation.ADD, resource = Resource.RECIM_MATCH)]
         public async Task<ActionResult<SurfaceViewModel>> PostSurface(SurfaceUploadViewModel newSurface)
         {
@@ -118,7 +118,7 @@ namespace Gordon360.Controllers.RecIM
         /// <param name="updatedSurface"></param>
         /// <returns></returns>
         [HttpPatch]
-        [Route("surface/{surfaceID}")]
+        [Route("surfaces/{surfaceID}")]
         [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_MATCH)]
         public async Task<ActionResult<SurfaceViewModel>> UpdateSurface(int surfaceID, SurfaceUploadViewModel updatedSurface)
         {
@@ -134,7 +134,7 @@ namespace Gordon360.Controllers.RecIM
         /// <param name="surfaceID"></param>
         /// <returns></returns>
         [HttpDelete]
-        [Route("surface/{surfaceID}")]
+        [Route("surfaces/{surfaceID}")]
         [StateYourBusiness(operation = Operation.DELETE, resource = Resource.RECIM_MATCH)]
         public ActionResult DeleteSurface(int surfaceID)
         {

--- a/Gordon360/Controllers/RecIM/MatchesController.cs
+++ b/Gordon360/Controllers/RecIM/MatchesController.cs
@@ -136,8 +136,9 @@ namespace Gordon360.Controllers.RecIM
         [HttpDelete]
         [Route("surfaces/{surfaceID}")]
         [StateYourBusiness(operation = Operation.DELETE, resource = Resource.RECIM_MATCH)]
-        public ActionResult DeleteSurface(int surfaceID)
+        public async Task<ActionResult> DeleteSurface(int surfaceID)
         {
+            await _matchService.DeleteSurfaceAsync(surfaceID);
             return NoContent();
         }
 

--- a/Gordon360/Controllers/RecIM/MatchesController.cs
+++ b/Gordon360/Controllers/RecIM/MatchesController.cs
@@ -103,7 +103,7 @@ namespace Gordon360.Controllers.RecIM
         /// <returns></returns>
         [HttpPost]
         [Route("surfaces")]
-        [StateYourBusiness(operation = Operation.ADD, resource = Resource.RECIM_MATCH)]
+        [StateYourBusiness(operation = Operation.ADD, resource = Resource.RECIM_SURFACE)]
         public async Task<ActionResult<SurfaceViewModel>> PostSurface(SurfaceUploadViewModel newSurface)
         {
             if (newSurface.Name is null && newSurface.Description is null) return BadRequest("Surface has to have name or description filled out");
@@ -119,7 +119,7 @@ namespace Gordon360.Controllers.RecIM
         /// <returns></returns>
         [HttpPatch]
         [Route("surfaces/{surfaceID}")]
-        [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_MATCH)]
+        [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_SURFACE)]
         public async Task<ActionResult<SurfaceViewModel>> UpdateSurface(int surfaceID, SurfaceUploadViewModel updatedSurface)
         {
             if (updatedSurface.Name is null && updatedSurface.Description is null) return BadRequest("Surface has to have name or description filled out");
@@ -135,7 +135,7 @@ namespace Gordon360.Controllers.RecIM
         /// <returns></returns>
         [HttpDelete]
         [Route("surfaces/{surfaceID}")]
-        [StateYourBusiness(operation = Operation.DELETE, resource = Resource.RECIM_MATCH)]
+        [StateYourBusiness(operation = Operation.DELETE, resource = Resource.RECIM_SURFACE)]
         public async Task<ActionResult> DeleteSurface(int surfaceID)
         {
             await _matchService.DeleteSurfaceAsync(surfaceID);

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -758,6 +758,42 @@
             <param name="matchID"></param>
             <returns></returns>
         </member>
+        <member name="M:Gordon360.Controllers.RecIM.MatchesController.GetMatchTypes(System.String)">
+            <summary>
+            Match lookup
+            </summary>
+            <param name="type"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Gordon360.Controllers.RecIM.MatchesController.GetSurfaces">
+            <summary>
+            Gets all surfaces
+            </summary>
+            <returns></returns>
+        </member>
+        <member name="M:Gordon360.Controllers.RecIM.MatchesController.PostSurface(Gordon360.Models.ViewModels.RecIM.SurfaceUploadViewModel)">
+            <summary>
+            Creates a new match/series surface
+            </summary>
+            <param name="newSurface"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Gordon360.Controllers.RecIM.MatchesController.UpdateSurface(System.Int32,Gordon360.Models.ViewModels.RecIM.SurfaceUploadViewModel)">
+            <summary>
+            Updates a given surface
+            </summary>
+            <param name="surfaceID"></param>
+            <param name="updatedSurface"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Gordon360.Controllers.RecIM.MatchesController.DeleteSurface(System.Int32)">
+            <summary>
+            Deletes surface, points all foreign keys to an unknown surface
+            to prevent corrupted data
+            </summary>
+            <param name="surfaceID"></param>
+            <returns></returns>
+        </member>
         <member name="M:Gordon360.Controllers.RecIM.MatchesController.UpdateStats(System.Int32,Gordon360.Models.ViewModels.RecIM.MatchStatsPatchViewModel)">
             <summary>
             Updates Match Scores, Sportsmanship Ratings, and Team Status

--- a/Gordon360/Models/ViewModels/RecIM/SurfaceUploadViewModel.cs
+++ b/Gordon360/Models/ViewModels/RecIM/SurfaceUploadViewModel.cs
@@ -1,0 +1,23 @@
+﻿using Gordon360.Models.CCT;
+using System;
+using System.Collections.Generic;
+
+namespace Gordon360.Models.ViewModels.RecIM
+{
+    public class SurfaceUploadViewModel
+    {
+        public string? Name { get; set; }
+        public string? Description { get; set; }
+
+        public Surface ToSurface()
+        {
+            this.Name ??= this.Description;
+            this.Description ??= this.Name;
+            return new Surface
+            {
+                Name = this.Name,
+                Description = this.Description,
+            };
+        }
+    }
+}

--- a/Gordon360/Models/ViewModels/RecIM/SurfaceViewModel.cs
+++ b/Gordon360/Models/ViewModels/RecIM/SurfaceViewModel.cs
@@ -1,0 +1,23 @@
+﻿using Gordon360.Models.CCT;
+using System;
+using System.Collections.Generic;
+
+namespace Gordon360.Models.ViewModels.RecIM
+{
+    public class SurfaceViewModel
+    {
+        public int ID { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+
+        public static implicit operator SurfaceViewModel(Surface s)
+        {
+            return new SurfaceViewModel
+            {
+                ID = s.ID,
+                Name = s.Name,
+                Description = s.Description,
+            };
+        }
+    }
+}

--- a/Gordon360/Services/RecIM/MatchService.cs
+++ b/Gordon360/Services/RecIM/MatchService.cs
@@ -237,7 +237,7 @@ namespace Gordon360.Services.RecIM
             return _context.Surface.Where(s => s.ID != 0).Select(s => (SurfaceViewModel)s);
         }
 
-        public async Task DeleteSurface(int surfaceID)
+        public async Task DeleteSurfaceAsync(int surfaceID)
         {
             var surface = _context.Surface
                 .Include(s => s.Match)

--- a/Gordon360/Services/RecIM/MatchService.cs
+++ b/Gordon360/Services/RecIM/MatchService.cs
@@ -1,8 +1,10 @@
 ﻿using Gordon360.Models.CCT;
 using Gordon360.Models.CCT.Context;
 using Gordon360.Models.ViewModels.RecIM;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -47,14 +49,6 @@ namespace Gordon360.Services.RecIM
                             Description = s.Description
                         })
                         .AsEnumerable(),
-                "surface" => _context.Surface.Where(query => query.ID != 0)
-                        .Select(s => new LookupViewModel
-                        {
-                            ID = s.ID,
-                            Description = s.Description
-                        })
-                        .AsEnumerable(),
-
                 _ => null
             };
         }
@@ -216,6 +210,51 @@ namespace Gordon360.Services.RecIM
                     })
                 });
             return matches;
+        }
+
+        public async Task<SurfaceViewModel> PostSurfaceAsync(SurfaceUploadViewModel newSurface)
+        {
+            var surface = newSurface.ToSurface();
+            await _context.Surface.AddAsync(surface);
+            await _context.SaveChangesAsync();
+
+            return surface;
+        }
+
+        public async Task<SurfaceViewModel> UpdateSurfaceAsync(int surfaceID, SurfaceUploadViewModel updatedSurface)
+        {
+            var surface = _context.Surface.Find(surfaceID);
+            //inherit description if possible
+            surface.Name = updatedSurface.Name ?? surface.Name ?? surface.Description ?? updatedSurface.Description;
+            surface.Description = updatedSurface.Description ?? surface.Description ?? surface.Name ?? updatedSurface.Name;
+            await _context.SaveChangesAsync();
+
+            return surface;
+        }
+
+        public IEnumerable<SurfaceViewModel> GetSurfaces()
+        {
+            return _context.Surface.Where(s => s.ID != 0).Select(s => (SurfaceViewModel)s);
+        }
+
+        public async Task DeleteSurface(int surfaceID)
+        {
+            var surface = _context.Surface
+                .Include(s => s.Match)
+                .Include(s => s.SeriesSurface)
+                .FirstOrDefault(s => s.ID == surfaceID);
+            var matches = surface.Match;
+            var seriesSurfaces = surface.SeriesSurface;
+
+            //point all matches to unknown surface
+            foreach (var match in matches)
+                match.SurfaceID = 0;
+            //point all seriessurface to unknown surface
+            foreach (var ss in seriesSurfaces)
+                ss.SurfaceID = 0;
+
+            _context.Surface.Remove(surface);
+            await _context.SaveChangesAsync();
         }
 
         public async Task<MatchViewModel> PostMatchAsync(MatchUploadViewModel newMatch)

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -386,7 +386,7 @@ namespace Gordon360.Services
             Task<SurfaceViewModel> PostSurfaceAsync(SurfaceUploadViewModel newSurface);
             Task<SurfaceViewModel> UpdateSurfaceAsync(int surfaceID, SurfaceUploadViewModel updatedSurface);
             IEnumerable<SurfaceViewModel> GetSurfaces();
-            Task DeleteSurface(int surfaceID);
+            Task DeleteSurfaceAsync(int surfaceID);
             MatchExtendedViewModel GetMatchForTeamByMatchID(int matchID);
             MatchExtendedViewModel GetMatchByID(int matchID);
             IEnumerable<MatchExtendedViewModel> GetMatchesBySeriesID(int seriesID);

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -385,6 +385,8 @@ namespace Gordon360.Services
             IEnumerable<LookupViewModel>? GetMatchLookup(string type);
             Task<SurfaceViewModel> PostSurfaceAsync(SurfaceUploadViewModel newSurface);
             Task<SurfaceViewModel> UpdateSurfaceAsync(int surfaceID, SurfaceUploadViewModel updatedSurface);
+            IEnumerable<SurfaceViewModel> GetSurfaces();
+            Task DeleteSurface(int surfaceID);
             MatchExtendedViewModel GetMatchForTeamByMatchID(int matchID);
             MatchExtendedViewModel GetMatchByID(int matchID);
             IEnumerable<MatchExtendedViewModel> GetMatchesBySeriesID(int seriesID);

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -383,6 +383,8 @@ namespace Gordon360.Services
             MatchViewModel GetSimpleMatchViewByID(int matchID);
             IEnumerable<ParticipantAttendanceViewModel> GetMatchAttendance(int matchID);
             IEnumerable<LookupViewModel>? GetMatchLookup(string type);
+            Task<SurfaceViewModel> PostSurfaceAsync(SurfaceUploadViewModel newSurface);
+            Task<SurfaceViewModel> UpdateSurfaceAsync(int surfaceID, SurfaceUploadViewModel updatedSurface);
             MatchExtendedViewModel GetMatchForTeamByMatchID(int matchID);
             MatchExtendedViewModel GetMatchByID(int matchID);
             IEnumerable<MatchExtendedViewModel> GetMatchesBySeriesID(int seriesID);

--- a/Gordon360/Static Classes/Names.cs
+++ b/Gordon360/Static Classes/Names.cs
@@ -35,6 +35,7 @@ namespace Gordon360.Static.Names
         public const string RECIM_TEAM = "A RecIM team resource";
         public const string RECIM_SPORT = "A RecIM sport resource";
         public const string RECIM_PARTICIPANT = "RecIM Participating User (FacStaff or Student)";
+        public const string RECIM_SURFACE = "RecIM Surfaces/Playing fields/Locations";
 
         // Partial resources, to be targetted by Operation.READ_PARTIAL
         public const string MEMBERSHIP_REQUEST_BY_ACTIVITY = "Membership Request Resources associated with an activity";


### PR DESCRIPTION
Tackles the following:

<h1> 
Surfaces
</h1>
Surfaces is a term used to define locations on which matches can be played. I debated whether or not to make it its own separate controller or to place it in a miscellaneous `recim` controller. But decided it simply made more sense to be connected to matches. 

Furthermore, these routes will have better implementation if/when they get connected at some intrinsic level to our 25Live booking service. 


<h3>
Deprecates
</h3>
`/api/recim/matches/lookup?type=surface`
This route is used for finding all surfaces and has historically been used for the Match page as well as the Match edit form. The biggest reason for this, is that Surface does not actually follow the exact model of other lookup tables as it has both a name and description (description used for details of the surface). As this route really was just a bandaid fix, it will now be deprecated as we have an official surface route.


<h3>
New Routes
</h3>

<b> GET </b> `/api/recim/matches/surfaces`
[no body]
Returns all surfaces, replacement for the deprecated lookup route.
![image](https://user-images.githubusercontent.com/78386128/224338842-0d529c51-57ea-48a3-9aba-08959169508b.png)

<b> POST </b> `/api/recim/matches/surfaces`
Request Body:
![image](https://user-images.githubusercontent.com/78386128/224341172-206861f2-5098-4a89-8e49-f0f5694e4955.png)
Name **or** description are nullable. They will inherit from each other when possible. However, **both** cannot be null. Doing so will throw a `400 BadRequest`

<b> PATCH </b> `/api/recim/matches/surfaces/{surfaceID}`
Request Body:
![image](https://user-images.githubusercontent.com/78386128/224339011-d22399c4-d2fb-432f-8f57-7cb7d87eb4b8.png)
Name **or** description are nullable. They will inherit from each other when possible. However, **both** cannot be null. Doing so will throw a `400 BadRequest`

<b> DELETE </b> `/api/recim/matches/surfaces/{surfaceID}`
[no body]
Originally was not going to implement this route. However, I found a relatively safe way of handling this. 
**Surfaces are true deleted**
However, before being deleted, all SQL table values pointing at specified surface will be pointed to the following surface:
![image](https://user-images.githubusercontent.com/78386128/224340155-f419751b-7e9d-4576-8800-a79d1102e0d7.png)

<hr>
