### PR TITLE
[Rec-IM] Scheduling Part 3 Conclusion Arc Part 1

### DIFF
--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -1275,6 +1275,38 @@
             <param name="nullableDateTime"></param>
             <returns>dateTime with type UTC, or null</returns>
         </member>
+        <member name="M:Gordon360.Extensions.System.DateTimeExtensions.ConvertUtcToEst(System.DateTime)">
+            <summary>
+            Converts UTC DateTime to Eastern Standard Time 
+            List of time zones specified by TimeZoneInfo https://i.stack.imgur.com/zHzGt.png
+            </summary>
+            <param name="dateTime">DateTime with kind UTC</param>
+            <returns>Converted DateTime with kind Unspecified</returns>
+        </member>
+        <member name="M:Gordon360.Extensions.System.DateTimeExtensions.ConvertUtcToEst(System.Nullable{System.DateTime})">
+            <summary>
+            Converts UTC DateTime? to Eastern Standard Time 
+            List of time zones specified by TimeZoneInfo https://i.stack.imgur.com/zHzGt.png
+            </summary>
+            <param name="nullableDateTime">DateTime? with kind UTC</param>
+            <returns>Converted DateTime with kind Unspecified or null if parameter is null</returns>
+        </member>
+        <member name="M:Gordon360.Extensions.System.DateTimeExtensions.ConvertEstToUtc(System.DateTime)">
+            <summary>
+            Converts Eastern Standard Time DateTime to UTC
+            List of time zones specified by TimeZoneInfo https://i.stack.imgur.com/zHzGt.png
+            </summary>
+            <param name="dateTime">Unspecified kind DateTime</param>
+            <returns>Converted DateTime with kind UTC</returns>
+        </member>
+        <member name="M:Gordon360.Extensions.System.DateTimeExtensions.ConvertEstToUtc(System.Nullable{System.DateTime})">
+            <summary>
+            Converts Eastern Standard Time DateTime? to UTC
+            List of time zones specified by TimeZoneInfo https://i.stack.imgur.com/zHzGt.png
+            </summary>
+            <param name="nullableDateTime">Unspecified kind DateTime?</param>
+            <returns>Converted DateTime with kind UTC</returns>
+        </member>
         <member name="P:Gordon360.Models.CCT.Clifton_Strengths.Private">
             <summary>
             Whether the user wants their strengths to be private (not shown to other users)

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -860,7 +860,7 @@
             Automatically creates Matches based on given Series
             </summary>
             <param name="seriesID"></param>
-            <param name="request"></param>
+            <param name="request">optional request data, used for additional options on autoscheduling</param>
         </member>
         <member name="M:Gordon360.Controllers.RecIM.SportsController.GetSports">
             <summary>

--- a/Gordon360/Extensions/DateTimeExtensions.cs
+++ b/Gordon360/Extensions/DateTimeExtensions.cs
@@ -20,7 +20,28 @@ static public class DateTimeExtensions
     {
         if (nullableDateTime is DateTime dateTime)
             return DateTime.SpecifyKind(dateTime, DateTimeKind.Utc);
+        return null;
+    }
 
+    /// <summary>
+    /// Converts UTC DateTime to Eastern Standard Time 
+    /// List of time zones specified by TimeZoneInfo https://i.stack.imgur.com/zHzGt.png
+    /// </summary>
+    /// <param name="dateTime">DateTime with kind UTC</param>
+    /// <returns>Converted DateTime with kind Unspecified</returns>
+    static public DateTime ConvertUtcToEst(this DateTime dateTime) => TimeZoneInfo.ConvertTimeFromUtc(dateTime, TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time"));
+
+
+    /// <summary>
+    /// Converts UTC DateTime? to Eastern Standard Time 
+    /// List of time zones specified by TimeZoneInfo https://i.stack.imgur.com/zHzGt.png
+    /// </summary>
+    /// <param name="nullableDateTime">DateTime with kind UTC</param>
+    /// <returns>Converted DateTime with kind Unspecified or null if parameter is null</returns>
+    static public DateTime? ConvertUtcToEst(this DateTime? nullableDateTime)
+    {
+        if (nullableDateTime is DateTime dateTime)
+            return TimeZoneInfo.ConvertTimeFromUtc(dateTime, TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time"));
         return null;
     }
 }

--- a/Gordon360/Extensions/DateTimeExtensions.cs
+++ b/Gordon360/Extensions/DateTimeExtensions.cs
@@ -36,12 +36,33 @@ static public class DateTimeExtensions
     /// Converts UTC DateTime? to Eastern Standard Time 
     /// List of time zones specified by TimeZoneInfo https://i.stack.imgur.com/zHzGt.png
     /// </summary>
-    /// <param name="nullableDateTime">DateTime with kind UTC</param>
+    /// <param name="nullableDateTime">DateTime? with kind UTC</param>
     /// <returns>Converted DateTime with kind Unspecified or null if parameter is null</returns>
     static public DateTime? ConvertUtcToEst(this DateTime? nullableDateTime)
     {
         if (nullableDateTime is DateTime dateTime)
             return TimeZoneInfo.ConvertTimeFromUtc(dateTime, TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time"));
+        return null;
+    }
+
+    /// <summary>
+    /// Converts Eastern Standard Time DateTime to UTC
+    /// List of time zones specified by TimeZoneInfo https://i.stack.imgur.com/zHzGt.png
+    /// </summary>
+    /// <param name="dateTime">Unspecified kind DateTime</param>
+    /// <returns>Converted DateTime with kind UTC</returns>
+    static public DateTime ConvertEstToUtc(this DateTime dateTime) => TimeZoneInfo.ConvertTimeToUtc(dateTime, TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time"));
+
+    /// <summary>
+    /// Converts Eastern Standard Time DateTime? to UTC
+    /// List of time zones specified by TimeZoneInfo https://i.stack.imgur.com/zHzGt.png
+    /// </summary>
+    /// <param name="nullableDateTime">Unspecified kind DateTime?</param>
+    /// <returns>Converted DateTime with kind UTC</returns>
+    static public DateTime? ConvertEstToUtc(this DateTime? nullableDateTime)
+    {
+        if (nullableDateTime is DateTime dateTime)
+            return TimeZoneInfo.ConvertTimeToUtc(dateTime, TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time"));
         return null;
     }
 }

--- a/Gordon360/Models/ViewModels/RecIM/SeriesPatchViewModel.cs
+++ b/Gordon360/Models/ViewModels/RecIM/SeriesPatchViewModel.cs
@@ -11,5 +11,6 @@ namespace Gordon360.Models.ViewModels.RecIM
         public DateTime? EndDate { get; set; }
         public int? StatusID { get; set; }
         public int? ScheduleID { get; set; }
+        public int[]? TeamIDs { get; set; }
     }
 }

--- a/Gordon360/Services/RecIM/SeriesService.cs
+++ b/Gordon360/Services/RecIM/SeriesService.cs
@@ -442,66 +442,7 @@ namespace Gordon360.Services.RecIM
 
         private async Task<IEnumerable<MatchViewModel>> ScheduleDoubleElimination(int seriesID)
         {
-            // var series = _context.Series.FirstOrDefault(s => s.ID == seriesID);
-            // //Teams are defaulted to be ordered by Wins if there was a reference series
-            // var teams = _context.SeriesTeam
-            //    .Where(st => st.ID == seriesID);
-
-            // //schedule first round
-            // var elimScheduler = await ScheduleElimRoundAsync(teams);
-            // int teamsInWinners = elimScheduler.TeamsInNextRound;
-            // int teamsInLosers = teams.Count() - teamsInWinners;
-
-            // //create matches for losers bracket
-            // int numBuys = 0;
-            // int teamCount = (int)teamsInLosers; //casting to avoid reference value
-            // while (!(((teamsInLosers + numBuys) != 0) && (((teamsInLosers + numBuys) & ((teamsInLosers + numBuys) - 1)) == 0))) //while not power of 2
-            // {
-            //     await _matchService.PostMatchAsync(new MatchUploadViewModel
-            //     {
-            //         StartTime = series.StartDate, //temporary before autoscheduling
-            //         SeriesID = series.ID,
-            //         SurfaceID = 1, //temporary before 25live integration
-            //         TeamIDs = new List<int>().AsEnumerable() //no teams
-            //     });
-            //     teamCount--;
-            //     numBuys++;
-            // }
-            // //teams in losers has weird logic where each team actually represents a match that needs to be made
-            // //since each team will be paired with a team from the upper bracket
-            // teamsInLosers = teamCount + numBuys;
-            // while (teamsInLosers > 1)
-            // {
-            //     for (int i = 0; i < teamsInLosers; i++)
-            //     {
-            //         await _matchService.PostMatchAsync(new MatchUploadViewModel
-            //         {
-            //             StartTime = series.StartDate, //temporary before autoscheduling
-            //             SeriesID = series.ID,
-            //             SurfaceID = 1, //temporary before 25live integration
-            //             TeamIDs = new List<int>().AsEnumerable() //no teams
-            //         });
-            //     }
-            //     teamsInLosers /= 2;
-            // }
-            // //create matches for winners bracket
-            // while (teamsInWinners > 0)
-            // {
-            //     for (int i = 0; i < teamsInWinners / 2; i++)
-            //     {
-            //         await _matchService.PostMatchAsync(new MatchUploadViewModel
-            //         {
-            //             StartTime = series.StartDate, //temporary before autoscheduling
-            //             SeriesID = series.ID,
-            //             SurfaceID = 1, //temporary before 25live integration
-            //             TeamIDs = new List<int>().AsEnumerable() //no teams
-            //         });
-            //     }
-            //     teamsInWinners /= 2;
-            // }
-
-            // //silence error
-            return new List<MatchViewModel>();
+            throw new NotImplementedException();
         }
         private async Task<IEnumerable<MatchViewModel>> ScheduleSingleElimination(int seriesID)
         {

--- a/Gordon360/Services/RecIM/SeriesService.cs
+++ b/Gordon360/Services/RecIM/SeriesService.cs
@@ -16,7 +16,6 @@ namespace Gordon360.Services.RecIM
     {
         private readonly CCTContext _context;
         private readonly IMatchService _matchService;
-        private static readonly TimeSpan midnight = new DateTime().TimeOfDay;
 
         public SeriesService(CCTContext context, IMatchService matchService)
         {
@@ -359,10 +358,10 @@ namespace Gordon360.Services.RecIM
                 .ConvertUtcToEst();
             string dayOfWeek = day.DayOfWeek.ToString();
             // scheduleEndTime is needed to combat the case where a schedule goes through midnight. (where EndTime < StartTime)
-            DateTime scheduleEndTime = day.AddDays(schedule.EndTime.TimeOfDay < schedule.StartTime.TimeOfDay ? 1 : 0);
-            scheduleEndTime = new DateTime(scheduleEndTime.Year, scheduleEndTime.Month, scheduleEndTime.Day, schedule.EndTime.Hour, schedule.EndTime.Minute, schedule.EndTime.Second)
-                .SpecifyUtc()
-                .ConvertUtcToEst();
+            var end = new DateTime().Add(schedule.EndTime.SpecifyUtc().ConvertUtcToEst().TimeOfDay);
+            var start = new DateTime().Add(schedule.StartTime.SpecifyUtc().ConvertUtcToEst().TimeOfDay);
+            DateTime scheduleEndTime = day.AddDays(end < start ? 1 : 0);
+            scheduleEndTime = new DateTime(scheduleEndTime.Year, scheduleEndTime.Month, scheduleEndTime.Day, schedule.EndTime.Hour, schedule.EndTime.Minute, schedule.EndTime.Second);
 
             int surfaceIndex = 0;
             for (int cycles = 0; cycles < numCycles; cycles++)
@@ -442,10 +441,10 @@ namespace Gordon360.Services.RecIM
                 .ConvertUtcToEst();
             string dayOfWeek = day.DayOfWeek.ToString();
             // scheduleEndTime is needed to combat the case where a schedule goes through midnight. (where EndTime < StartTime)
-            DateTime scheduleEndTime = day.AddDays(schedule.EndTime.TimeOfDay < schedule.StartTime.TimeOfDay ? 1 : 0);
-            scheduleEndTime = new DateTime(scheduleEndTime.Year, scheduleEndTime.Month, scheduleEndTime.Day, schedule.EndTime.Hour, schedule.EndTime.Minute, schedule.EndTime.Second)
-                .SpecifyUtc()
-                .ConvertUtcToEst();
+            var end = new DateTime().Add(schedule.EndTime.SpecifyUtc().ConvertUtcToEst().TimeOfDay);
+            var start = new DateTime().Add(schedule.StartTime.SpecifyUtc().ConvertUtcToEst().TimeOfDay);
+            DateTime scheduleEndTime = day.AddDays(end < start ? 1 : 0);
+            scheduleEndTime = new DateTime(scheduleEndTime.Year, scheduleEndTime.Month, scheduleEndTime.Day, schedule.EndTime.Hour, schedule.EndTime.Minute, schedule.EndTime.Second);
 
             //local variables
             var numMatchesRemaining = request.NumberOfLadderMatches ?? 1;
@@ -504,64 +503,6 @@ namespace Gordon360.Services.RecIM
 
         private async Task<IEnumerable<MatchViewModel>> ScheduleDoubleElimination(int seriesID)
         {
-            // var series = _context.Series.FirstOrDefault(s => s.ID == seriesID);
-            // //Teams are defaulted to be ordered by Wins if there was a reference series
-            // var teams = _context.SeriesTeam
-            //    .Where(st => st.ID == seriesID);
-
-            // //schedule first round
-            // var elimScheduler = await ScheduleElimRoundAsync(teams);
-            // int teamsInWinners = elimScheduler.TeamsInNextRound;
-            // int teamsInLosers = teams.Count() - teamsInWinners;
-
-            // //create matches for losers bracket
-            // int numBuys = 0;
-            // int teamCount = (int)teamsInLosers; //casting to avoid reference value
-            // while (!(((teamsInLosers + numBuys) != 0) && (((teamsInLosers + numBuys) & ((teamsInLosers + numBuys) - 1)) == 0))) //while not power of 2
-            // {
-            //     await _matchService.PostMatchAsync(new MatchUploadViewModel
-            //     {
-            //         StartTime = series.StartDate, //temporary before autoscheduling
-            //         SeriesID = series.ID,
-            //         SurfaceID = 1, //temporary before 25live integration
-            //         TeamIDs = new List<int>().AsEnumerable() //no teams
-            //     });
-            //     teamCount--;
-            //     numBuys++;
-            // }
-            // //teams in losers has weird logic where each team actually represents a match that needs to be made
-            // //since each team will be paired with a team from the upper bracket
-            // teamsInLosers = teamCount + numBuys;
-            // while (teamsInLosers > 1)
-            // {
-            //     for (int i = 0; i < teamsInLosers; i++)
-            //     {
-            //         await _matchService.PostMatchAsync(new MatchUploadViewModel
-            //         {
-            //             StartTime = series.StartDate, //temporary before autoscheduling
-            //             SeriesID = series.ID,
-            //             SurfaceID = 1, //temporary before 25live integration
-            //             TeamIDs = new List<int>().AsEnumerable() //no teams
-            //         });
-            //     }
-            //     teamsInLosers /= 2;
-            // }
-            // //create matches for winners bracket
-            // while (teamsInWinners > 0)
-            // {
-            //     for (int i = 0; i < teamsInWinners / 2; i++)
-            //     {
-            //         await _matchService.PostMatchAsync(new MatchUploadViewModel
-            //         {
-            //             StartTime = series.StartDate, //temporary before autoscheduling
-            //             SeriesID = series.ID,
-            //             SurfaceID = 1, //temporary before 25live integration
-            //             TeamIDs = new List<int>().AsEnumerable() //no teams
-            //         });
-            //     }
-            //     teamsInWinners /= 2;
-            // }
-            // //silence error
             return new List<MatchViewModel>();
         }
         private async Task<IEnumerable<MatchViewModel>> ScheduleSingleElimination(int seriesID)

--- a/Gordon360/Services/RecIM/SeriesService.cs
+++ b/Gordon360/Services/RecIM/SeriesService.cs
@@ -310,8 +310,11 @@ namespace Gordon360.Services.RecIM
             var series = _context.Series
                 .Include(s => s.Type)
                 .FirstOrDefault(s => s.ID == seriesID);
-            //if the series is deleted, throw exception
+            // if the series is deleted, throw exception
             if (series.StatusID == 0) throw new UnprocessibleEntity { ExceptionMessage = "Series has been deleted" };
+
+            // ensure series has surfaces to autoschedule on
+            if (!_context.SeriesSurface.Any(ss => ss.SeriesID == seriesID)) throw new UnprocessibleEntity { ExceptionMessage = "Series has no specified surfaces" };
 
             var typeCode = series.Type.TypeCode;
 
@@ -328,7 +331,10 @@ namespace Gordon360.Services.RecIM
         private async Task<IEnumerable<MatchViewModel>> ScheduleRoundRobin(int seriesID, UploadScheduleRequest request)
         {
             var createdMatches = new List<MatchViewModel>();
-            var series = _context.Series.Include(s => s.SeriesSurface).FirstOrDefault(s => s.ID == seriesID);
+            var series = _context.Series
+                .Include(s => s.SeriesSurface)
+                .Include(s => s.Schedule)
+                .FirstOrDefault(s => s.ID == seriesID);
             var teams = _context.SeriesTeam
                 .Where(st => st.SeriesID == seriesID)
                 .Select(st => st.TeamID)
@@ -337,14 +343,16 @@ namespace Gordon360.Services.RecIM
             //algorithm requires odd number of teams
             teams.Add(0);//0 is not a valid true team ID thus will act as dummy team
 
-            SeriesScheduleViewModel schedule = _context.SeriesSchedule
-                            .FirstOrDefault(ss => ss.ID == series.ScheduleID);
+            SeriesScheduleViewModel schedule = series.Schedule;
             var availableSurfaces = series.SeriesSurface.ToArray();
 
             //day = starting datetime accurate to minute and seconds based on scheduler
             var day = series.StartDate;
-            day = new DateTime(day.Year, day.Month, day.Day, schedule.StartTime.Hour, schedule.StartTime.Minute, schedule.StartTime.Second);
+            day = new DateTime(day.Year, day.Month, day.Day, schedule.StartTime.Hour, schedule.StartTime.Minute, schedule.StartTime.Second).SpecifyUtc();
             string dayOfWeek = day.DayOfWeek.ToString();
+            // scheduleEndTime is needed to combat the case where a schedule goes through midnight. (where EndTime < StartTime)
+            DateTime scheduleEndTime = day.AddDays(schedule.EndTime.TimeOfDay < schedule.StartTime.TimeOfDay ? 1 : 0);
+            scheduleEndTime = new DateTime(scheduleEndTime.Year, scheduleEndTime.Month, scheduleEndTime.Day, schedule.EndTime.Hour, schedule.EndTime.Minute, schedule.EndTime.Second).SpecifyUtc();
 
             int surfaceIndex = 0;
             for (int cycles = 0; cycles < numCycles; cycles++)
@@ -362,12 +370,14 @@ namespace Gordon360.Services.RecIM
                     //ensure matchtime is in an available day will be a "bug" if the match goes beyond 12AM
                     //minor bug as it just means that some games will be scheduled on the next possible day
                     //even if they are "hypothetically" able to play on the original day
-                    while (!schedule.AvailableDays[dayOfWeek] ||
-                        day.AddMinutes(schedule.EstMatchTime + 15).TimeOfDay > schedule.EndTime.TimeOfDay
-                        )
+                    while (!schedule.AvailableDays[dayOfWeek] || day.AddMinutes(schedule.EstMatchTime + 15) > scheduleEndTime)
                     {
-                        day = day.AddDays(1);
-                        day = new DateTime(day.Year, day.Month, day.Day, schedule.StartTime.Hour, schedule.StartTime.Minute, schedule.StartTime.Second);
+                        // this check covers the basis that the while loop is initialized by only the condition that current schedule time has passed end time
+                        // thus to ensure that we aren't skipping consecutive days if we pass midnight, we need to NOT add a day if we're still on an accepted day of the week
+                        if (!schedule.AvailableDays[dayOfWeek])
+                            day = day.AddDays(1);
+                        day = new DateTime(day.Year, day.Month, day.Day, schedule.StartTime.Hour, schedule.StartTime.Minute, schedule.StartTime.Second).SpecifyUtc();
+                        scheduleEndTime = scheduleEndTime.AddDays(1);
                         dayOfWeek = day.DayOfWeek.ToString();
                         surfaceIndex = 0;
                     }
@@ -404,6 +414,7 @@ namespace Gordon360.Services.RecIM
             var series = _context.Series
                 .Include(s => s.SeriesTeam)
                 .Include(s => s.SeriesSurface)
+                .Include(s => s.Schedule)
                 .FirstOrDefault(s => s.ID == seriesID);
             var teams = series.SeriesTeam
                 .Select(st => st.TeamID)
@@ -411,11 +422,14 @@ namespace Gordon360.Services.RecIM
 
             //scheduler based variables
             var availableSurfaces = series.SeriesSurface.ToArray();
-            SeriesScheduleViewModel schedule = _context.SeriesSchedule
-                            .FirstOrDefault(ss => ss.ID == series.ScheduleID);
+            SeriesScheduleViewModel schedule = series.Schedule;
+
             var day = series.StartDate;
-            day = new DateTime(day.Year, day.Month, day.Day, schedule.StartTime.Hour, schedule.StartTime.Minute, schedule.StartTime.Second);
+            day = new DateTime(day.Year, day.Month, day.Day, schedule.StartTime.Hour, schedule.StartTime.Minute, schedule.StartTime.Second).SpecifyUtc();
             string dayOfWeek = day.DayOfWeek.ToString();
+            // scheduleEndTime is needed to combat the case where a schedule goes through midnight. (where EndTime < StartTime)
+            DateTime scheduleEndTime = day.AddDays(schedule.EndTime.TimeOfDay < schedule.StartTime.TimeOfDay ? 1 : 0);
+            scheduleEndTime = new DateTime(scheduleEndTime.Year, scheduleEndTime.Month, scheduleEndTime.Day, schedule.EndTime.Hour, schedule.EndTime.Minute, schedule.EndTime.Second).SpecifyUtc();
 
             //local variables
             var numMatchesRemaining = request.NumberOfLadderMatches ?? 1;
@@ -431,11 +445,15 @@ namespace Gordon360.Services.RecIM
                     day = day.AddMinutes(schedule.EstMatchTime + 15);//15 minute buffer between matches as suggested by customer
                 }
 
-                while (!schedule.AvailableDays[dayOfWeek] ||
-                    day.AddMinutes(schedule.EstMatchTime + 15).TimeOfDay > schedule.EndTime.TimeOfDay)
+                while (!schedule.AvailableDays[dayOfWeek] || day.AddMinutes(schedule.EstMatchTime + 15) > scheduleEndTime)
                 {
-                    day = day.AddDays(1);
-                    day = new DateTime(day.Year, day.Month, day.Day, schedule.StartTime.Hour, schedule.StartTime.Minute, schedule.StartTime.Second);
+                    // this check covers the basis that the while loop is initialized by only the condition that current schedule time has passed end time
+                    // thus to ensure that we aren't skipping consecutive days if we pass midnight, we need to NOT add a day if we're still on an accepted day of the week
+                    if (!schedule.AvailableDays[dayOfWeek])
+                        day = day.AddDays(1);
+                    day = new DateTime(day.Year, day.Month, day.Day, schedule.StartTime.Hour, schedule.StartTime.Minute, schedule.StartTime.Second).SpecifyUtc();
+                    scheduleEndTime = scheduleEndTime.AddDays(1);
+
                     dayOfWeek = day.DayOfWeek.ToString();
                     surfaceIndex = 0;
                 }

--- a/Gordon360/Services/RecIM/SeriesService.cs
+++ b/Gordon360/Services/RecIM/SeriesService.cs
@@ -442,7 +442,66 @@ namespace Gordon360.Services.RecIM
 
         private async Task<IEnumerable<MatchViewModel>> ScheduleDoubleElimination(int seriesID)
         {
-            throw new NotImplementedException();
+            // var series = _context.Series.FirstOrDefault(s => s.ID == seriesID);
+            // //Teams are defaulted to be ordered by Wins if there was a reference series
+            // var teams = _context.SeriesTeam
+            //    .Where(st => st.ID == seriesID);
+
+            // //schedule first round
+            // var elimScheduler = await ScheduleElimRoundAsync(teams);
+            // int teamsInWinners = elimScheduler.TeamsInNextRound;
+            // int teamsInLosers = teams.Count() - teamsInWinners;
+
+            // //create matches for losers bracket
+            // int numBuys = 0;
+            // int teamCount = (int)teamsInLosers; //casting to avoid reference value
+            // while (!(((teamsInLosers + numBuys) != 0) && (((teamsInLosers + numBuys) & ((teamsInLosers + numBuys) - 1)) == 0))) //while not power of 2
+            // {
+            //     await _matchService.PostMatchAsync(new MatchUploadViewModel
+            //     {
+            //         StartTime = series.StartDate, //temporary before autoscheduling
+            //         SeriesID = series.ID,
+            //         SurfaceID = 1, //temporary before 25live integration
+            //         TeamIDs = new List<int>().AsEnumerable() //no teams
+            //     });
+            //     teamCount--;
+            //     numBuys++;
+            // }
+            // //teams in losers has weird logic where each team actually represents a match that needs to be made
+            // //since each team will be paired with a team from the upper bracket
+            // teamsInLosers = teamCount + numBuys;
+            // while (teamsInLosers > 1)
+            // {
+            //     for (int i = 0; i < teamsInLosers; i++)
+            //     {
+            //         await _matchService.PostMatchAsync(new MatchUploadViewModel
+            //         {
+            //             StartTime = series.StartDate, //temporary before autoscheduling
+            //             SeriesID = series.ID,
+            //             SurfaceID = 1, //temporary before 25live integration
+            //             TeamIDs = new List<int>().AsEnumerable() //no teams
+            //         });
+            //     }
+            //     teamsInLosers /= 2;
+            // }
+            // //create matches for winners bracket
+            // while (teamsInWinners > 0)
+            // {
+            //     for (int i = 0; i < teamsInWinners / 2; i++)
+            //     {
+            //         await _matchService.PostMatchAsync(new MatchUploadViewModel
+            //         {
+            //             StartTime = series.StartDate, //temporary before autoscheduling
+            //             SeriesID = series.ID,
+            //             SurfaceID = 1, //temporary before 25live integration
+            //             TeamIDs = new List<int>().AsEnumerable() //no teams
+            //         });
+            //     }
+            //     teamsInWinners /= 2;
+            // }
+
+            // //silence error
+            return new List<MatchViewModel>();
         }
         private async Task<IEnumerable<MatchViewModel>> ScheduleSingleElimination(int seriesID)
         {

--- a/Gordon360/Services/RecIM/SeriesService.cs
+++ b/Gordon360/Services/RecIM/SeriesService.cs
@@ -91,64 +91,6 @@ namespace Gordon360.Services.RecIM
 
         public SeriesExtendedViewModel GetSeriesByID(int seriesID)
         {
-            // var series = _context.Series.FirstOrDefault(s => s.ID == seriesID);
-            // //Teams are defaulted to be ordered by Wins if there was a reference series
-            // var teams = _context.SeriesTeam
-            //    .Where(st => st.ID == seriesID);
-
-            // //schedule first round
-            // var elimScheduler = await ScheduleElimRoundAsync(teams);
-            // int teamsInWinners = elimScheduler.TeamsInNextRound;
-            // int teamsInLosers = teams.Count() - teamsInWinners;
-
-            // //create matches for losers bracket
-            // int numBuys = 0;
-            // int teamCount = (int)teamsInLosers; //casting to avoid reference value
-            // while (!(((teamsInLosers + numBuys) != 0) && (((teamsInLosers + numBuys) & ((teamsInLosers + numBuys) - 1)) == 0))) //while not power of 2
-            // {
-            //     await _matchService.PostMatchAsync(new MatchUploadViewModel
-            //     {
-            //         StartTime = series.StartDate, //temporary before autoscheduling
-            //         SeriesID = series.ID,
-            //         SurfaceID = 1, //temporary before 25live integration
-            //         TeamIDs = new List<int>().AsEnumerable() //no teams
-            //     });
-            //     teamCount--;
-            //     numBuys++;
-            // }
-            // //teams in losers has weird logic where each team actually represents a match that needs to be made
-            // //since each team will be paired with a team from the upper bracket
-            // teamsInLosers = teamCount + numBuys;
-            // while (teamsInLosers > 1)
-            // {
-            //     for (int i = 0; i < teamsInLosers; i++)
-            //     {
-            //         await _matchService.PostMatchAsync(new MatchUploadViewModel
-            //         {
-            //             StartTime = series.StartDate, //temporary before autoscheduling
-            //             SeriesID = series.ID,
-            //             SurfaceID = 1, //temporary before 25live integration
-            //             TeamIDs = new List<int>().AsEnumerable() //no teams
-            //         });
-            //     }
-            //     teamsInLosers /= 2;
-            // }
-            // //create matches for winners bracket
-            // while (teamsInWinners > 0)
-            // {
-            //     for (int i = 0; i < teamsInWinners / 2; i++)
-            //     {
-            //         await _matchService.PostMatchAsync(new MatchUploadViewModel
-            //         {
-            //             StartTime = series.StartDate, //temporary before autoscheduling
-            //             SeriesID = series.ID,
-            //             SurfaceID = 1, //temporary before 25live integration
-            //             TeamIDs = new List<int>().AsEnumerable() //no teams
-            //         });
-            //     }
-            //     teamsInWinners /= 2;
-            // }
-            // //silence error
             return GetSeries().FirstOrDefault(s => s.ID == seriesID);
         }
 


### PR DESCRIPTION
PR tackles the following:

Edit Series v2
--
`http.patch /recim/series/{seriesID}` 
Now has a **NEW** field 
- int[ ] TeamIDs
![image](https://user-images.githubusercontent.com/78386128/224576250-2e63ab7e-7483-4e31-803c-78193ffc73f2.png)

This new field allows for a series to modify the current teams within the series. 
Now you might be wondering, "why isn't this in `POST`"? This field is not necessary for `POST` due to the fact that `POST` inherits Teams from either a reference series (i.e. top 8 teams of the Regular Season) or all teams in the activity. Thus, it is unnecessary and clunky to add a specific team select. 

This modification will need to be added **immediately** to the UI for series edit to work. (However, with the current `null` check it won't break anything per say)


Series Auto-Schedule time fix
--
There are 2 main problems regarding auto-scheduling with our previous model:
_below is our series schedule view model_
![image](https://user-images.githubusercontent.com/78386128/224576453-247e8ab3-6bcb-40f7-bc60-6b295bb4dc8c.png)

1. Days of the week are boolean values and Start/End Time is in UTC (denoted with the `z`). Why is this a problem? 
> - Our customer base **should** be operating out of Eastern Standard Time. 
> - After ~19:00-20:00 a specified "Available" day may no longer be available when calculating in UTC (which the API operates in) 
> - When creating a schedule, it is impractical for the customer to consider that the schedule has available days in terms of EST but handle dates in UTC. 

**Solution**! Handle all calculations in EST and specify on the UI that the schedule will be localized to Gordon Local Time (EST)

2. Less of a model issue but there was a flaw in the autoscheduling algorithm (denoted by the "midnight" bug) where we had issues regarding End Time being before Start Time (in the event that a schedule passes through midnight). 
> - New algorithm uses a checked specific "endDate" instead of end time. This date follows the start date as the termination point for a schedule on a specified time period. 

- [x] Add/remove teams to series (edit series)
- [x] Fix autoscheduling midnight bug