### PR TITLE
[Rec-IM] attendance v3

### DIFF
--- a/Gordon360/Controllers/RecIM/MatchesController.cs
+++ b/Gordon360/Controllers/RecIM/MatchesController.cs
@@ -211,10 +211,41 @@ namespace Gordon360.Controllers.RecIM
         [HttpPut]
         [Route("{matchID}/attendance")]
         [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_MATCH)]
-        public async Task<ActionResult<IEnumerable<MatchAttendance>>> AddParticipantAttendance(int matchID, ParticipantAttendanceViewModel teamAttendanceList)
+        public async Task<ActionResult<IEnumerable<MatchAttendance>>> PutParticipantAttendance(int matchID, ParticipantAttendanceViewModel teamAttendanceList)
         {
-            var attendance = await _teamService.AddParticipantAttendanceAsync(matchID, teamAttendanceList);
+            var attendance = await _teamService.PutParticipantAttendanceAsync(matchID, teamAttendanceList);
+            return CreatedAtAction(nameof(PutParticipantAttendance), attendance);
+        }
+
+
+        /// <summary>
+        /// Adds single match participant
+        /// </summary>
+        /// <param name="matchID">match id</param>
+        /// <param name="attendee">object holding required username (optional teamID)</param>
+        /// <returns></returns>
+        [HttpPost]
+        [Route("{matchID}/attendance")]
+        [StateYourBusiness(operation = Operation.ADD, resource = Resource.RECIM_MATCH)]
+        public async Task<ActionResult<IEnumerable<MatchAttendance>>> AddParticipantAttendance(int matchID, MatchAttendance attendee)
+        {
+            var attendance = await _matchService.AddParticipantAttendanceAsync(matchID, attendee);
             return CreatedAtAction(nameof(AddParticipantAttendance), attendance);
+        }
+
+        /// <summary>
+        /// Deletes single match participant
+        /// </summary>
+        /// <param name="matchID">match id</param>
+        /// <param name="attendee">object holding required username (optional teamID)</param>
+        /// <returns></returns>
+        [HttpDelete]
+        [Route("{matchID}/attendance")]
+        [StateYourBusiness(operation = Operation.DELETE, resource = Resource.RECIM_MATCH)]
+        public async Task<ActionResult<IEnumerable<MatchAttendance>>> DeleteParticipantAttendance(int matchID, MatchAttendance attendee)
+        {
+            await _matchService.DeleteParticipantAttendanceAsync(matchID, attendee);
+            return NoContent();
         }
     }
 }

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -831,13 +831,29 @@
             <param name="matchID"></param>
             <returns></returns>
         </member>
-        <member name="M:Gordon360.Controllers.RecIM.MatchesController.AddParticipantAttendance(System.Int32,Gordon360.Models.ViewModels.RecIM.ParticipantAttendanceViewModel)">
+        <member name="M:Gordon360.Controllers.RecIM.MatchesController.PutParticipantAttendance(System.Int32,Gordon360.Models.ViewModels.RecIM.ParticipantAttendanceViewModel)">
             <summary>
             creates match attendance
             </summary>
             <param name="matchID"></param>
             <param name="teamID"></param>
             <param name="teamAttendanceList">List of attendees for a team</param>
+            <returns></returns>
+        </member>
+        <member name="M:Gordon360.Controllers.RecIM.MatchesController.AddParticipantAttendance(System.Int32,Gordon360.Models.ViewModels.RecIM.MatchAttendance)">
+            <summary>
+            Adds single match participant
+            </summary>
+            <param name="matchID">match id</param>
+            <param name="attendee">object holding required username (optional teamID)</param>
+            <returns></returns>
+        </member>
+        <member name="M:Gordon360.Controllers.RecIM.MatchesController.DeleteParticipantAttendance(System.Int32,Gordon360.Models.ViewModels.RecIM.MatchAttendance)">
+            <summary>
+            Deletes single match participant
+            </summary>
+            <param name="matchID">match id</param>
+            <param name="attendee">object holding required username (optional teamID)</param>
             <returns></returns>
         </member>
         <member name="M:Gordon360.Controllers.RecIM.SeriesController.GetSeries(System.Boolean)">

--- a/Gordon360/Services/RecIM/MatchService.cs
+++ b/Gordon360/Services/RecIM/MatchService.cs
@@ -353,6 +353,12 @@ namespace Gordon360.Services.RecIM
             var teamID = attendee.TeamID ?? 
                 _context.MatchParticipant
                 .FirstOrDefault(mp => mp.ParticipantUsername == attendee.Username && mp.MatchID == matchID).TeamID;
+
+            var attemptFind = _context.MatchParticipant
+                .FirstOrDefault(mp => mp.ParticipantUsername == attendee.Username && mp.TeamID == teamID && mp.MatchID == matchID);
+
+            if (attemptFind is not null) return attemptFind;
+
             var newAttendee = new MatchParticipant
             {
                 ParticipantUsername = attendee.Username,

--- a/Gordon360/Services/RecIM/MatchService.cs
+++ b/Gordon360/Services/RecIM/MatchService.cs
@@ -348,6 +348,36 @@ namespace Gordon360.Services.RecIM
             return res;
         }
 
+        public async Task<MatchAttendance> AddParticipantAttendanceAsync(int matchID, MatchAttendance attendee)
+        {
+            var teamID = attendee.TeamID ?? 
+                _context.MatchParticipant
+                .FirstOrDefault(mp => mp.ParticipantUsername == attendee.Username && mp.MatchID == matchID).TeamID;
+            var newAttendee = new MatchParticipant
+            {
+                ParticipantUsername = attendee.Username,
+                MatchID = matchID,
+                TeamID = teamID
+            };
+            await _context.MatchParticipant.AddAsync(newAttendee);
+            await _context.SaveChangesAsync();
+
+            return newAttendee;
+        }
+
+        public async Task DeleteParticipantAttendanceAsync(int matchID, MatchAttendance attendee)
+        {
+            var teamID = attendee.TeamID ??
+                _context.MatchParticipant
+                .FirstOrDefault(mp => mp.ParticipantUsername == attendee.Username && mp.MatchID == matchID).TeamID;
+            var res = _context.MatchParticipant
+                .FirstOrDefault(mp => mp.ParticipantUsername == attendee.Username && mp.TeamID == teamID && mp.MatchID == matchID);
+
+            _context.MatchParticipant.Remove(res);
+            await _context.SaveChangesAsync();
+        }
+
+
         public async Task<MatchViewModel> DeleteMatchCascadeAsync(int matchID)
         {
             //deletematch

--- a/Gordon360/Services/RecIM/TeamService.cs
+++ b/Gordon360/Services/RecIM/TeamService.cs
@@ -418,7 +418,7 @@ namespace Gordon360.Services.RecIM
             return _context.MatchParticipant.Count(mp => mp.TeamID == teamID && mp.ParticipantUsername == username);
         }
 
-        public async Task<IEnumerable<MatchAttendance>> AddParticipantAttendanceAsync(int matchID, ParticipantAttendanceViewModel attendance)
+        public async Task<IEnumerable<MatchAttendance>> PutParticipantAttendanceAsync(int matchID, ParticipantAttendanceViewModel attendance)
         {
             var res = new List<MatchAttendance>();
             int teamID = attendance.TeamID;

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -350,7 +350,7 @@ namespace Gordon360.Services
             bool HasTeamNameTaken(int activityID, string teamName);
             bool IsTeamCaptain(string username, int teamID);
             int GetTeamActivityID(int teamID);
-            Task<IEnumerable<MatchAttendance>> AddParticipantAttendanceAsync(int matchID, ParticipantAttendanceViewModel attendance);
+            Task<IEnumerable<MatchAttendance>> PutParticipantAttendanceAsync(int matchID, ParticipantAttendanceViewModel attendance);
             public int ParticipantAttendanceCount(int teamID, string username);
         }
 
@@ -395,6 +395,8 @@ namespace Gordon360.Services
             Task<MatchViewModel> UpdateMatchAsync(int matchID, MatchPatchViewModel match);
             Task CreateMatchTeamMappingAsync(int teamID, int matchID);
             Task<MatchViewModel> DeleteMatchCascadeAsync(int matchID);
+            Task DeleteParticipantAttendanceAsync(int matchID, MatchAttendance attendee);
+            Task<MatchAttendance> AddParticipantAttendanceAsync(int matchID, MatchAttendance attendee);
         }
     }
 


### PR DESCRIPTION
due to a proposed implementation by @cpabbot, new routes had to be devised for simplicity sake

both `post` & `delete` only **requires** username, teamID is optional

![image](https://user-images.githubusercontent.com/78386128/224521835-68bfd1e9-8618-4ded-a0b9-26dd11ca8e63.png)
example:
POST `recim/matches/{_____}/attendance`
```
{ 
    username: amos.cha
}
```
will create 1 instance of MatchParticipant, if one is found, will instantly return found object.

![image](https://user-images.githubusercontent.com/78386128/224521876-00e908b5-c4d5-4f7e-a920-709aa276d6e3.png)
example:
DELETE `recim/matches/{_____}/attendance`
```
{ 
    username: amos.cha
}
```
if no TeamID is specified, teamID by query and added to the search. 