### PR TITLE
[Rec-IM] Team Record management/automation + Bug fixes + improvements

### DIFF
--- a/Gordon360/Controllers/RecIM/TeamsController.cs
+++ b/Gordon360/Controllers/RecIM/TeamsController.cs
@@ -254,8 +254,6 @@ namespace Gordon360.Controllers.RecIM
 
             if (invite is null)
                 return NotFound("You were not invited by this team.");
-            if (invite.RoleTypeID == 0)
-                return UnprocessableEntity("Team has been deleted");
             if (username != invite.ParticipantUsername)
                 return Forbid($"You are not permitted to accept invitations for another participant.");
 

--- a/Gordon360/Exceptions/CustomExceptionFilter.cs
+++ b/Gordon360/Exceptions/CustomExceptionFilter.cs
@@ -37,12 +37,6 @@ namespace Gordon360.Exceptions
                 case UnauthorizedAccessException:
                     statusCode = HttpStatusCode.Unauthorized;
                     break;
-
-                // Not a custom exception
-                case NotFound:
-                    statusCode = HttpStatusCode.NotFound;
-                    break;
-
             }
 
             // Create Http Response

--- a/Gordon360/Exceptions/CustomExceptions.cs
+++ b/Gordon360/Exceptions/CustomExceptions.cs
@@ -21,9 +21,5 @@ namespace Gordon360.Exceptions
     {
         public string ExceptionMessage { get; set; }
     }
-    public class NotFound : Exception
-    {
-        public string ExceptionMessage { get; set; }
-    }
 }
 

--- a/Gordon360/Models/ViewModels/RecIM/MatchExtendedViewModel.cs
+++ b/Gordon360/Models/ViewModels/RecIM/MatchExtendedViewModel.cs
@@ -11,8 +11,8 @@ namespace Gordon360.Models.ViewModels.RecIM
         public DateTime StartTime { get; set; }
         public string Surface { get; set; }
         public string Status { get; set; }
-        public int SeriesID { get; set; }
         public ActivityExtendedViewModel Activity { get; set; }
+        public SeriesExtendedViewModel Series { get; set; }
         public IEnumerable<ParticipantExtendedViewModel> Attendance { get; set; }
         public IEnumerable<TeamExtendedViewModel> Team { get; set; }
     }

--- a/Gordon360/Models/ViewModels/RecIM/ParticipantExtendedViewModel.cs
+++ b/Gordon360/Models/ViewModels/RecIM/ParticipantExtendedViewModel.cs
@@ -8,8 +8,9 @@ namespace Gordon360.Models.ViewModels.RecIM
     public class ParticipantExtendedViewModel
     {
         public string Username { get; set; }
-        public string Email { get; set; }
+        public string? Email { get; set; }
         public string? Role { get; set; }
+        public int? GamesAttended { get; set; }
         public string Status { get; set; }
         public IEnumerable<ParticipantNotificationViewModel> Notification { get; set; } 
         public bool IsAdmin { get; set; }

--- a/Gordon360/Models/ViewModels/RecIM/TeamRecordViewModel.cs
+++ b/Gordon360/Models/ViewModels/RecIM/TeamRecordViewModel.cs
@@ -5,6 +5,7 @@ namespace Gordon360.Models.ViewModels.RecIM
     public class TeamRecordViewModel
     {
         public int SeriesID { get; set; }
+        public int TeamID { get; set; }
         public string Name { get; set; }
         public int WinCount { get; set; }  
         public int LossCount { get; set; }
@@ -14,6 +15,7 @@ namespace Gordon360.Models.ViewModels.RecIM
             return new TeamRecordViewModel
             {
                 SeriesID = st.SeriesID,
+                TeamID = st.TeamID,
                 Name = st.Team.Name,
                 WinCount = st.WinCount,
                 LossCount = st.LossCount,

--- a/Gordon360/Services/RecIM/MatchService.cs
+++ b/Gordon360/Services/RecIM/MatchService.cs
@@ -187,6 +187,11 @@ namespace Gordon360.Services.RecIM
                                     Opponent = other_mt.Team,
                                     TeamScore = own_mt.Score,
                                     OpposingTeamScore = other_mt.Score,
+                                    Status = own_mt.Score > other_mt.Score
+                                            ? "Win"
+                                            : own_mt.Score < other_mt.Score
+                                                ? "Lose"
+                                                : "Tie",
                                     MatchStatusID = own_mt.Match.StatusID,
                                     MatchStartTime = own_mt.Match.StartTime.SpecifyUtc(),  
                                 }

--- a/Gordon360/Services/RecIM/MatchService.cs
+++ b/Gordon360/Services/RecIM/MatchService.cs
@@ -90,7 +90,22 @@ namespace Gordon360.Services.RecIM
                             Name = _mt.Team.Name,
                         })
                         .AsEnumerable(),
-                    Activity = mt.Match.Series.Activity,
+                    Series = _context.Series
+                        .Include(s => s.SeriesTeam)
+                            .ThenInclude(s => s.Team)
+                        .Where(s => s.ID == mt.Match.SeriesID)
+                        .Select(s => new SeriesExtendedViewModel
+                        {
+                            ID = s.ID,
+                            Name = s.Name,
+                            Type = s.Type.Description,
+                            TeamStanding = s.SeriesTeam.Select(st => (TeamRecordViewModel)st)
+                        }).FirstOrDefault(),
+                    Activity = new ActivityExtendedViewModel
+                    {
+                        ID = mt.Team.ActivityID,
+                        Name = mt.Team.Activity.Name
+                    },
 
                 })
                 .FirstOrDefault();
@@ -130,22 +145,23 @@ namespace Gordon360.Services.RecIM
                             Username = mp.ParticipantUsername
                         }).AsEnumerable(),
                     
-                    SeriesID = m.SeriesID,
-                    // Team will eventually be handled by TeamService 
-                    Activity = _context.Activity
-                        .Where(a => a.ID == m.Series.ActivityID)
-                        .Select(a => new ActivityExtendedViewModel
+                    Series = _context.Series
+                        .Include(s => s.SeriesTeam)
+                            .ThenInclude(s => s.Team)
+                        .Where(s => s.ID == m.SeriesID)
+                        .Select(s => new SeriesExtendedViewModel
                         {
-                            ID = a.ID,
-                            Name = a.Name,
-                            Team = a.Team.Select(t => new TeamExtendedViewModel
-                            {
-                                ID = t.ID,
-                                Name = t.Name,
-                                Logo = t.Logo
-                            })
-                        })
-                        .FirstOrDefault(),
+                            ID = s.ID,
+                            Name = s.Name,
+                            Type = s.Type.Description,
+                            TeamStanding = s.SeriesTeam.Select(st => (TeamRecordViewModel)st)
+                        }).FirstOrDefault(),
+                    // Team will eventually be handled by TeamService 
+                    Activity = new ActivityExtendedViewModel
+                    {
+                        ID = m.Series.ActivityID,
+                        Name = m.Series.Activity.Name
+                    },
                     Team = m.MatchTeam.Select(mt => new TeamExtendedViewModel
                     {
                         ID = mt.TeamID,

--- a/Gordon360/Services/RecIM/MatchService.cs
+++ b/Gordon360/Services/RecIM/MatchService.cs
@@ -168,7 +168,7 @@ namespace Gordon360.Services.RecIM
                         Name = mt.Team.Name,
                         Status = mt.Status.Description,
                         Participant = mt.Team.ParticipantTeam
-                            .Where(pt => new int[] {0,1,6}.Contains(pt.RoleTypeID)) //roletype is either deleted, invalid, invited to join
+                            .Where(pt => !new int[] {0,1,6}.Contains(pt.RoleTypeID)) //roletype is either deleted, invalid, invited to join
                             .Select(pt => new ParticipantExtendedViewModel
                             {
                                 Username = pt.ParticipantUsername,

--- a/Gordon360/Services/RecIM/MatchService.cs
+++ b/Gordon360/Services/RecIM/MatchService.cs
@@ -312,6 +312,8 @@ namespace Gordon360.Services.RecIM
         {
 
             var teamstats = _context.MatchTeam.FirstOrDefault(mt => mt.MatchID == matchID && mt.TeamID == vm.TeamID);
+            teamstats.Score = vm.Score ?? teamstats.Score;
+            teamstats.SportsmanshipScore = vm.SportsmanshipScore ?? teamstats.SportsmanshipScore;
 
             if (teamstats.StatusID == 4 && vm.StatusID != 4 ) //statusID = 4 (forfeited) 
             {
@@ -346,14 +348,13 @@ namespace Gordon360.Services.RecIM
                         var ownRecord = seriesRecords.FirstOrDefault(st => st.TeamID == vm.TeamID);
                         // complete match
                         match.StatusID = 6; //completed
+                        teamstats.Score = 0; //remove team score of forfeit
                         opposingRecord.WinCount++;
                         ownRecord.LossCount++;
                     }
                 }
             }
 
-            teamstats.Score = vm.Score ?? teamstats.Score;
-            teamstats.SportsmanshipScore = vm.SportsmanshipScore ?? teamstats.SportsmanshipScore;
             teamstats.StatusID = vm.StatusID ?? teamstats.StatusID;
 
             await _context.SaveChangesAsync();

--- a/Gordon360/Services/RecIM/MatchService.cs
+++ b/Gordon360/Services/RecIM/MatchService.cs
@@ -380,7 +380,7 @@ namespace Gordon360.Services.RecIM
                 return newAttendee;
             }
 
-            throw new NotFound() { ExceptionMessage = "Participant was not found in a team in this match" };
+            throw new ResourceNotFoundException() { ExceptionMessage = "Participant was not found in a team in this match" };
         }
 
         public async Task DeleteParticipantAttendanceAsync(int matchID, MatchAttendance attendee)
@@ -397,7 +397,7 @@ namespace Gordon360.Services.RecIM
             var res = _context.MatchParticipant
                 .FirstOrDefault(mp => mp.ParticipantUsername == attendee.Username && mp.TeamID == teamID && mp.MatchID == matchID);
 
-            if (teamID is null || res is null) throw new NotFound() { ExceptionMessage = "Participant was not found in a team in this match" };
+            if (teamID is null || res is null) throw new ResourceNotFoundException() { ExceptionMessage = "Participant was not found in a team in this match" };
 
             _context.MatchParticipant.Remove(res);
             await _context.SaveChangesAsync();

--- a/Gordon360/Services/RecIM/MatchService.cs
+++ b/Gordon360/Services/RecIM/MatchService.cs
@@ -168,7 +168,7 @@ namespace Gordon360.Services.RecIM
                         Name = mt.Team.Name,
                         Status = mt.Status.Description,
                         Participant = mt.Team.ParticipantTeam
-                            .Where(pt => !new int[] {0,1,6}.Contains(pt.RoleTypeID)) //roletype is either deleted, invalid, invited to join
+                            .Where(pt => !new int[] {0,1,2}.Contains(pt.RoleTypeID)) //roletype is either deleted, invalid, invited to join
                             .Select(pt => new ParticipantExtendedViewModel
                             {
                                 Username = pt.ParticipantUsername,

--- a/Gordon360/Services/RecIM/ParticipantService.cs
+++ b/Gordon360/Services/RecIM/ParticipantService.cs
@@ -45,13 +45,21 @@ namespace Gordon360.Services.RecIM
 
         public ParticipantExtendedViewModel GetParticipantByUsername(string username)
         {
-            var account = _accountService.GetAccountByUsername(username);
+            string? accountEmail = null;
+            try
+            {
+                accountEmail = _accountService.GetAccountByUsername(username).Email;
+            }
+            catch
+            {
+                // if exception is thrown, we know that this was a manually added participant
+            }
             var participant = _context.Participant
                                 .Where(p => p.Username == username)
                                 .Select(p => new ParticipantExtendedViewModel
                                 {
                                     Username = username,
-                                    Email = account.Email,
+                                    Email = accountEmail,
                                     Status = p.ParticipantStatusHistory
                                                 .OrderByDescending(psh => psh.ID)
                                                 .FirstOrDefault()
@@ -102,9 +110,7 @@ namespace Gordon360.Services.RecIM
 
         public IEnumerable<TeamExtendedViewModel> GetParticipantTeams(string username)
         {
-       
-            //to be handled by teamservice
-            var teams = _context.ParticipantTeam
+                   var teams = _context.ParticipantTeam
                             .Where(pt => pt.ParticipantUsername == username && pt.RoleTypeID != 0)
                                 .Join(_context.Team.Where(t => t.StatusID != 0),
                                     pt => pt.TeamID,
@@ -128,7 +134,6 @@ namespace Gordon360.Services.RecIM
             var participants = _context.Participant.Select(p => new ParticipantExtendedViewModel
             {
                 Username = p.Username,
-                Email = _accountService.GetAccountByUsername(p.Username).Email,
                 Status = p.ParticipantStatusHistory.OrderByDescending(psh => psh.ID).FirstOrDefault().Status.Description,
                 IsAdmin = p.IsAdmin
             });

--- a/Gordon360/Services/RecIM/SeriesService.cs
+++ b/Gordon360/Services/RecIM/SeriesService.cs
@@ -644,9 +644,9 @@ namespace Gordon360.Services.RecIM
             {
                 var createdMatch = await _matchService.PostMatchAsync(new MatchUploadViewModel
                 {
-                    StartTime = series.StartDate, //default time, autoscheduling will modify
+                    StartTime = series.StartDate, //default time, will be modified by autoscheduling
                     SeriesID = series.ID,
-                    SurfaceID = 1, //temporary before 25live integration
+                    SurfaceID = 0, //default surface (undefined surface type) will be modified by autoscheduling
                     TeamIDs = teamPair
                 });
                 matches.Add(createdMatch);

--- a/Gordon360/Services/RecIM/TeamService.cs
+++ b/Gordon360/Services/RecIM/TeamService.cs
@@ -135,8 +135,9 @@ namespace Gordon360.Services.RecIM
                                                     Username = pt.ParticipantUsername,
                                                     Email = _accountService.GetAccountByUsername(pt.ParticipantUsername).Email,
                                                     Role = pt.RoleType.Description,
+                                                    GamesAttended = ParticipantAttendanceCount(teamID, pt.ParticipantUsername)
                                                 }),
-                                MatchHistory = _context.Match.Where(m => m.StatusID != 0) // deleted status
+                                MatchHistory = _context.Match.Where(m => m.StatusID == 6) // completed status
                                                 .Join(_context.MatchTeam
                                                     .Where(mt => mt.TeamID == teamID)
 

--- a/Gordon360/Services/RecIM/TeamService.cs
+++ b/Gordon360/Services/RecIM/TeamService.cs
@@ -137,7 +137,7 @@ namespace Gordon360.Services.RecIM
                                                     Role = pt.RoleType.Description,
                                                     GamesAttended = _context.MatchParticipant.Count(mp => mp.TeamID == teamID && mp.ParticipantUsername == pt.ParticipantUsername)
         }),
-                                MatchHistory = _context.Match.Where(m => m.StatusID == 6) // completed status
+                                MatchHistory = _context.Match.Where(m => m.StatusID == 6 || m.StatusID == 4) // completed or forfeited status
                                                 .Join(_context.MatchTeam
                                                     .Where(mt => mt.TeamID == teamID)
 


### PR DESCRIPTION
PR tackles the following:

Team Record Management
--
### MATCH COMPLETION
(sorry for the mess)

![image](https://user-images.githubusercontent.com/78386128/225086456-0f376a36-889e-4964-ab16-451023a1234d.png)
- Upon setting a match to `completed` the team with the highest score will be granted a win in their Series Record (expanded in the console on the right) and the opposing team[s] will be given a loss in their Series Record.

![image](https://user-images.githubusercontent.com/78386128/225087886-30dddd7c-9fd8-4545-b31b-e929903dfaeb.png)
- Upon setting the match OFF `completed` (completed -> anything else) the win/losses is granted by this match will be reverted.

### MATCH FORFEIT
![image](https://user-images.githubusercontent.com/78386128/225088319-fc344fa1-8aa7-4f59-b8c1-a836c9463935.png)
- Upon match `forfeit` status for a team, Loss is granted to the selected team and Win is granted to Opposing team
- Scores will be set to `0:1` in favor of the non-forfeit team
- Match status will be set to `forfeited`
- IF THERE ARE NO OTHER TEAMS OR THERE ARE MORE THAN 1 OPPOSING TEAM, Loss is granted to selected team ONLY

![image](https://user-images.githubusercontent.com/78386128/225092204-07650835-0684-4f6d-996c-508641b04f79.png)
- Upon switching the team OFF `forfeit` change is reverted
- Match status will be changed to `confirmed`


### Q&A
1. So what if a match is set to `completed` then a team is set to `forfeit`?
> Status is set, no loss/no win granted as completed should have already handled win/loss grants

2. So what if a team is set to `forfeit` then match is set off `completed`?
> Not possible. Exception 422 is thrown when trying to change immutable status `Forfeited`

3. What happens if both teams forfeit?
> Not possible. Exception 422 is thrown stating `Both teams cannot forfeit.`

Bug Fixes
--

### Match can propagate the wrong teams.
_* this bug never affected us as we never dealt with SeriesTeam table with no management of records, but with the new implementation, this is VITAL_

Match creation/edit on the UI side has a drop down 
![image](https://user-images.githubusercontent.com/78386128/225060506-0e9f1eb0-aced-44d6-972f-7dea3389a6e4.png)
However, this is a bug as this is the list of **every** team in the Activity. Not the ones in the Series.

![image](https://user-images.githubusercontent.com/78386128/225063162-3877dfa8-732d-43c1-a1a8-6a151fcbee71.png)
- Match will now return an instance of its Series with it's associated teams under `TeamRecord`. `TeamRecordViewModel` has also been modified to return `TeamID` so that it can be used properly as an index for the TeamListing.
- Match's Activity extended viewmodel is now truncated to only return ID & Name for routing purposes
- Associated UI PR has already tackled these changes.


### Filled Invite Loopholes /other invite glitches

- Possible race condition could leave Participants with lingering invites which could be accepted post registration period
- If a participant is removed during registration period (their status is set to 0 that they can be invited by another team) This becomes an issue if the original team tries to invite the participant. Route will now look for the existence of the deleted participant and reinstate it. (Solves the FirstOrDefault error)


Improvments
--
### ATTENDANCE
![image](https://user-images.githubusercontent.com/78386128/225073505-2d9512bd-1147-4e9d-be9d-72779ac83bfb.png)![image](https://user-images.githubusercontent.com/78386128/225085435-d4415e86-906f-4047-abd4-2779e5b8f17f.png)
- Match will not show `invalid`, `request join`, `deleted` (thus attendance cannot be set for these people)

### MATCH PAGE
- Team Match History is now properly propagated and only shows `completed` or `forfeited` matches. As well as a Status of `Win` `Loss` `Tie` that can be used to color or state game status.  

### Non-Gordon STU/FACSTAFF can now be added to our Participant Table
![image](https://user-images.githubusercontent.com/78386128/225059906-1b1b06be-e1e0-4b7d-b0d5-86494d791594.png)
UI will have to tackle the following:
- [ ] Profile does not exist
- [ ] People without a Gordon account still **CANNOT** see recim (locked behind login)
- [ ] Display the data on listing and remove attempt to link to gordon profile

This PR is a part of a larger PR. Please review the base PR... https://github.com/gordon-cs/gordon-360-api/pull/858