### PR TITLE
[Rec-IM] Image Hotfix: treat 'NONE' as null

### DIFF
--- a/Gordon360/Services/RecIM/ActivityService.cs
+++ b/Gordon360/Services/RecIM/ActivityService.cs
@@ -159,7 +159,7 @@ namespace Gordon360.Services.RecIM
             activity.EndDate = updatedActivity.EndDate ?? activity.EndDate;
             activity.SeriesScheduleID = updatedActivity.SeriesScheduleID ?? activity.SeriesScheduleID;
 
-            if (updatedActivity.Logo != null)
+            if (updatedActivity.Logo != null && updatedActivity.Logo != "NONE")
             {
                 // ImageUtils.GetImageFormat checks whether the image type is valid (jpg/jpeg/png)
                 var (extension, format, data) = ImageUtils.GetImageFormat(updatedActivity.Logo);

--- a/Gordon360/Services/RecIM/SportService.cs
+++ b/Gordon360/Services/RecIM/SportService.cs
@@ -78,7 +78,7 @@ namespace Gordon360.Services.RecIM
             sport.Rules = updatedSport.Rules ?? sport.Rules;
             
             // UNTESTED FEATURE
-            if (updatedSport.Logo != null)
+            if (updatedSport.Logo != null && updatedSport.Logo != "NONE")
             {
                 // ImageUtils.GetImageFormat checks whether the image type is valid (jpg/jpeg/png)
                 var (extension, format, data) = ImageUtils.GetImageFormat(updatedSport.Logo);

--- a/Gordon360/Services/RecIM/TeamService.cs
+++ b/Gordon360/Services/RecIM/TeamService.cs
@@ -346,7 +346,7 @@ namespace Gordon360.Services.RecIM
             t.Name = update.Name ?? t.Name;
             t.StatusID = update.StatusID ?? t.StatusID;
             
-            if (update.Logo != null)
+            if (update.Logo != null && update.Logo != "NONE")
             {
                 // ImageUtils.GetImageFormat checks whether the image type is valid (jpg/jpeg/png)
                 var (extension, format, data) = ImageUtils.GetImageFormat(update.Logo);


### PR DESCRIPTION
This pr fixes an urgent issue created by my image validation check from the just merged Rec-IM image pr. Because now the UI sends Logo as `'NONE'` if the logo is null.