### PR TITLE
[Rec-IM] StateYourBusiness.cs renaming recim variables

### DIFF
--- a/Gordon360/Authorization/StateYourBusiness.cs
+++ b/Gordon360/Authorization/StateYourBusiness.cs
@@ -54,11 +54,11 @@ namespace Gordon360.Authorization
         private IConfiguration _config;
 
         //RecIM services
-        private IParticipantService _participantService;
-        private Services.RecIM.IActivityService _activityService;
-        private ISeriesService _seriesService;
-        private ITeamService _teamService;
-        private IMatchService _matchService;
+        private IParticipantService _recimParticipantService;
+        private Services.RecIM.IActivityService _recimActivityService;
+        private ISeriesService _recimSeriesService;
+        private ITeamService _recimTeamService;
+        private IMatchService _recimMatchService;
 
         // User position at the college and their id.
         private IEnumerable<AuthGroup> user_groups { get; set; }
@@ -79,11 +79,11 @@ namespace Gordon360.Authorization
             _MyGordonContext = context.HttpContext.RequestServices.GetService<MyGordonContext>();
 
             // set RecIM services
-            _participantService = context.HttpContext.RequestServices.GetRequiredService<IParticipantService>();
-            _matchService = context.HttpContext.RequestServices.GetRequiredService<IMatchService>();
-            _teamService = context.HttpContext.RequestServices.GetRequiredService<ITeamService>();
-            _seriesService = context.HttpContext.RequestServices.GetRequiredService<ISeriesService>();
-            _activityService = context.HttpContext.RequestServices.GetRequiredService<Services.RecIM.IActivityService>();
+            _recimParticipantService = context.HttpContext.RequestServices.GetRequiredService<IParticipantService>();
+            _recimMatchService = context.HttpContext.RequestServices.GetRequiredService<IMatchService>();
+            _recimTeamService = context.HttpContext.RequestServices.GetRequiredService<ITeamService>();
+            _recimSeriesService = context.HttpContext.RequestServices.GetRequiredService<ISeriesService>();
+            _recimActivityService = context.HttpContext.RequestServices.GetRequiredService<Services.RecIM.IActivityService>();
 
             user_name = AuthUtils.GetUsername(authenticatedUser);
             user_groups = AuthUtils.GetGroups(authenticatedUser);
@@ -515,7 +515,7 @@ namespace Gordon360.Authorization
                     //fallthrough
                 case Resource.RECIM_SPORT:
                     {
-                        return _participantService.IsAdmin(user_name);
+                        return _recimParticipantService.IsAdmin(user_name);
                     }
                 default: return false;
             }
@@ -732,14 +732,14 @@ namespace Gordon360.Authorization
                     //fallthrough
                 case Resource.RECIM_SPORT:
                     {
-                        return _participantService.IsAdmin(user_name);
+                        return _recimParticipantService.IsAdmin(user_name);
                     }
 
                 case Resource.RECIM_TEAM:
                     {
                         if(context.ActionArguments.TryGetValue("teamID",out object? teamID_object) && teamID_object is int teamID)
                         {
-                            return _teamService.IsTeamCaptain(user_name, teamID) || _participantService.IsAdmin(user_name);
+                            return _recimTeamService.IsTeamCaptain(user_name, teamID) || _recimParticipantService.IsAdmin(user_name);
                         }
                         return false;
                     }
@@ -749,11 +749,11 @@ namespace Gordon360.Authorization
                         if (context.ActionArguments.TryGetValue("matchID", out object? matchID_Object) && matchID_Object is int matchID)
                         {
                             // if admin
-                            if (_participantService.IsAdmin(user_name)) return true;
+                            if (_recimParticipantService.IsAdmin(user_name)) return true;
 
                             //if ref
                             var activityID = _CCTContext.Match.Find(matchID).Series.ActivityID;
-                            return _activityService.IsReferee(user_name, activityID);
+                            return _recimActivityService.IsReferee(user_name, activityID);
                         }
                         return false;
                     }
@@ -889,7 +889,7 @@ namespace Gordon360.Authorization
                 case Resource.RECIM_SURFACE:
                     //fallthrough
                 case Resource.RECIM_MATCH:
-                    return _participantService.IsAdmin(user_name);
+                    return _recimParticipantService.IsAdmin(user_name);
                 default: return false;
             }
         }


### PR DESCRIPTION
Renamed recim variables in `StateYourBusiness.cs`:
 - `_participantService` -> `_reicmParticipantService`
 - `_activityService` -> `_recimActivityService`
 - `_teamService` -> `_recimTeamService`
 - `_seriesService` -> `_recimSeriesService`
 - `_matchService` -> `_recimMatchService`