### PR TITLE
HOTFIX: Fix Logic for Housing Admin Check

### DIFF
--- a/Gordon360/Controllers/HousingController.cs
+++ b/Gordon360/Controllers/HousingController.cs
@@ -232,22 +232,15 @@ namespace Gordon360.Controllers
             //get token data from context, username is the username of current logged in person
             var authenticatedUserIdString = User.FindFirst(ClaimTypes.NameIdentifier).Value;
 
-            bool isAdmin = _housingService.CheckIfHousingAdmin(authenticatedUserIdString); // This line can be removed once the StateYourBusiness has been implemented
-            if (isAdmin) // This line can be removed once the StateYourBusiness has been implemented
+            
+            ApartmentApplicationViewModel[] result = _housingService.GetAllApartmentApplication();
+            if (result != null)
             {
-                ApartmentApplicationViewModel[] result = _housingService.GetAllApartmentApplication();
-                if (result != null)
-                {
-                    return Ok(result);
-                }
-                else
-                {
-                    return NotFound();
-                }
+                return Ok(result);
             }
-            else // This line can be removed once the StateYourBusiness has been implemented
+            else
             {
-                throw new UnauthorizedAccessException("Unauthorized to view apartment applications"); // This line can be removed once the StateYourBusiness has been implemented
+                return NotFound();
             }
         }
     }

--- a/Gordon360/Services/HousingService.cs
+++ b/Gordon360/Services/HousingService.cs
@@ -5,6 +5,8 @@ using Gordon360.Models.ViewModels;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Gordon360.Authorization;
+using Gordon360.Enums;
 
 namespace Gordon360.Services
 {
@@ -25,7 +27,7 @@ namespace Gordon360.Services
         /// <returns> Whether or not the user is on the staff whitelist </returns>
         public bool CheckIfHousingAdmin(string username)
         {
-            return false;
+            return AuthUtils.GetGroups(username).Contains(AuthGroup.HousingAdmin);
         }
 
         /// <summary>


### PR DESCRIPTION
Housing Admins cannot currently view apartapp applications. This PR fixes that.