### PR TITLE
Small update to GetImageURL() Logic

### DIFF
--- a/Gordon360/Services/NewsService.cs
+++ b/Gordon360/Services/NewsService.cs
@@ -317,6 +317,9 @@ namespace Gordon360.Services
         {
             var serverAddress = _serverUtils.GetAddress();
             if (serverAddress is not string) throw new Exception("Could not upload Student News Image: Server Address is null");
+
+            if (serverAddress.Contains("localhost"))
+                serverAddress += '/';
             var url = $"{serverAddress}browseable/uploads/news/{filename}";
             return url;
         }


### PR DESCRIPTION
Add a `if` statement to modify the server address when running on localhost. So the images will store to the correct file path when running on both server and localhost, the localhost is also able to retrieve images stored on server.