### PR TITLE
HOTFIX: update hallchoiceid from bigint to int

### DIFF
--- a/Gordon360/Models/CCT/dbo/Housing_HallChoices.cs
+++ b/Gordon360/Models/CCT/dbo/Housing_HallChoices.cs
@@ -12,7 +12,7 @@ namespace Gordon360.Models.CCT
     public partial class Housing_HallChoices
     {
         [Key]
-        public long HallChoiceID { get; set; }
+        public int HallChoiceID { get; set; }
         public int HousingAppID { get; set; }
         public int Ranking { get; set; }
         [Required]


### PR DESCRIPTION
This PR updates EF Core with mappings to the Housing_HallChoice.HallChoiceID field so that it is an INT instead of a BIGINT.