### PR TITLE
Save Changes after deleting and return true.

### DIFF
--- a/Gordon360/Services/HousingService.cs
+++ b/Gordon360/Services/HousingService.cs
@@ -41,7 +41,8 @@ namespace Gordon360.Services
             try
             {
                 var result = _context.Housing_Applications.Remove(new Housing_Applications { HousingAppID = applicationID });
-                return result == null;
+                _context.SaveChanges();
+                return true;
             }
             catch
             {


### PR DESCRIPTION
Apart App did not save changes after deleting an application (probably my fault). I added a call to `_context.SaveChanges()`.

Also, the happy path for deletion was comparing the EF Core deletion result object to `null`, expecting it to be `null` if the deletion succeeded. However, the `result` object is never null so this was always returning `false` even when deletion succeeded. In the event that deletion fails, EF Core throws an error which is caught by the surrounding `try catch` block, so we can always return true from the happy path because if no error was thrown then deletion succeeded.