### PR TITLE
[Rec-IM] Create & Edit custom participants

### DIFF
--- a/Gordon360/Authorization/StateYourBusiness.cs
+++ b/Gordon360/Authorization/StateYourBusiness.cs
@@ -511,6 +511,8 @@ namespace Gordon360.Authorization
                     return true;
                 case Resource.NEWS:
                     return true;
+                case Resource.RECIM_PARTICIPANT_ADMIN:
+                    //fallthrough
                 case Resource.RECIM_ACTIVITY:
                     //fallthrough
                 case Resource.RECIM_SERIES:

--- a/Gordon360/Controllers/RecIM/ParticipantsController.cs
+++ b/Gordon360/Controllers/RecIM/ParticipantsController.cs
@@ -2,6 +2,7 @@
 using Gordon360.Models.ViewModels.RecIM;
 using Gordon360.Services.RecIM;
 using Gordon360.Static.Names;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -9,6 +10,7 @@ using System.Threading.Tasks;
 namespace Gordon360.Controllers.RecIM
 {
     [Route("api/recim/[controller]")]
+    [AllowAnonymous]
     public class ParticipantsController : GordonControllerBase
     {
         private readonly IParticipantService _participantService;
@@ -72,7 +74,7 @@ namespace Gordon360.Controllers.RecIM
 
         [HttpPut]
         [Route("{username}/custom")]
-        [StateYourBusiness(operation = Operation.ADD, resource = Resource.RECIM_PARTICIPANT_ADMIN)]
+        //[StateYourBusiness(operation = Operation.ADD, resource = Resource.RECIM_PARTICIPANT_ADMIN)]
         public async Task<ActionResult<ParticipantExtendedViewModel>> AddCustomParticipant(string username, [FromBody] CustomParticipantViewModel newCustomParticipant)
         {
             var participant = await _participantService.PostCustomParticipantAsync(username, newCustomParticipant);
@@ -81,7 +83,7 @@ namespace Gordon360.Controllers.RecIM
 
         [HttpPatch]
         [Route("{username}/custom/update")]
-        [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_PARTICIPANT_ADMIN)]
+        //[StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_PARTICIPANT_ADMIN)]
         public async Task<ActionResult<ParticipantExtendedViewModel>> SetCustomParticipant(string username, [FromBody] CustomParticipantViewModel updatedCustomParticipant)
         {
             var p = _participantService.GetParticipantByUsername(username);
@@ -94,7 +96,7 @@ namespace Gordon360.Controllers.RecIM
 
         [HttpPatch]
         [Route("{username}/admin")]
-        [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_PARTICIPANT_ADMIN)]
+        //[StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_PARTICIPANT_ADMIN)]
         public async Task<ActionResult<ParticipantExtendedViewModel>> SetParticipantAdminStatus(string username, [FromBody] bool isAdmin)
         {
             var participant = await _participantService.SetParticipantAdminStatusAsync(username,isAdmin);
@@ -103,7 +105,7 @@ namespace Gordon360.Controllers.RecIM
 
         [HttpPatch]
         [Route("{username}/emails")]
-        [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_PARTICIPANT)]
+        //[StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_PARTICIPANT)]
         public async Task<ActionResult<ParticipantExtendedViewModel>> SetParticipantAllowEmails(string username, [FromBody] bool allowEmails)
         {
             var participant = await _participantService.UpdateParticipantAllowEmailsAsync(username, allowEmails);
@@ -122,7 +124,7 @@ namespace Gordon360.Controllers.RecIM
 
         [HttpPatch]
         [Route("{username}/activities")]
-        [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_PARTICIPANT)]
+        //[StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_PARTICIPANT)]
         public async Task<ActionResult> UpdateParticipantActivity(string username, ParticipantActivityPatchViewModel updatedParticipantActivity)
         {
 
@@ -132,7 +134,7 @@ namespace Gordon360.Controllers.RecIM
 
         [HttpPatch]
         [Route("{username}/status")]
-        [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_PARTICIPANT)]
+        //[StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_PARTICIPANT)]
         public async Task<ActionResult<ParticipantStatusHistoryViewModel>> UpdateParticipantStatus(string username, ParticipantStatusPatchViewModel updatedParticipant)
         {
             var status = await _participantService.UpdateParticipantStatusAsync(username, updatedParticipant);

--- a/Gordon360/Controllers/RecIM/ParticipantsController.cs
+++ b/Gordon360/Controllers/RecIM/ParticipantsController.cs
@@ -104,7 +104,7 @@ namespace Gordon360.Controllers.RecIM
         [HttpPut]
         [Route("{username}/custom")]
         [StateYourBusiness(operation = Operation.ADD, resource = Resource.RECIM_PARTICIPANT_ADMIN)]
-        public async Task<ActionResult<ParticipantExtendedViewModel>> AddCustomParticipant(string username, [FromBody] CustomParticipantViewModel newCustomParticipant)
+        public async Task<ActionResult<ParticipantExtendedViewModel>> AddCustomParticipantAsync(string username, [FromBody] CustomParticipantViewModel newCustomParticipant)
         {
             var participant = await _participantService.PostCustomParticipantAsync(username, newCustomParticipant);
             return CreatedAtAction(nameof(GetParticipantByUsername), new { username = participant.Username }, participant);

--- a/Gordon360/Controllers/RecIM/ParticipantsController.cs
+++ b/Gordon360/Controllers/RecIM/ParticipantsController.cs
@@ -113,7 +113,7 @@ namespace Gordon360.Controllers.RecIM
         [HttpPatch]
         [Route("{username}/custom/update")]
         [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_PARTICIPANT_ADMIN)]
-        public async Task<ActionResult<ParticipantExtendedViewModel>> SetCustomParticipant(string username, [FromBody] CustomParticipantViewModel updatedCustomParticipant)
+        public async Task<ActionResult<ParticipantExtendedViewModel>> SetCustomParticipantAsync(string username, [FromBody] CustomParticipantViewModel updatedCustomParticipant)
         {
             var p = _participantService.GetParticipantByUsername(username);
             if (!p.IsCustom)

--- a/Gordon360/Controllers/RecIM/ParticipantsController.cs
+++ b/Gordon360/Controllers/RecIM/ParticipantsController.cs
@@ -70,6 +70,28 @@ namespace Gordon360.Controllers.RecIM
             return CreatedAtAction(nameof(GetParticipantByUsername), new { username = participant.Username }, participant);
         }
 
+        [HttpPut]
+        [Route("{username}/custom")]
+        [StateYourBusiness(operation = Operation.ADD, resource = Resource.RECIM_PARTICIPANT_ADMIN)]
+        public async Task<ActionResult<ParticipantExtendedViewModel>> AddCustomParticipant(string username, [FromBody] CustomParticipantViewModel newCustomParticipant)
+        {
+            var participant = await _participantService.PostCustomParticipantAsync(username, newCustomParticipant);
+            return CreatedAtAction(nameof(GetParticipantByUsername), new { username = participant.Username }, participant);
+        }
+
+        [HttpPatch]
+        [Route("{username}/custom/update")]
+        [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_PARTICIPANT_ADMIN)]
+        public async Task<ActionResult<ParticipantExtendedViewModel>> SetCustomParticipant(string username, [FromBody] CustomParticipantViewModel updatedCustomParticipant)
+        {
+            var p = _participantService.GetParticipantByUsername(username);
+            if (!p.IsCustom)
+                return UnprocessableEntity("This is not a custom participant");
+
+            var participant = await _participantService.UpdateCustomParticipantAsync(username, updatedCustomParticipant);
+            return CreatedAtAction(nameof(GetParticipantByUsername), new { username = participant.Username, isCustom = participant.IsCustom }, participant);
+        }
+
         [HttpPatch]
         [Route("{username}/admin")]
         [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_PARTICIPANT_ADMIN)]
@@ -116,6 +138,5 @@ namespace Gordon360.Controllers.RecIM
             var status = await _participantService.UpdateParticipantStatusAsync(username, updatedParticipant);
             return CreatedAtAction(nameof(GetParticipantByUsername), new { username = status.ParticipantUsername }, status);
         }
-
     }
 }

--- a/Gordon360/Controllers/RecIM/ParticipantsController.cs
+++ b/Gordon360/Controllers/RecIM/ParticipantsController.cs
@@ -15,7 +15,6 @@ using System.Threading.Tasks;
 namespace Gordon360.Controllers.RecIM
 {
     [Route("api/recim/[controller]")]
-    [AllowAnonymous]
     public class ParticipantsController : GordonControllerBase
     {
         private readonly IParticipantService _participantService;

--- a/Gordon360/Controllers/RecIM/ParticipantsController.cs
+++ b/Gordon360/Controllers/RecIM/ParticipantsController.cs
@@ -154,7 +154,7 @@ namespace Gordon360.Controllers.RecIM
 
         [HttpPatch]
         [Route("{username}/activities")]
-        //[StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_PARTICIPANT)]
+        [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_PARTICIPANT)]
         public async Task<ActionResult> UpdateParticipantActivity(string username, ParticipantActivityPatchViewModel updatedParticipantActivity)
         {
 

--- a/Gordon360/Controllers/RecIM/ParticipantsController.cs
+++ b/Gordon360/Controllers/RecIM/ParticipantsController.cs
@@ -74,8 +74,8 @@ namespace Gordon360.Controllers.RecIM
         [Route("search/{searchString}")]
         public async Task<ActionResult<IEnumerable<BasicInfoViewModel>>> SearchAsync(string searchString)
         {
-            //var username = AuthUtils.GetUsername(User);
-            var isAdmin = true;// _participantService.IsAdmin(username);
+            var username = AuthUtils.GetUsername(User);
+            var isAdmin = _participantService.IsAdmin(username);
 
             var accounts = await _accountService.GetAllBasicInfoExceptAlumniAsync();
             if (isAdmin)

--- a/Gordon360/Controllers/RecIM/TeamsController.cs
+++ b/Gordon360/Controllers/RecIM/TeamsController.cs
@@ -122,7 +122,7 @@ namespace Gordon360.Controllers.RecIM
         [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_TEAM)]
         public async Task<ActionResult<ParticipantTeamViewModel>> AddParticipantToTeam(int teamID, ParticipantTeamUploadViewModel participant)
         {
-            var inviterUsername = "";// AuthUtils.GetUsername(User);
+            var inviterUsername = AuthUtils.GetUsername(User);
             var activityID = _teamService.GetTeamActivityID(teamID);
             if (!_teamService.HasUserJoined(activityID, participant.Username) || _participantService.IsAdmin(inviterUsername))
             {

--- a/Gordon360/Controllers/RecIM/TeamsController.cs
+++ b/Gordon360/Controllers/RecIM/TeamsController.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 namespace Gordon360.Controllers.RecIM
 {
     [Route("api/recim/[controller]")]
-    [AllowAnonymous]
     public class TeamsController : GordonControllerBase
     {
         private readonly ITeamService _teamService;

--- a/Gordon360/Controllers/RecIM/TeamsController.cs
+++ b/Gordon360/Controllers/RecIM/TeamsController.cs
@@ -3,6 +3,7 @@ using Gordon360.Exceptions;
 using Gordon360.Models.ViewModels.RecIM;
 using Gordon360.Services.RecIM;
 using Gordon360.Static.Names;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -10,6 +11,7 @@ using System.Threading.Tasks;
 namespace Gordon360.Controllers.RecIM
 {
     [Route("api/recim/[controller]")]
+    [AllowAnonymous]
     public class TeamsController : GordonControllerBase
     {
         private readonly ITeamService _teamService;
@@ -120,7 +122,7 @@ namespace Gordon360.Controllers.RecIM
         [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_TEAM)]
         public async Task<ActionResult<ParticipantTeamViewModel>> AddParticipantToTeam(int teamID, ParticipantTeamUploadViewModel participant)
         {
-            var inviterUsername = AuthUtils.GetUsername(User);
+            var inviterUsername = "";// AuthUtils.GetUsername(User);
             var activityID = _teamService.GetTeamActivityID(teamID);
             if (!_teamService.HasUserJoined(activityID, participant.Username) || _participantService.IsAdmin(inviterUsername))
             {

--- a/Gordon360/Models/CCT/RecIM/Participant.cs
+++ b/Gordon360/Models/CCT/RecIM/Participant.cs
@@ -9,6 +9,7 @@ using Microsoft.EntityFrameworkCore;
 namespace Gordon360.Models.CCT
 {
     [Table("Participant", Schema = "RecIM")]
+    [Index("Username", "IsCustom", Name = "Unique_Participant", IsUnique = true)]
     public partial class Participant
     {
         public Participant()
@@ -31,6 +32,13 @@ namespace Gordon360.Models.CCT
         public string SpecifiedGender { get; set; }
         [Required]
         public bool? AllowEmails { get; set; }
+        public bool IsCustom { get; set; }
+        [StringLength(20)]
+        [Unicode(false)]
+        public string FirstName { get; set; }
+        [StringLength(20)]
+        [Unicode(false)]
+        public string LastName { get; set; }
 
         [InverseProperty("ParticipantUsernameNavigation")]
         public virtual ICollection<MatchParticipant> MatchParticipant { get; set; }

--- a/Gordon360/Models/CCT/RecIM/Participant.cs
+++ b/Gordon360/Models/CCT/RecIM/Participant.cs
@@ -39,6 +39,9 @@ namespace Gordon360.Models.CCT
         [StringLength(20)]
         [Unicode(false)]
         public string LastName { get; set; }
+        [StringLength(50)]
+        [Unicode(false)]
+        public string Email { get; set; }
 
         [InverseProperty("ParticipantUsernameNavigation")]
         public virtual ICollection<MatchParticipant> MatchParticipant { get; set; }

--- a/Gordon360/Models/ViewModels/RecIM/CustomParticipantViewModel.cs
+++ b/Gordon360/Models/ViewModels/RecIM/CustomParticipantViewModel.cs
@@ -1,0 +1,10 @@
+﻿namespace Gordon360.Models.ViewModels.RecIM
+{
+    public class CustomParticipantViewModel
+    {
+        public bool? AllowEmails { get; set; }
+        public string? SpecifiedGender { get; set; }
+        public string? FirstName { get; set; }
+        public string? LastName { get; set; }
+    }
+}

--- a/Gordon360/Models/ViewModels/RecIM/CustomParticipantViewModel.cs
+++ b/Gordon360/Models/ViewModels/RecIM/CustomParticipantViewModel.cs
@@ -3,6 +3,7 @@
     public class CustomParticipantViewModel
     {
         public bool? AllowEmails { get; set; }
+        public string? Email { get; set; }
         public string? SpecifiedGender { get; set; }
         public string? FirstName { get; set; }
         public string? LastName { get; set; }

--- a/Gordon360/Models/ViewModels/RecIM/ParticipantExtendedViewModel.cs
+++ b/Gordon360/Models/ViewModels/RecIM/ParticipantExtendedViewModel.cs
@@ -16,6 +16,9 @@ namespace Gordon360.Models.ViewModels.RecIM
         public bool IsAdmin { get; set; }
         public bool AllowEmails { get; set; }
         public string SpecifiedGender { get; set; }
+        public bool IsCustom { get; set; }
+        public string? FirstName { get; set; }
+        public string? LastName { get; set; }
 
         public static implicit operator ParticipantExtendedViewModel(ACCOUNT a)
         {

--- a/Gordon360/Services/RecIM/MatchService.cs
+++ b/Gordon360/Services/RecIM/MatchService.cs
@@ -17,12 +17,14 @@ namespace Gordon360.Services.RecIM
     {
         private readonly CCTContext _context;
         private readonly IAccountService _accountService;
+        private readonly IParticipantService _participantService;
 
 
-        public MatchService(CCTContext context,  IAccountService accountService)
+        public MatchService(CCTContext context,  IAccountService accountService, IParticipantService participantService)
         {
             _context = context;
             _accountService = accountService;
+            _participantService = participantService;
         }
 
         public MatchViewModel GetSimpleMatchViewByID(int matchID)
@@ -176,7 +178,11 @@ namespace Gordon360.Services.RecIM
                                 .Select(pt => new ParticipantExtendedViewModel
                                 {
                                     Username = pt.ParticipantUsername,
-                                    Email = _accountService.GetAccountByUsername(pt.ParticipantUsername).Email,
+
+                                    FirstName = _participantService.GetParticipantFirstName(pt.ParticipantUsername),
+                                    LastName = _participantService.GetParticipantLastName(pt.ParticipantUsername),
+                                    IsCustom = _participantService.GetParticipantIsCustom(pt.ParticipantUsername),
+                                    Email = _context.Participant.First(p => p.Username == pt.ParticipantUsername).Email ?? _accountService.GetAccountByUsername(pt.ParticipantUsername).Email,
                                     Role = pt.RoleType.Description
                                 }),
                             MatchHistory = _context.MatchTeam.Where(_mt => _mt.TeamID == mt.TeamID && _mt.Match.StatusID == 6)

--- a/Gordon360/Services/RecIM/ParticipantService.cs
+++ b/Gordon360/Services/RecIM/ParticipantService.cs
@@ -395,7 +395,7 @@ namespace Gordon360.Services.RecIM
 
         private string GetCustomUnqiueUsername(string username)
         {
-            var customSuffix = "Custom";
+            var customSuffix = ".custom";
             if (_context.Participant.Any((p) => p.Username == username + customSuffix && p.IsCustom == true))
             {
                 var index = 2;

--- a/Gordon360/Services/RecIM/ParticipantService.cs
+++ b/Gordon360/Services/RecIM/ParticipantService.cs
@@ -266,7 +266,6 @@ namespace Gordon360.Services.RecIM
             return participant;
         }
 
-        // change to ParticipantUploadViewModel: a new viewmodel only for adds custom participants
         public async Task<ParticipantExtendedViewModel> PostCustomParticipantAsync(string username, CustomParticipantViewModel newCustomParticipant)
         {
             var newUsername = GetCustomUnqiueUsername(username);

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -370,11 +370,13 @@ namespace Gordon360.Services
             ParticipantExtendedViewModel GetParticipantByUsername(string username);
             IEnumerable<TeamExtendedViewModel> GetParticipantTeams(string username);
             Task<ParticipantExtendedViewModel> PostParticipantAsync(string username, int? statusID = 4);
+            Task<ParticipantExtendedViewModel> PostCustomParticipantAsync(string username, CustomParticipantViewModel newCustomParticipant);
             Task<ParticipantExtendedViewModel> SetParticipantAdminStatusAsync(string username, bool isAdmin);
             Task<ParticipantNotificationViewModel> SendParticipantNotificationAsync(string username, ParticipantNotificationUploadViewModel notificationVM);
             Task<ParticipantActivityViewModel> UpdateParticipantActivityAsync(string username, ParticipantActivityPatchViewModel updatedParticipant);
             Task<ParticipantStatusHistoryViewModel> UpdateParticipantStatusAsync(string username, ParticipantStatusPatchViewModel participantStatus);
             Task<ParticipantExtendedViewModel> UpdateParticipantAllowEmailsAsync(string username, bool allowEmails);
+            Task<ParticipantExtendedViewModel> UpdateCustomParticipantAsync(string username, CustomParticipantViewModel updatedParticipant);
             bool IsParticipant(string username);
             bool IsAdmin(string username);
         }

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -366,6 +366,10 @@ namespace Gordon360.Services
         {
             IEnumerable<LookupViewModel>? GetParticipantLookup(string type);
             IEnumerable<ParticipantExtendedViewModel> GetParticipants();
+            string GetParticipantFirstName(string username);
+            string GetParticipantLastName(string username);
+            bool GetParticipantIsCustom(string username);
+            IEnumerable<BasicInfoViewModel> GetAllCustomParticipantsBasicInfo();
             IEnumerable<ParticipantStatusExtendedViewModel> GetParticipantStatusHistory(string username);
             ParticipantExtendedViewModel GetParticipantByUsername(string username);
             IEnumerable<TeamExtendedViewModel> GetParticipantTeams(string username);


### PR DESCRIPTION
This pr adds new routes for creating and updating a custom participant,
also improves the method `GetParticipants` in `ParticipantService.cs` by using a double left join on Participant table and added order by `username`, so it's easier to find a participant on Admin page.

Three new columns added to `CCT.RecIM.Participant` table:
 - IsCustom
 - FirstName
 - LastName
PS: `FirstName` and `LastName` are only used to store custom participants' names, `null` for others.

UI pr: https://github.com/gordon-cs/gordon-360-ui/pull/1780.