### PR TITLE
[Rec-IM] scheduling finale (probably)

### DIFF
--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -2366,7 +2366,13 @@
             <param name="seriesID"></param>
             <returns>Created Match objects</returns>
         </member>
-        <member name="M:Gordon360.Services.RecIM.SeriesService.ScheduleElimRoundAsync(System.Collections.Generic.IEnumerable{Gordon360.Models.CCT.SeriesTeam})">
+        <member name="M:Gordon360.Services.RecIM.SeriesService.ScheduleDoubleElimination(System.Int32)">
+            <summary>
+            Current double elimination autoscheduling will consider "play-in" as a "play-in" tournament
+            Losers of the play in do not count for the double elimination bracket.
+            </summary>
+        </member>
+        <member name="M:Gordon360.Services.RecIM.SeriesService.ScheduleElimRoundAsync(System.Collections.Generic.IEnumerable{Gordon360.Models.CCT.SeriesTeam},System.Boolean)">
             <summary>
             Goal of this function is to generate a single elimination round.
             On the first possible round, this would imply handling teams with byes to ensure

--- a/Gordon360/Services/RecIM/MatchService.cs
+++ b/Gordon360/Services/RecIM/MatchService.cs
@@ -309,7 +309,8 @@ namespace Gordon360.Services.RecIM
             await _context.SaveChangesAsync();
             foreach (var teamID in newMatch.TeamIDs)
             {
-                await CreateMatchTeamMappingAsync(teamID, match.ID);
+                if (teamID != -1) // do not create team mappings for fake teams
+                    await CreateMatchTeamMappingAsync(teamID, match.ID);
             }
             await _context.SaveChangesAsync();
             return match;

--- a/Gordon360/Services/RecIM/MatchService.cs
+++ b/Gordon360/Services/RecIM/MatchService.cs
@@ -333,6 +333,9 @@ namespace Gordon360.Services.RecIM
 
             var teamstats = _context.MatchTeam.FirstOrDefault(mt => mt.MatchID == matchID && mt.TeamID == vm.TeamID);
             var match = _context.Match.Find(matchID);
+
+            if (match.SeriesID == 6) throw new UnprocessibleEntity() { ExceptionMessage = "Stats cannot be updated for a completed match" };
+
             teamstats.Score = vm.Score ?? teamstats.Score;
             teamstats.SportsmanshipScore = vm.SportsmanshipScore ?? teamstats.SportsmanshipScore;
 

--- a/Gordon360/Services/RecIM/SeriesService.cs
+++ b/Gordon360/Services/RecIM/SeriesService.cs
@@ -580,6 +580,16 @@ namespace Gordon360.Services.RecIM
             var matchIDs = elimScheduler.Match.Select(es => es.ID);
             // int numNonBye = matchIDs.count() - teamsInNextRound; // uncomment this if we decide that there should be a break day between non-byes and official bracket
 
+
+            // at this point first round matches have been made, bye round matches have been made
+
+            //@TODO
+            /**
+             *  1) losing teams in the bye round? not going to handle, bye round will be considered a play-in 
+             *  2) "second bracket" to be made (mirrors first)
+             */
+
+
             return createdMatches;
         }
 
@@ -838,7 +848,7 @@ namespace Gordon360.Services.RecIM
             };
         }
 
-        private async Task<IEnumerable<MatchBracketViewModel>> CreateEliminationBracket(List<int> matchesIDs, int roundNumber)
+        private async Task<IEnumerable<MatchBracketViewModel>> CreateEliminationBracket(List<int> matchesIDs, int roundNumber, bool isLosers = false)
         {
             var res = new List<MatchBracketViewModel>();
             int rounds = (int)Math.Log(matchesIDs.Count(), 2);
@@ -868,7 +878,7 @@ namespace Gordon360.Services.RecIM
                         RoundNumber = roundNumber,
                         RoundOf = matchArr.Length * 2,
                         SeedIndex = j,
-                        IsLosers = false //Double elimination not handled yet
+                        IsLosers = isLosers
                     };
                     await _context.MatchBracket.AddAsync(matchBracketPlacement);
                     res.Add(matchBracketPlacement);

--- a/Gordon360/Services/RecIM/SeriesService.cs
+++ b/Gordon360/Services/RecIM/SeriesService.cs
@@ -541,7 +541,11 @@ namespace Gordon360.Services.RecIM
             }
             return createdMatches;
         }
-
+        
+        /// <summary>
+        /// Current double elimination autoscheduling will consider "play-in" as a "play-in" tournament
+        /// Losers of the play in do not count for the double elimination bracket.
+        /// </summary>
         private async Task<IEnumerable<MatchViewModel>> ScheduleDoubleElimination(int seriesID)
         {
             var createdMatches = new List<MatchViewModel>();
@@ -586,8 +590,10 @@ namespace Gordon360.Services.RecIM
             //@TODO
             /**
              *  1) losing teams in the bye round? not going to handle, bye round will be considered a play-in 
+             *      * ammendment, will do it...
              *  2) "second bracket" to be made (mirrors first)
              */
+            var byeLoserTeams = new List<int>();
             int byeMatchCounter = 0;
             foreach (var matchID in matchIDs)
             {
@@ -766,6 +772,7 @@ namespace Gordon360.Services.RecIM
             }
             return createdMatches;
         }
+
 
         /// <summary>
         /// Goal of this function is to generate a single elimination round.

--- a/Gordon360/Services/RecIM/SeriesService.cs
+++ b/Gordon360/Services/RecIM/SeriesService.cs
@@ -587,11 +587,6 @@ namespace Gordon360.Services.RecIM
             // at this point first round matches have been made, bye round matches have been made
 
 
-            //@TODO
-            /**
-             *  1) losing teams in the bye round? not going to handle, bye round will be considered a play-in 
-             *  2) "second bracket" to be made (mirrors first)
-             */
             foreach (var matchID in matchIDs)
             {
                 if (surfaceIndex == availableSurfaces.Length)
@@ -672,10 +667,10 @@ namespace Gordon360.Services.RecIM
                 roundNumber++;
                 teamsInNextRound /= 2;
             }
-            //temporary solution: losers bracket will be played in the time between winners finals -> grandfinals
+            //current solution: losers bracket will be played in the time between winners finals -> grandfinals
             int j = 0;
             roundNumber = 0;
-            while (numOfBracketParticipatingTeams > 1)
+            while (numOfBracketParticipatingTeams > 0)
             {
                 //reset between rounds + prime the pump from first round
                 day = day.AddDays(1);
@@ -685,11 +680,9 @@ namespace Gordon360.Services.RecIM
                 dayOfWeek = day.ConvertFromUtc(Time_Zones.EST).DayOfWeek.ToString();
                 surfaceIndex = 0;
 
-                // round modfier, for a lack of a better name, is used to calculate losers current round and how to handle the round
-                // - losers bracket alternates between matches among the teams of the lower bracket and teams that JUST lost from the winners side
-                var roundModifier = j % 2 == 0 ? 2 : 1;
 
-                for (int i = 0; i < numOfBracketParticipatingTeams / roundModifier; i++)
+                // - losers bracket alternates between matches among the teams of the lower bracket and teams that JUST lost from the winners side
+                for (int i = 0; i < numOfBracketParticipatingTeams / (j % 2 == 0 ? 2 : 1); i++)
                 {
                     if (surfaceIndex == availableSurfaces.Length)
                     {
@@ -727,12 +720,10 @@ namespace Gordon360.Services.RecIM
                     await _context.SaveChangesAsync();
                     surfaceIndex++;
                 }
-                numOfBracketParticipatingTeams /= roundModifier;
+                numOfBracketParticipatingTeams /= (j % 2 == 0 ? 2 : 1);
                 j++;
                 roundNumber++;
             }
-
-
 
             // GRAND FINALS (played on the same day [if possible] as the losers bracket)
             for (int i = 1; i < 3; i++)


### PR DESCRIPTION
Double Elimination
--
Handles Lower Bracket as well as its associated bracket creation and seeding. 
2 Downsides of the current implementation:
1) all lower bracket matches are played in between Winners Finals and Grand Finals. 
2) all byes do not count towards double elimination and are instead handled as a "play-in" tournament. Winners get to participate, losers don't.


Timing the correct games to be played in conjunction with the winner's side proved to be incredibly irritating and would result in inefficiency and potentially a lot of bugs. Current system is more robust but obviously doesn't have the "optimal" pathing. However, this is definitely the second best option by far as this allows the "difficulty" of a losers run to still exist. 

Handling byes in double elimination "properly" causes byes to have to occur CONSTANTLY throughout the lower bracket due to the "RoundOf" of the lower bracket not always matching the winner bracket. Thus, I chose to not handle it after doing some head scratching and thinking of a methodology of potentially handling it. 

- [x] double elimination
- [x] double elimination bracketing
- [x] scan for bugs