### PR TITLE
Fix logging

### DIFF
--- a/Gordon360/Controllers/LogController.cs
+++ b/Gordon360/Controllers/LogController.cs
@@ -13,10 +13,6 @@ namespace Gordon360.Controllers
     {
         private readonly IErrorLogService _errorLogService;
 
-        public LogController(CCTContext context)
-        {
-            _errorLogService = new ErrorLogService(context);
-        }
         public LogController(IErrorLogService errorLogService)
         {
             _errorLogService = errorLogService;

--- a/Gordon360/Controllers/LogController.cs
+++ b/Gordon360/Controllers/LogController.cs
@@ -1,5 +1,4 @@
 ﻿using Gordon360.Authorization;
-using Gordon360.Models.CCT.Context;
 using Gordon360.Exceptions;
 using Gordon360.Models.CCT;
 using Gordon360.Services;
@@ -36,23 +35,6 @@ namespace Gordon360.Controllers
             var result = _errorLogService.Log(error_message);
 
             return Created("error log", result);
-        }
-
-
-        /// <summary>Create a new error log item to be added to database</summary>
-        /// <param name="error_log">The error log containing the ERROR_TIME, and the LOG_MESSAGE</param>
-        /// <returns></returns>
-        /// <remarks>Posts a new error_log to the server to be added into the database. Useful if you want to input the datetime in the front end for greater accuracy</remarks>
-        // POST api/<controller>
-        [HttpPost]
-        [Route("add", Name = "error_add")]
-        [StateYourBusiness(operation = Operation.ADD, resource = Resource.ERROR_LOG)]
-        public ActionResult<ERROR_LOG> Post([FromBody] ERROR_LOG error_log)
-        {
-            var result = _errorLogService.Add(error_log);
-
-            return Created("error log", result);
-
         }
     }
 }

--- a/Gordon360/Program.cs
+++ b/Gordon360/Program.cs
@@ -46,6 +46,7 @@ builder.Services.AddDbContext<CCTContext>(options =>
 builder.Services.AddScoped<IAccountService, AccountService>();
 builder.Services.AddScoped<IActivityService, ActivityService>();
 builder.Services.AddScoped<IEventService, EventService>();
+builder.Services.AddScoped<IErrorLogService, ErrorLogService>();
 builder.Services.AddScoped<IProfileService, ProfileService>();
 builder.Services.AddScoped<IAddressesService, AddressesService>();
 builder.Services.AddScoped<IMembershipService, MembershipService>();


### PR DESCRIPTION
Our error logging routes have been broken since the API Upgrade in fall of 2022. The issue is that LogController had two constructors, which were somehow ambiguous to ASP.NET Core's dependency injection process, so the controller was failing to construct and the log routes were all returning 500 errors.

This is a major issue for our ID Uploader, which apparently fails if the log routes fail.