### PR TITLE
Add support for OAuth authentication in SwaggerUI

### DIFF
--- a/Gordon360/Authorization/AzureAdConfig.cs
+++ b/Gordon360/Authorization/AzureAdConfig.cs
@@ -1,0 +1,7 @@
+﻿public record AzureAdConfig
+{
+    public string Instance { get; init; }
+    public string ClientId { get; init; }
+    public string TenantId { get; init; }
+    public string Audience { get; init; }
+}


### PR DESCRIPTION
With this PR, I have added support for OAuth2.0 authentication to Azure AD from within the Swagger UI API interface. This will enable quick testing of authorized routes, which should dramatically improve developer experience and productivity.