### PR TITLE
added a fromquery parameter to get schdules for a specific term

### DIFF
--- a/Gordon360/Controllers/ScheduleController.cs
+++ b/Gordon360/Controllers/ScheduleController.cs
@@ -77,20 +77,17 @@ namespace Gordon360.Controllers
             var authenticatedUserUsername = AuthUtils.GetUsername(User);
 
             var groups = AuthUtils.GetGroups(username);
-            var id = _accountService.GetAccountByUsername(username).GordonID;
-            var scheduleControl = _context.Schedule_Control.Find(id);
 
             IEnumerable<ScheduleViewModel>? scheduleResult = null;
-            if (authenticatedUserUsername == username)
-            {
-                scheduleResult = await _scheduleService.GetScheduleStudentAsync(username, sessionID);
-            }
 
             if (groups.Contains(AuthGroup.Student))
             {
-                int schedulePrivacy = scheduleControl?.IsSchedulePrivate ?? 1;
+                if (authenticatedUserUsername == username)
+                {
+                    scheduleResult = await _scheduleService.GetScheduleStudentAsync(username, sessionID);
 
-                if (viewerGroups.Contains(AuthGroup.Police) || viewerGroups.Contains(AuthGroup.SiteAdmin))
+                }
+                else if (viewerGroups.Contains(AuthGroup.Police) || viewerGroups.Contains(AuthGroup.SiteAdmin))
                 {
                     scheduleResult = await _scheduleService.GetScheduleStudentAsync(username, sessionID);
 

--- a/Gordon360/Controllers/ScheduleController.cs
+++ b/Gordon360/Controllers/ScheduleController.cs
@@ -73,6 +73,9 @@ namespace Gordon360.Controllers
             //probably needs privacy stuff like ProfilesController and service
             var viewerGroups = AuthUtils.GetGroups(User);
 
+
+            var authenticatedUserUsername = AuthUtils.GetUsername(User);
+
             var groups = AuthUtils.GetGroups(username);
             var id = _accountService.GetAccountByUsername(username).GordonID;
             var scheduleControl = _context.Schedule_Control.Find(id);
@@ -87,10 +90,6 @@ namespace Gordon360.Controllers
                     scheduleResult = await _scheduleService.GetScheduleStudentAsync(username, sessionID);
 
                 }
-                else if (viewerGroups.Contains(AuthGroup.Student) && schedulePrivacy == 1)
-                {
-                    scheduleResult = await _scheduleService.GetScheduleStudentAsync(username, sessionID);
-                }
                 else if (viewerGroups.Contains(AuthGroup.Advisors))
                 {
                     scheduleResult = await _scheduleService.GetScheduleStudentAsync(username, sessionID);
@@ -103,6 +102,11 @@ namespace Gordon360.Controllers
             else
             {
                 return NotFound();
+            }
+
+            if (authenticatedUserUsername == username)
+            {
+                scheduleResult = await _scheduleService.GetScheduleStudentAsync(username, sessionID);
             }
 
             JArray result = JArray.FromObject(scheduleResult);

--- a/Gordon360/Controllers/ScheduleController.cs
+++ b/Gordon360/Controllers/ScheduleController.cs
@@ -81,6 +81,11 @@ namespace Gordon360.Controllers
             var scheduleControl = _context.Schedule_Control.Find(id);
 
             IEnumerable<ScheduleViewModel>? scheduleResult = null;
+            if (authenticatedUserUsername == username)
+            {
+                scheduleResult = await _scheduleService.GetScheduleStudentAsync(username, sessionID);
+            }
+
             if (groups.Contains(AuthGroup.Student))
             {
                 int schedulePrivacy = scheduleControl?.IsSchedulePrivate ?? 1;
@@ -102,11 +107,6 @@ namespace Gordon360.Controllers
             else
             {
                 return NotFound();
-            }
-
-            if (authenticatedUserUsername == username)
-            {
-                scheduleResult = await _scheduleService.GetScheduleStudentAsync(username, sessionID);
             }
 
             JArray result = JArray.FromObject(scheduleResult);

--- a/Gordon360/Controllers/ScheduleController.cs
+++ b/Gordon360/Controllers/ScheduleController.cs
@@ -32,7 +32,7 @@ namespace Gordon360.Controllers
         /// <returns>A IEnumerable of schedule objects</returns>
         [HttpGet]
         [Route("")]
-        public ActionResult<ScheduleViewModel> Get()
+        public ActionResult<ScheduleViewModel> Get(string sessionID)
         {
             var authenticatedUserUsername = AuthUtils.GetUsername(User);
             var groups = AuthUtils.GetGroups(User);
@@ -68,7 +68,7 @@ namespace Gordon360.Controllers
         /// <returns>A IEnumerable of schedule objects</returns>
         [HttpGet]
         [Route("{username}")]
-        public async Task<ActionResult<JArray>> GetAsync(string username)
+        public async Task<ActionResult<JArray>> GetAsync(string username, [FromQuery] string? sessionID)
         {
             //probably needs privacy stuff like ProfilesController and service
             var viewerGroups = AuthUtils.GetGroups(User);
@@ -84,21 +84,48 @@ namespace Gordon360.Controllers
 
                 if (viewerGroups.Contains(AuthGroup.Police) || viewerGroups.Contains(AuthGroup.SiteAdmin))
                 {
-                    scheduleResult = await _scheduleService.GetScheduleStudentAsync(username);
+                    if (sessionID is not null)
+                    {
+                        scheduleResult = await _scheduleService.GetSpecificScheduleStudentAsync(username, sessionID);
+                    }
+                    else
+                    {
+                        scheduleResult = await _scheduleService.GetScheduleStudentAsync(username);
+                    }
                 }
-                else if (viewerGroups.Contains(AuthGroup.Student) && schedulePrivacy == 0)
+                else if (viewerGroups.Contains(AuthGroup.Student) && schedulePrivacy == 1)
                 {
-
-                    scheduleResult = await _scheduleService.GetScheduleStudentAsync(username);
+                    if (sessionID is not null)
+                    {
+                        scheduleResult = await _scheduleService.GetSpecificScheduleStudentAsync(username, sessionID);
+                    }
+                    else
+                    {
+                        scheduleResult = await _scheduleService.GetScheduleStudentAsync(username);
+                    }
                 }
                 else if (viewerGroups.Contains(AuthGroup.Advisors))
                 {
-                    scheduleResult = await _scheduleService.GetScheduleStudentAsync(username);
+                    if (sessionID is not null)
+                    {
+                        scheduleResult = await _scheduleService.GetSpecificScheduleStudentAsync(username, sessionID);
+                    }
+                    else
+                    {
+                        scheduleResult = await _scheduleService.GetScheduleStudentAsync(username);
+                    }
                 }
             }
             else if (groups.Contains(AuthGroup.FacStaff))
             {
-                scheduleResult = await _scheduleService.GetScheduleFacultyAsync(username);
+                if (sessionID is not null)
+                {
+                    scheduleResult = await _scheduleService.GetSpecificScheduleFacultyAsync(username, sessionID);
+                }
+                else
+                {
+                    scheduleResult = await _scheduleService.GetScheduleFacultyAsync(username);
+                }
             }
             else
             {

--- a/Gordon360/Controllers/ScheduleController.cs
+++ b/Gordon360/Controllers/ScheduleController.cs
@@ -32,14 +32,14 @@ namespace Gordon360.Controllers
         /// <returns>A IEnumerable of schedule objects</returns>
         [HttpGet]
         [Route("")]
-        public ActionResult<ScheduleViewModel> Get(string sessionID)
+        public ActionResult<ScheduleViewModel> Get()
         {
             var authenticatedUserUsername = AuthUtils.GetUsername(User);
             var groups = AuthUtils.GetGroups(User);
 
             if (groups.Contains(AuthGroup.Student))
             {
-                var result = _scheduleService.GetScheduleStudentAsync(authenticatedUserUsername);
+                var result = _scheduleService.GetScheduleStudentAsync(authenticatedUserUsername, null);
                 if (result == null)
                 {
                     return NotFound();
@@ -49,7 +49,7 @@ namespace Gordon360.Controllers
 
             else if (groups.Contains(AuthGroup.FacStaff))
             {
-                var result = _scheduleService.GetScheduleFacultyAsync(authenticatedUserUsername);
+                var result = _scheduleService.GetScheduleFacultyAsync(authenticatedUserUsername, null);
                 if (result == null)
                 {
                     return NotFound();
@@ -84,48 +84,21 @@ namespace Gordon360.Controllers
 
                 if (viewerGroups.Contains(AuthGroup.Police) || viewerGroups.Contains(AuthGroup.SiteAdmin))
                 {
-                    if (sessionID is not null)
-                    {
-                        scheduleResult = await _scheduleService.GetSpecificScheduleStudentAsync(username, sessionID);
-                    }
-                    else
-                    {
-                        scheduleResult = await _scheduleService.GetScheduleStudentAsync(username);
-                    }
+                    scheduleResult = await _scheduleService.GetScheduleStudentAsync(username, sessionID);
+
                 }
                 else if (viewerGroups.Contains(AuthGroup.Student) && schedulePrivacy == 1)
                 {
-                    if (sessionID is not null)
-                    {
-                        scheduleResult = await _scheduleService.GetSpecificScheduleStudentAsync(username, sessionID);
-                    }
-                    else
-                    {
-                        scheduleResult = await _scheduleService.GetScheduleStudentAsync(username);
-                    }
+                    scheduleResult = await _scheduleService.GetScheduleStudentAsync(username, sessionID);
                 }
                 else if (viewerGroups.Contains(AuthGroup.Advisors))
                 {
-                    if (sessionID is not null)
-                    {
-                        scheduleResult = await _scheduleService.GetSpecificScheduleStudentAsync(username, sessionID);
-                    }
-                    else
-                    {
-                        scheduleResult = await _scheduleService.GetScheduleStudentAsync(username);
-                    }
+                    scheduleResult = await _scheduleService.GetScheduleStudentAsync(username, sessionID);
                 }
             }
             else if (groups.Contains(AuthGroup.FacStaff))
             {
-                if (sessionID is not null)
-                {
-                    scheduleResult = await _scheduleService.GetSpecificScheduleFacultyAsync(username, sessionID);
-                }
-                else
-                {
-                    scheduleResult = await _scheduleService.GetScheduleFacultyAsync(username);
-                }
+                scheduleResult = await _scheduleService.GetScheduleFacultyAsync(username, sessionID);
             }
             else
             {

--- a/Gordon360/Controllers/ScheduleController.cs
+++ b/Gordon360/Controllers/ScheduleController.cs
@@ -39,7 +39,7 @@ namespace Gordon360.Controllers
 
             if (groups.Contains(AuthGroup.Student))
             {
-                var result = _scheduleService.GetScheduleStudentAsync(authenticatedUserUsername, null);
+                var result = _scheduleService.GetScheduleStudentAsync(authenticatedUserUsername);
                 if (result == null)
                 {
                     return NotFound();
@@ -49,7 +49,7 @@ namespace Gordon360.Controllers
 
             else if (groups.Contains(AuthGroup.FacStaff))
             {
-                var result = _scheduleService.GetScheduleFacultyAsync(authenticatedUserUsername, null);
+                var result = _scheduleService.GetScheduleFacultyAsync(authenticatedUserUsername);
                 if (result == null)
                 {
                     return NotFound();

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -384,12 +384,6 @@
             <returns></returns>
             <remarks>Posts a new message to the service to be added into the database</remarks>
         </member>
-        <member name="M:Gordon360.Controllers.LogController.Post(Gordon360.Models.CCT.ERROR_LOG)">
-            <summary>Create a new error log item to be added to database</summary>
-            <param name="error_log">The error log containing the ERROR_TIME, and the LOG_MESSAGE</param>
-            <returns></returns>
-            <remarks>Posts a new error_log to the server to be added into the database. Useful if you want to input the datetime in the front end for greater accuracy</remarks>
-        </member>
         <member name="M:Gordon360.Controllers.MembershipsController.GetMemberships(System.String,System.String,System.String,System.Collections.Generic.List{System.String})">
             <summary>
             Get all the memberships associated with a given activity
@@ -557,6 +551,15 @@
             </summary>
             <param name="newsID">The id of the news item to edit</param>
             <param name="studentNewsEdit">The news object that contains updated values</param>
+            <returns>The updated news item</returns>
+            <remarks>The news item must be authored by the user and must not be expired and must be unapproved</remarks>
+        </member>
+        <member name="M:Gordon360.Controllers.NewsController.EditPostingImage(System.Int32,System.String)">
+            <summary>
+            (Controller) Edits a news image in the database
+            </summary>
+            <param name="newsID">The id of the news item to edit</param>
+            <param name="newImageData">The new image string updates the image value</param>
             <returns>The updated news item</returns>
             <remarks>The news item must be authored by the user and must not be expired and must be unapproved</remarks>
         </member>
@@ -1165,13 +1168,13 @@
             <param name="value">New description</param>
             <returns></returns>
         </member>
-        <member name="M:Gordon360.Controllers.ScheduleController.Get">
+        <member name="M:Gordon360.Controllers.ScheduleController.Get(System.String)">
             <summary>
              Gets all schedule objects for a user
             </summary>
             <returns>A IEnumerable of schedule objects</returns>
         </member>
-        <member name="M:Gordon360.Controllers.ScheduleController.GetAsync(System.String)">
+        <member name="M:Gordon360.Controllers.ScheduleController.GetAsync(System.String,System.String)">
             <summary>
              Gets all schedule objects for a user
             </summary>
@@ -2184,6 +2187,15 @@
             <returns>The updated news item's view model</returns>
             <remarks>The news item must be authored by the user and must not be expired and must be unapproved</remarks>
         </member>
+        <member name="M:Gordon360.Services.NewsService.EditImage(System.Int32,System.String)">
+            <summary>
+            (Service) Edits the image of a news item in the database
+            </summary>
+            <param name="newsID">The id of the news item to edit</param>
+            <param name="newImageData">The news image object that contains the updated image value</param>
+            <returns>The updated news item's view model</returns>
+            <remarks>The news item must be authored by the user and must not be expired and must be unapproved</remarks>
+        </member>
         <member name="M:Gordon360.Services.NewsService.VerifyUnapproved(Gordon360.Models.MyGordon.StudentNews)">
             <summary>
             Helper method to verify that a given news item has not yet been approved
@@ -2454,6 +2466,22 @@
             Fetch the schedule item whose id and session code is specified by the parameter
             </summary>
             <param name="username">The AD Username of the instructor</param>
+            <returns>StudentScheduleViewModel if found, null if not found</returns>
+        </member>
+        <member name="M:Gordon360.Services.ScheduleService.GetSpecificScheduleFacultyAsync(System.String,System.String)">
+            <summary>
+            Fetch the schedule item whose id and session code is specified by the parameter
+            </summary>
+            <param name="username">The AD Username of the instructor</param>
+            <param name="sessionID">The session of the instructor</param>
+            <returns>StudentScheduleViewModel if found, null if not found</returns>
+        </member>
+        <member name="M:Gordon360.Services.ScheduleService.GetSpecificScheduleStudentAsync(System.String,System.String)">
+            <summary>
+            Fetch the schedule item whose id and session code is specified by the parameter
+            </summary>
+            <param name="username">The AD Username of the Student</param>
+            <param name="sessionID">The session of the student</param>
             <returns>StudentScheduleViewModel if found, null if not found</returns>
         </member>
         <member name="T:Gordon360.Services.SessionService">

--- a/Gordon360/Services/ScheduleService.cs
+++ b/Gordon360/Services/ScheduleService.cs
@@ -26,7 +26,7 @@ namespace Gordon360.Services
         /// <param name="username">The AD Username of the student</param>
         /// <param name="sessionID">The selected session of the student</param>
         /// <returns>StudentScheduleViewModel if found, null if not found</returns>
-        public async Task<IEnumerable<ScheduleViewModel>> GetScheduleStudentAsync(string username, string? sessionID)
+        public async Task<IEnumerable<ScheduleViewModel>> GetScheduleStudentAsync(string username, string? sessionID = null)
         {
             var account = _context.ACCOUNT.FirstOrDefault(x => x.AD_Username == username);
 
@@ -35,14 +35,7 @@ namespace Gordon360.Services
                 throw new ResourceNotFoundException() { ExceptionMessage = "The Account was not found." };
             }
 
-            var sessionCode = "";
-            if (sessionID is not null)
-            {
-                sessionCode = sessionID;
-            } else
-            {
-                sessionCode = Helpers.GetCurrentSession(_context);
-            }
+            var sessionCode = sessionID ?? Helpers.GetCurrentSession(_context);
             var result = await _context.Procedures.STUDENT_COURSES_BY_ID_NUM_AND_SESS_CDEAsync(int.Parse(account.gordon_id), sessionCode);
 
             return result.Select(x => new ScheduleViewModel
@@ -69,7 +62,7 @@ namespace Gordon360.Services
         /// <param name="username">The AD Username of the instructor</param>
         /// <param name="sessionID">The selected session of the instructor</param>
         /// <returns>StudentScheduleViewModel if found, null if not found</returns>
-        public async Task<IEnumerable<ScheduleViewModel>> GetScheduleFacultyAsync(string username, string? sessionID)
+        public async Task<IEnumerable<ScheduleViewModel>> GetScheduleFacultyAsync(string username, string? sessionID = null)
         {
             var account = _context.ACCOUNT.FirstOrDefault(x => x.AD_Username == username);
             if (account == null)
@@ -77,16 +70,7 @@ namespace Gordon360.Services
                 throw new ResourceNotFoundException() { ExceptionMessage = "The Schedule was not found." };
             }
 
-            var sessionCode = "";
-            if (sessionID is not null)
-            {
-                sessionCode = sessionID;
-            }
-            else
-            {
-                sessionCode = Helpers.GetCurrentSession(_context);
-            }
-
+            var sessionCode = sessionID ?? Helpers.GetCurrentSession(_context);
             var result = await _context.Procedures.INSTRUCTOR_COURSES_BY_ID_NUM_AND_SESS_CDEAsync(int.Parse(account.gordon_id), sessionCode);
 
             return result.Select(x => new ScheduleViewModel

--- a/Gordon360/Services/ScheduleService.cs
+++ b/Gordon360/Services/ScheduleService.cs
@@ -24,18 +24,25 @@ namespace Gordon360.Services
         /// Fetch the schedule item whose id and session code is specified by the parameter
         /// </summary>
         /// <param name="username">The AD Username of the student</param>
+        /// <param name="sessionID">The selected session of the student</param>
         /// <returns>StudentScheduleViewModel if found, null if not found</returns>
-        public async Task<IEnumerable<ScheduleViewModel>> GetScheduleStudentAsync(string username)
+        public async Task<IEnumerable<ScheduleViewModel>> GetScheduleStudentAsync(string username, string? sessionID)
         {
             var account = _context.ACCOUNT.FirstOrDefault(x => x.AD_Username == username);
 
             if (account == null)
             {
-                throw new ResourceNotFoundException() { ExceptionMessage = "The Schedule was not found." };
+                throw new ResourceNotFoundException() { ExceptionMessage = "The Account was not found." };
             }
 
-
-            var sessionCode = Helpers.GetCurrentSession(_context);
+            var sessionCode = "";
+            if (sessionID is not null)
+            {
+                sessionCode = sessionID;
+            } else
+            {
+                sessionCode = Helpers.GetCurrentSession(_context);
+            }
             var result = await _context.Procedures.STUDENT_COURSES_BY_ID_NUM_AND_SESS_CDEAsync(int.Parse(account.gordon_id), sessionCode);
 
             return result.Select(x => new ScheduleViewModel
@@ -60,91 +67,31 @@ namespace Gordon360.Services
         /// Fetch the schedule item whose id and session code is specified by the parameter
         /// </summary>
         /// <param name="username">The AD Username of the instructor</param>
+        /// <param name="sessionID">The selected session of the instructor</param>
         /// <returns>StudentScheduleViewModel if found, null if not found</returns>
-        public async Task<IEnumerable<ScheduleViewModel>> GetScheduleFacultyAsync(string username)
+        public async Task<IEnumerable<ScheduleViewModel>> GetScheduleFacultyAsync(string username, string? sessionID)
         {
             var account = _context.ACCOUNT.FirstOrDefault(x => x.AD_Username == username);
-            //var currentSessionCode = Helpers.GetCurrentSession().SessionCode;
             if (account == null)
             {
                 throw new ResourceNotFoundException() { ExceptionMessage = "The Schedule was not found." };
             }
 
-            var sessionCode = Helpers.GetCurrentSession(_context);
+            var sessionCode = "";
+            if (sessionID is not null)
+            {
+                sessionCode = sessionID;
+            }
+            else
+            {
+                sessionCode = Helpers.GetCurrentSession(_context);
+            }
+
             var result = await _context.Procedures.INSTRUCTOR_COURSES_BY_ID_NUM_AND_SESS_CDEAsync(int.Parse(account.gordon_id), sessionCode);
 
             return result.Select(x => new ScheduleViewModel
             {
                 ID_NUM = x.ID_NUM ?? default,
-                CRS_CDE = x.CRS_CDE,
-                CRS_TITLE = x.CRS_TITLE,
-                BLDG_CDE = x.BLDG_CDE,
-                ROOM_CDE = x.ROOM_CDE,
-                MONDAY_CDE = x.MONDAY_CDE,
-                TUESDAY_CDE = x.TUESDAY_CDE,
-                WEDNESDAY_CDE = x.WEDNESDAY_CDE,
-                THURSDAY_CDE = x.THURSDAY_CDE,
-                FRIDAY_CDE = x.FRIDAY_CDE,
-                BEGIN_TIME = x.BEGIN_TIME,
-                END_TIME = x.END_TIME
-            });
-        }
-
-
-        /// <summary>
-        /// Fetch the schedule item whose id and session code is specified by the parameter
-        /// </summary>
-        /// <param name="username">The AD Username of the instructor</param>
-        /// <param name="sessionID">The session of the instructor</param>
-        /// <returns>StudentScheduleViewModel if found, empty array if not found</returns>
-        public async Task<IEnumerable<ScheduleViewModel>> GetSpecificScheduleFacultyAsync(string username, string sessionID)
-        {
-            var account = _context.ACCOUNT.FirstOrDefault(x => x.AD_Username == username);
-            if (account == null)
-            {
-                throw new ResourceNotFoundException() { ExceptionMessage = "The Schedule was not found." };
-            }
-
-            var sessionCode = sessionID;
-            var result = await _context.Procedures.INSTRUCTOR_COURSES_BY_ID_NUM_AND_SESS_CDEAsync(int.Parse(account.gordon_id), sessionCode);
-
-            return result.Select(x => new ScheduleViewModel
-            {
-                ID_NUM = x.ID_NUM ?? default,
-                CRS_CDE = x.CRS_CDE,
-                CRS_TITLE = x.CRS_TITLE,
-                BLDG_CDE = x.BLDG_CDE,
-                ROOM_CDE = x.ROOM_CDE,
-                MONDAY_CDE = x.MONDAY_CDE,
-                TUESDAY_CDE = x.TUESDAY_CDE,
-                WEDNESDAY_CDE = x.WEDNESDAY_CDE,
-                THURSDAY_CDE = x.THURSDAY_CDE,
-                FRIDAY_CDE = x.FRIDAY_CDE,
-                BEGIN_TIME = x.BEGIN_TIME,
-                END_TIME = x.END_TIME
-            });
-        }
-
-        /// <summary>
-        /// Fetch the schedule item whose id and session code is specified by the parameter
-        /// </summary>
-        /// <param name="username">The AD Username of the Student</param>
-        /// <param name="sessionID">The session of the student</param>
-        /// <returns>StudentScheduleViewModel if found, empty array if not found</returns>
-        public async Task<IEnumerable<ScheduleViewModel>> GetSpecificScheduleStudentAsync(string username, string sessionID)
-        {
-            var account = _context.ACCOUNT.FirstOrDefault(x => x.AD_Username == username);
-            if (account == null)
-            {
-                throw new ResourceNotFoundException() { ExceptionMessage = "The Schedule was not found." };
-            }
-
-            var sessionCode = sessionID;
-            var result = await _context.Procedures.STUDENT_COURSES_BY_ID_NUM_AND_SESS_CDEAsync(int.Parse(account.gordon_id), sessionCode);
-
-            return result.Select(x => new ScheduleViewModel
-            {
-                ID_NUM = x.ID_NUM,
                 CRS_CDE = x.CRS_CDE,
                 CRS_TITLE = x.CRS_TITLE,
                 BLDG_CDE = x.BLDG_CDE,

--- a/Gordon360/Services/ScheduleService.cs
+++ b/Gordon360/Services/ScheduleService.cs
@@ -89,5 +89,76 @@ namespace Gordon360.Services
                 END_TIME = x.END_TIME
             });
         }
+
+
+        /// <summary>
+        /// Fetch the schedule item whose id and session code is specified by the parameter
+        /// </summary>
+        /// <param name="username">The AD Username of the instructor</param>
+        /// <param name="sessionID">The session of the instructor</param>
+        /// <returns>StudentScheduleViewModel if found, null if not found</returns>
+        public async Task<IEnumerable<ScheduleViewModel>> GetSpecificScheduleFacultyAsync(string username, string sessionID)
+        {
+            var account = _context.ACCOUNT.FirstOrDefault(x => x.AD_Username == username);
+            //var currentSessionCode = Helpers.GetCurrentSession().SessionCode;
+            if (account == null)
+            {
+                throw new ResourceNotFoundException() { ExceptionMessage = "The Schedule was not found." };
+            }
+
+            var sessionCode = sessionID;//Helpers.GetCurrentSession(_context);
+            var result = await _context.Procedures.INSTRUCTOR_COURSES_BY_ID_NUM_AND_SESS_CDEAsync(int.Parse(account.gordon_id), sessionCode);
+
+            return result.Select(x => new ScheduleViewModel
+            {
+                ID_NUM = x.ID_NUM ?? default,
+                CRS_CDE = x.CRS_CDE,
+                CRS_TITLE = x.CRS_TITLE,
+                BLDG_CDE = x.BLDG_CDE,
+                ROOM_CDE = x.ROOM_CDE,
+                MONDAY_CDE = x.MONDAY_CDE,
+                TUESDAY_CDE = x.TUESDAY_CDE,
+                WEDNESDAY_CDE = x.WEDNESDAY_CDE,
+                THURSDAY_CDE = x.THURSDAY_CDE,
+                FRIDAY_CDE = x.FRIDAY_CDE,
+                BEGIN_TIME = x.BEGIN_TIME,
+                END_TIME = x.END_TIME
+            });
+        }
+
+        /// <summary>
+        /// Fetch the schedule item whose id and session code is specified by the parameter
+        /// </summary>
+        /// <param name="username">The AD Username of the Student</param>
+        /// <param name="sessionID">The session of the student</param>
+        /// <returns>StudentScheduleViewModel if found, null if not found</returns>
+        public async Task<IEnumerable<ScheduleViewModel>> GetSpecificScheduleStudentAsync(string username, string sessionID)
+        {
+            var account = _context.ACCOUNT.FirstOrDefault(x => x.AD_Username == username);
+            //var currentSessionCode = Helpers.GetCurrentSession().SessionCode;
+            if (account == null)
+            {
+                throw new ResourceNotFoundException() { ExceptionMessage = "The Schedule was not found." };
+            }
+
+            var sessionCode = sessionID;//Helpers.GetCurrentSession(_context);
+            var result = await _context.Procedures.STUDENT_COURSES_BY_ID_NUM_AND_SESS_CDEAsync(int.Parse(account.gordon_id), sessionCode);
+
+            return result.Select(x => new ScheduleViewModel
+            {
+                ID_NUM = x.ID_NUM,
+                CRS_CDE = x.CRS_CDE,
+                CRS_TITLE = x.CRS_TITLE,
+                BLDG_CDE = x.BLDG_CDE,
+                ROOM_CDE = x.ROOM_CDE,
+                MONDAY_CDE = x.MONDAY_CDE,
+                TUESDAY_CDE = x.TUESDAY_CDE,
+                WEDNESDAY_CDE = x.WEDNESDAY_CDE,
+                THURSDAY_CDE = x.THURSDAY_CDE,
+                FRIDAY_CDE = x.FRIDAY_CDE,
+                BEGIN_TIME = x.BEGIN_TIME,
+                END_TIME = x.END_TIME
+            });
+        }
     }
 }

--- a/Gordon360/Services/ScheduleService.cs
+++ b/Gordon360/Services/ScheduleService.cs
@@ -96,17 +96,16 @@ namespace Gordon360.Services
         /// </summary>
         /// <param name="username">The AD Username of the instructor</param>
         /// <param name="sessionID">The session of the instructor</param>
-        /// <returns>StudentScheduleViewModel if found, null if not found</returns>
+        /// <returns>StudentScheduleViewModel if found, empty array if not found</returns>
         public async Task<IEnumerable<ScheduleViewModel>> GetSpecificScheduleFacultyAsync(string username, string sessionID)
         {
             var account = _context.ACCOUNT.FirstOrDefault(x => x.AD_Username == username);
-            //var currentSessionCode = Helpers.GetCurrentSession().SessionCode;
             if (account == null)
             {
                 throw new ResourceNotFoundException() { ExceptionMessage = "The Schedule was not found." };
             }
 
-            var sessionCode = sessionID;//Helpers.GetCurrentSession(_context);
+            var sessionCode = sessionID;
             var result = await _context.Procedures.INSTRUCTOR_COURSES_BY_ID_NUM_AND_SESS_CDEAsync(int.Parse(account.gordon_id), sessionCode);
 
             return result.Select(x => new ScheduleViewModel
@@ -131,17 +130,16 @@ namespace Gordon360.Services
         /// </summary>
         /// <param name="username">The AD Username of the Student</param>
         /// <param name="sessionID">The session of the student</param>
-        /// <returns>StudentScheduleViewModel if found, null if not found</returns>
+        /// <returns>StudentScheduleViewModel if found, empty array if not found</returns>
         public async Task<IEnumerable<ScheduleViewModel>> GetSpecificScheduleStudentAsync(string username, string sessionID)
         {
             var account = _context.ACCOUNT.FirstOrDefault(x => x.AD_Username == username);
-            //var currentSessionCode = Helpers.GetCurrentSession().SessionCode;
             if (account == null)
             {
                 throw new ResourceNotFoundException() { ExceptionMessage = "The Schedule was not found." };
             }
 
-            var sessionCode = sessionID;//Helpers.GetCurrentSession(_context);
+            var sessionCode = sessionID;
             var result = await _context.Procedures.STUDENT_COURSES_BY_ID_NUM_AND_SESS_CDEAsync(int.Parse(account.gordon_id), sessionCode);
 
             return result.Select(x => new ScheduleViewModel

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -227,8 +227,8 @@ namespace Gordon360.Services
     }
     public interface IScheduleService
     {
-        Task<IEnumerable<ScheduleViewModel>> GetScheduleStudentAsync(string username, string? sessionID);
-        Task<IEnumerable<ScheduleViewModel>> GetScheduleFacultyAsync(string username, string? sessionID);
+        Task<IEnumerable<ScheduleViewModel>> GetScheduleStudentAsync(string username, string? sessionID=null);
+        Task<IEnumerable<ScheduleViewModel>> GetScheduleFacultyAsync(string username, string? sessionID=null);
     }
 
     public interface IScheduleControlService

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -229,6 +229,9 @@ namespace Gordon360.Services
     {
         Task<IEnumerable<ScheduleViewModel>> GetScheduleStudentAsync(string username);
         Task<IEnumerable<ScheduleViewModel>> GetScheduleFacultyAsync(string username);
+        Task<IEnumerable<ScheduleViewModel>> GetSpecificScheduleFacultyAsync(string username, string sessionID);
+        Task<IEnumerable<ScheduleViewModel>> GetSpecificScheduleStudentAsync(string username, string sessionID);
+
     }
 
     public interface IScheduleControlService

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -227,11 +227,8 @@ namespace Gordon360.Services
     }
     public interface IScheduleService
     {
-        Task<IEnumerable<ScheduleViewModel>> GetScheduleStudentAsync(string username);
-        Task<IEnumerable<ScheduleViewModel>> GetScheduleFacultyAsync(string username);
-        Task<IEnumerable<ScheduleViewModel>> GetSpecificScheduleFacultyAsync(string username, string sessionID);
-        Task<IEnumerable<ScheduleViewModel>> GetSpecificScheduleStudentAsync(string username, string sessionID);
-
+        Task<IEnumerable<ScheduleViewModel>> GetScheduleStudentAsync(string username, string? sessionID);
+        Task<IEnumerable<ScheduleViewModel>> GetScheduleFacultyAsync(string username, string? sessionID);
     }
 
     public interface IScheduleControlService

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -227,8 +227,8 @@ namespace Gordon360.Services
     }
     public interface IScheduleService
     {
-        Task<IEnumerable<ScheduleViewModel>> GetScheduleStudentAsync(string username, string? sessionID=null);
-        Task<IEnumerable<ScheduleViewModel>> GetScheduleFacultyAsync(string username, string? sessionID=null);
+        Task<IEnumerable<ScheduleViewModel>> GetScheduleStudentAsync(string username, string? sessionID = null);
+        Task<IEnumerable<ScheduleViewModel>> GetScheduleFacultyAsync(string username, string? sessionID = null);
     }
 
     public interface IScheduleControlService


### PR DESCRIPTION
We added a sessionID parameter in the get schedule api function so that if it is null, it would just get the current schedule for the user, but would return the schedule for a specific term if it is passed through the parameter. We made two new functions in the ScheduleService.cs for fetching schedules for faculty and students for specific sessions, but we felt like it could possibly be combined with the pre-existing functions that get the current session's schedule. We would greatly appreciate your input on this.

#915 