### PR TITLE
Figure out the permission for different AuthGroups

### DIFF
--- a/Gordon360/Controllers/ProfilesController.cs
+++ b/Gordon360/Controllers/ProfilesController.cs
@@ -89,16 +89,32 @@ namespace Gordon360.Controllers
                 faculty = _faculty == null ? null : (PublicFacultyStaffProfileViewModel)_faculty;
                 alumni = _alumni == null ? null : (PublicAlumniProfileViewModel)_alumni;
             }
+            else if (viewerGroups.Contains(AuthGroup.Alumni) && viewerGroups.Contains(AuthGroup.Student))
+            {
+                // Ask Chris about what group (Alumni + Student) can see
+                student = _student == null ? null : (PublicStudentProfileViewModel)_student;
+                faculty = _faculty == null ? null : (PublicFacultyStaffProfileViewModel)_faculty;
+                alumni = _alumni == null ? null : (PublicAlumniProfileViewModel)_alumni;
+            }
+            else if (viewerGroups.Contains(AuthGroup.Alumni))
+            {
+                /* student = _student == null ? null : (PublicStudentProfileViewModel)_student;
+                faculty = _faculty == null ? null : (PublicFacultyStaffProfileViewModel)_faculty; */
+                // Ask Chris about what group Alumni can see
+                student = null;
+                faculty = null;
+                alumni = _alumni == null ? null : (PublicAlumniProfileViewModel)_alumni;
+            }
             else if (viewerGroups.Contains(AuthGroup.Student))
             {
                 student = _student == null ? null : (PublicStudentProfileViewModel)_student;
                 faculty = _faculty == null ? null : (PublicFacultyStaffProfileViewModel)_faculty;
-                alumni = null;  //student can't see alumini
+                alumni = null;  //student can't see alumni
             }
 
             if (student is null && alumni is null && faculty is null)
             {
-                return Ok(null);
+                return Ok();
             }
 
             var profile = _profileService.ComposeProfile(student, alumni, faculty, _customInfo);


### PR DESCRIPTION
Fixes #919 

This PR is to figure out the permission for different `AuthGroup`s (especially for `Alumni` group) and implement it in the code. For now, we think that:

- If the person is an Alumni, then s/he can only see the public profile of alumni (and the faculty?)
- If the person is an Alumni and a student, then s/he can see the public profile of student, alumni and faculty
- If the person is [an Alumni and a faculty] or [a student, an Alumni and a faculty], then s/he can see the profile of student, and the public profile of alumni and faculty

@ChrisImagineer How do you think?