### PR TITLE
Advisor, Leader, and members should be able to see members form the same club session

### DIFF
--- a/Gordon360/Authorization/StateYourBusiness.cs
+++ b/Gordon360/Authorization/StateYourBusiness.cs
@@ -241,7 +241,6 @@ namespace Gordon360.Authorization
                         // Only members can read a specific activity's memberships
                         if (context.ActionArguments.TryGetValue("involvementCode", out object? involvementCode_object)  && involvementCode_object is string involvementCode)
                         {
-                            //System.Collections.Generic.IEnumerable<Gordon360.Models.CCT.MembershipView> activityMembers = {};
                             if (context.ActionArguments.TryGetValue("sessionCode", out object? sessionCode_object) && sessionCode_object is string sessionCode)
                             {
                                 var activityMembers = _membershipService.GetMemberships(activityCode: involvementCode, username: user_name, sessionCode: sessionCode);
@@ -255,8 +254,6 @@ namespace Gordon360.Authorization
                                 var is_personAMember = activityMembers.Any(x => x.Participation != "GUEST");
                                 return is_personAMember;
                             }
-                            //var is_personAMember = activityMembers.Any(x => x.Participation != "GUEST");
-                           // return is_personAMember;
                         }
 
 

--- a/Gordon360/Authorization/StateYourBusiness.cs
+++ b/Gordon360/Authorization/StateYourBusiness.cs
@@ -241,9 +241,22 @@ namespace Gordon360.Authorization
                         // Only members can read a specific activity's memberships
                         if (context.ActionArguments.TryGetValue("involvementCode", out object? involvementCode_object)  && involvementCode_object is string involvementCode)
                         {
-                            var activityMembers = _membershipService.GetMemberships(activityCode: involvementCode, username: user_name, sessionCode: "*");
-                            var is_personAMember = activityMembers.Any(x => x.Participation != "GUEST");
-                            return is_personAMember;
+                            //System.Collections.Generic.IEnumerable<Gordon360.Models.CCT.MembershipView> activityMembers = {};
+                            if (context.ActionArguments.TryGetValue("sessionCode", out object? sessionCode_object) && sessionCode_object is string sessionCode)
+                            {
+                                var activityMembers = _membershipService.GetMemberships(activityCode: involvementCode, username: user_name, sessionCode: sessionCode);
+                                var is_personAMember = activityMembers.Any(x => x.Participation != "GUEST");
+                                return is_personAMember;
+
+                            }
+                            else
+                            {
+                                var activityMembers = _membershipService.GetMemberships(activityCode: involvementCode, username: user_name, sessionCode: "*");
+                                var is_personAMember = activityMembers.Any(x => x.Participation != "GUEST");
+                                return is_personAMember;
+                            }
+                            //var is_personAMember = activityMembers.Any(x => x.Participation != "GUEST");
+                           // return is_personAMember;
                         }
 
 

--- a/Gordon360/Authorization/StateYourBusiness.cs
+++ b/Gordon360/Authorization/StateYourBusiness.cs
@@ -239,12 +239,13 @@ namespace Gordon360.Authorization
                         }
 
                         // Only members can read a specific activity's memberships
-                        if (context.ActionArguments.TryGetValue("involvementCode", out object? involvementCode_object) && involvementCode_object is string involvementCode)
+                        if (context.ActionArguments.TryGetValue("involvementCode", out object? involvementCode_object)  && involvementCode_object is string involvementCode)
                         {
-                            var activityMembers = _membershipService.GetMemberships(activityCode: involvementCode, username: user_name);
-                            var is_personAMember = activityMembers.Any(x => x.Participation != Participation.Guest.GetCode());
+                            var activityMembers = _membershipService.GetMemberships(activityCode: involvementCode, username: user_name, sessionCode: "*");
+                            var is_personAMember = activityMembers.Any(x => x.Participation != "GUEST");
                             return is_personAMember;
                         }
+
 
                         return false;
                     }

--- a/Gordon360/Controllers/MembershipsController.cs
+++ b/Gordon360/Controllers/MembershipsController.cs
@@ -37,12 +37,6 @@ namespace Gordon360.Controllers
             var authenticatedUserUsername = AuthUtils.GetUsername(User);
             var viewerGroups = AuthUtils.GetGroups(User);
 
-            var userMemberships = _membershipService.GetMemberships(
-                activityCode: involvementCode,
-                username: authenticatedUserUsername,
-                sessionCode: sessionCode,
-                participationTypes: participationTypes);
-
             var memberships = _membershipService.GetMemberships(
                 activityCode: involvementCode,
                 username: username,

--- a/Gordon360/Controllers/MembershipsController.cs
+++ b/Gordon360/Controllers/MembershipsController.cs
@@ -53,16 +53,8 @@ namespace Gordon360.Controllers
             if ((username is null) && !(viewerGroups.Contains(AuthGroup.SiteAdmin)
                 || viewerGroups.Contains(AuthGroup.Police)))
             {
-                // Advisor, Member, and Leader should be able to see members form a group session and activity (not Guests)
-                if ((involvementCode is not null) && (userMemberships is not null) && (userMemberships.FirstOrDefault(u => u.Participation == "GUEST") is null)) 
-                {
-                    return Ok(memberships);
-                }
-                else
-                {
                     memberships = _membershipService.RemovePrivateMemberships(memberships, authenticatedUserUsername);
                     return Ok(memberships);
-                }
             }
             // Only user, siteAdmin and Police can see all the user's memberships.
             else if ((username is not null) && !(username == authenticatedUserUsername

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -398,7 +398,6 @@
             <summary>
             Get all the memberships associated with a given activity
             </summary>
-            <param name="myProf">Optional boolean indication if you are searching for your public profile</param>
             <param name="involvementCode">Optional involvementCode filter</param>
             <param name="username">Optional username filter</param>
             <param name="sessionCode">Optional session code for which session memberships should be retrieved. Defaults to current session. Use "*" for all sessions.</param>

--- a/Gordon360/Services/MembershipService.cs
+++ b/Gordon360/Services/MembershipService.cs
@@ -47,7 +47,8 @@ namespace Gordon360.Services
         )
         {
             IQueryable<MembershipView> memberships = _context.MembershipView;
-            if (username is not null) memberships = memberships.Where(m => EF.Functions.Like(m.Username, username));
+            if (username is not null) memberships = memberships.Where(m => m.Username == username);
+
             if (activityCode is not null) memberships = memberships.Where(m => m.ActivityCode == activityCode);
 
             // Null sessionCode defaults to current session

--- a/Gordon360/Services/MembershipService.cs
+++ b/Gordon360/Services/MembershipService.cs
@@ -47,7 +47,7 @@ namespace Gordon360.Services
         )
         {
             IQueryable<MembershipView> memberships = _context.MembershipView;
-            if (username is not null) memberships = memberships.Where(m => m.Username == username);
+            if (username is not null) memberships = memberships.Where(m => EF.Functions.Like(m.Username, username));
 
             if (activityCode is not null) memberships = memberships.Where(m => m.ActivityCode == activityCode);
 

--- a/Gordon360/Services/MembershipService.cs
+++ b/Gordon360/Services/MembershipService.cs
@@ -47,7 +47,7 @@ namespace Gordon360.Services
         )
         {
             IQueryable<MembershipView> memberships = _context.MembershipView;
-            if (username is not null) memberships = memberships.Where(m => EF.Functions.Like(m.Username, username));
+            if (username is not null) memberships = memberships.Where(m => m.Username == username);
 
             if (activityCode is not null) memberships = memberships.Where(m => m.ActivityCode == activityCode);
 


### PR DESCRIPTION
I think the pull request to put more security in the backend that was merged last week might have not taken in consideration the Advisors, Leaders, and members. This might solve the issue, but needs more tests to make sure