### PR TITLE
Don't show search results for alumni who have requested their names not be shown.

### DIFF
--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -398,7 +398,6 @@
             <summary>
             Get all the memberships associated with a given activity
             </summary>
-            <param name="myProf">Optional boolean indication if you are searching for your public profile</param>
             <param name="involvementCode">Optional involvementCode filter</param>
             <param name="username">Optional username filter</param>
             <param name="sessionCode">Optional session code for which session memberships should be retrieved. Defaults to current session. Use "*" for all sessions.</param>

--- a/Gordon360/Services/AccountService.cs
+++ b/Gordon360/Services/AccountService.cs
@@ -196,8 +196,6 @@ namespace Gordon360.Services
                 accounts = accounts.Join(members, a => a.AD_Username, mv => mv.Username, (a, mv) => a).Distinct();
             }
 
-            // Don't show results for alumni who have requested their names not be shown
-            accounts = accounts.Where(a => a.ShareName != "N");
             return accounts.OrderBy(a => a.LastName).ThenBy(a => a.FirstName);
         }
 
@@ -233,7 +231,7 @@ namespace Gordon360.Services
             IEnumerable<Alumni> alumni = Enumerable.Empty<Alumni>();
             if (accountTypes.Contains("alumni"))
             {
-                alumni = _context.Alumni;
+                alumni = _context.Alumni.Where(a => a.ShareName != "N");
             }
 
             // Do not indirectly reveal the address of facstaff and alumni who have requested to keep it private.

--- a/Gordon360/Services/AccountService.cs
+++ b/Gordon360/Services/AccountService.cs
@@ -196,6 +196,8 @@ namespace Gordon360.Services
                 accounts = accounts.Join(members, a => a.AD_Username, mv => mv.Username, (a, mv) => a).Distinct();
             }
 
+            // Don't show results for alumni who have requested their names not be shown
+            accounts = accounts.Where(a => a.ShareName != "N");
             return accounts.OrderBy(a => a.LastName).ThenBy(a => a.FirstName);
         }
 


### PR DESCRIPTION
Alumni have the option of requesting their names and/or addresses not be shown.  This was already enforced on profiles, but not on search results.  This fixes #970.