### PR TITLE
Don't crash when 25Live request fails

### DIFF
--- a/Gordon360/Services/EventCacheRefreshService.cs
+++ b/Gordon360/Services/EventCacheRefreshService.cs
@@ -5,6 +5,9 @@ using System.Threading.Tasks;
 using System.Threading;
 using System;
 using System.Diagnostics;
+using System.Collections;
+using Gordon360.Models.ViewModels;
+using System.Collections.Generic;
 
 namespace Gordon360.Services
 {
@@ -28,7 +31,15 @@ namespace Gordon360.Services
 
         private async void UpdateEventsCacheAsync(object? state)
         {
-            var events = await EventService.FetchEventsAsync();
+            IEnumerable<EventViewModel>? events = null;
+            try
+            {
+                events = await EventService.FetchEventsAsync();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(ex.Message);
+            }
             _cache.Set(CacheKeys.Events, events);
         }
 

--- a/Gordon360/Services/EventService.cs
+++ b/Gordon360/Services/EventService.cs
@@ -110,6 +110,8 @@ namespace Gordon360.Services
             if (response != null && response.IsSuccessStatusCode)
             {
                 var content = await response.Content.ReadAsStringAsync();
+                try
+                {
                 var eventsXML = XDocument.Parse(content);
                 return eventsXML
                     .Descendants(EventViewModel.r25 + "event")
@@ -119,6 +121,12 @@ namespace Gordon360.Services
                         // Map the event e with it's occurrence details o to a new EventViewModel
                         (e, o) => new EventViewModel(e, o)
                     );
+                }
+                catch (Exception)
+                {
+
+                    throw;
+                }
             }
             else
             {


### PR DESCRIPTION
25Live is currently down for maintenance. The background service that caches 25Live responses therefore throws an uncaught exception, which crashes the whole API. I added some minimal try-catch logic so that the API can continue to function (although all event requests will error).