### PR TITLE
Update type of `UserID` in Enrollment Check In stored procedures

### DIFF
--- a/Gordon360/Models/CCT/dbo/FINALIZATION_GET_FINALIZATION_STATUSResult.cs
+++ b/Gordon360/Models/CCT/dbo/FINALIZATION_GET_FINALIZATION_STATUSResult.cs
@@ -7,7 +7,7 @@ namespace Gordon360.Models.CCT
 {
     public partial class FINALIZATION_GET_FINALIZATION_STATUSResult
     {
-        public string UserID { get; set; }
+        public int UserID { get; set; }
         public string Period { get; set; }
         public bool FinalizationCompleted { get; set; }
         public string RootQuery { get; set; }

--- a/Gordon360/Models/CCT/dbo/FINALIZATION_MARK_AS_CURRENTLY_COMPLETEDResult.cs
+++ b/Gordon360/Models/CCT/dbo/FINALIZATION_MARK_AS_CURRENTLY_COMPLETEDResult.cs
@@ -7,7 +7,7 @@ namespace Gordon360.Models.CCT
 {
     public partial class FINALIZATION_MARK_AS_CURRENTLY_COMPLETEDResult
     {
-        public string UserID { get; set; }
+        public int UserID { get; set; }
         public string Period { get; set; }
         public bool FinalizationCompleted { get; set; }
         public string RootQuery { get; set; }


### PR DESCRIPTION
The type of `UserID` returned by the `FINALIZATION_*` stored procedures is currently different in Train and Prod (because of a change unrelated to 360). In Production, it was changed to an int, which is causing EF Core to fail when mapping returned results to C# objects, which causes Enrollment check in to break.

I am releasing this hotfix into production directly to get Enrollment Check In working. We will have to investigate updating the type of `UserID` in train at a later date.