### PR TITLE
Look for `involvement_code` param instead of `id`

### DIFF
--- a/Gordon360/Authorization/StateYourBusiness.cs
+++ b/Gordon360/Authorization/StateYourBusiness.cs
@@ -670,11 +670,11 @@ namespace Gordon360.Authorization
                         if (user_groups.Contains(AuthGroup.SiteAdmin))
                             return true;
 
-                        if (context.ActionArguments["id"] is string activityCode)
+                        if (context.ActionArguments.TryGetValue("involvement_code", out object? involvementCodeObject) && involvementCodeObject is string involvementCode)
                         {
                             var isGroupAdmin = _membershipService
                                 .GetMemberships(
-                                    activityCode: activityCode,
+                                    activityCode: involvementCode,
                                     username: user_name,
                                     participationTypes: new List<string> { Participation.GroupAdmin.GetCode() })
                                 .Any();

--- a/Gordon360/Controllers/ActivitiesController.cs
+++ b/Gordon360/Controllers/ActivitiesController.cs
@@ -279,15 +279,15 @@ namespace Gordon360.Controllers
         }
 
         /// <summary>Update an existing activity to be private or not</summary>
-        /// <param name="id">The id of the activity</param>
+        /// <param name="involvement_code">The code of the involvement</param>
         /// <param name = "p">the boolean value</param>
         /// <remarks>Calls the server to make a call and update the database with the changed information</remarks>
         [HttpPut]
-        [Route("{id}/privacy/{p}")]
+        [Route("{involvement_code}/privacy/{p}")]
         [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.ACTIVITY_INFO)]
-        public ActionResult TogglePrivacy(string id, bool p)
+        public ActionResult TogglePrivacy(string involvement_code, bool p)
         {
-            _activityService.TogglePrivacy(id, p);
+            _activityService.TogglePrivacy(involvement_code, p);
             return Ok();
         }
 


### PR DESCRIPTION
StateYourBusiness was looking for the wrong param when authorizing update requests for the `ACITIVTY_INFO` resource. Previously, the first param was `id`, but it got updated to `involvement_code` at some point without also updating the param name in StateYourBusiness, which caused the authorization attribute to always return a 500 error for these requests.