### PR TITLE
Remove [FromBody] attribute that was breaking route

### DIFF
--- a/Gordon360/Controllers/ProfilesController.cs
+++ b/Gordon360/Controllers/ProfilesController.cs
@@ -500,7 +500,7 @@ namespace Gordon360.Controllers
         /// <returns></returns>
         [HttpPut]
         [Route("mobile_privacy/{value}")]
-        public async Task<ActionResult> UpdateMobilePrivacyAsync([FromBody]string value)
+        public async Task<ActionResult> UpdateMobilePrivacyAsync(string value)
         {
             var authenticatedUserUsername = AuthUtils.GetUsername(User);
             await _profileService.UpdateMobilePrivacyAsync(authenticatedUserUsername, value);


### PR DESCRIPTION
A `[FromBody]` attribute was added to the Profiles Controller `UpdtaeMobilePrivacyAsync` method parameter `value`. However, as denoted in the Route path, the `value` parameter is actually expected to come from the path, not the body. I'm not sure why this update was committed but it broke the route, preventing anyone from updating their mobile privacy preferences.