### PR TITLE
Fix query for getting activities by status, and DRY up code

### DIFF
--- a/Gordon360/Controllers/ActivitiesController.cs
+++ b/Gordon360/Controllers/ActivitiesController.cs
@@ -28,7 +28,7 @@ namespace Gordon360.Controllers
         [HttpGet]
         [Route("")]
         [AllowAnonymous]
-        public ActionResult<ActivityInfoViewModel> Get()
+        public ActionResult<IEnumerable<ActivityInfoViewModel>> Get()
         {
             var all = _activityService.GetAll();
             return Ok(all);
@@ -106,49 +106,16 @@ namespace Gordon360.Controllers
         }
 
         /// <summary>
-        /// Get all the activities that have not yet been closed out for the current session
+        /// Get all activities that have not yet been closed out for the current session
         /// </summary>
-        /// <returns></returns>
+        /// <returns>Enumerable of ActivityInfo for each open activity in the current session</returns>
         [HttpGet]
         [Route("open")]
-        [AllowAnonymous]
-        public async Task<ActionResult<IEnumerable<string>>> GetOpenActivitiesAsync()
+        public ActionResult<IEnumerable<ActivityInfoViewModel>> GetOpenActivities()
         {
             var sessionCode = Helpers.GetCurrentSession(_context);
 
-            var activity_codes = _activityService.GetOpenActivities(sessionCode);
-
-            var activities = new List<ActivityInfoViewModel>();
-
-            foreach (var code in activity_codes)
-            {
-                activities.Add(_activityService.Get(code));
-            }
-
-            return Ok(activities);
-        }
-
-        /// <summary>
-        /// Get all the activities that have not yet been closed out for the current session for 
-        /// which a given user is the group admin
-        /// </summary>
-        /// <param name="id">The id of the user who is group admin</param>
-        /// <returns></returns>
-        [HttpGet]
-        [Route("{id}/open")]
-        [AllowAnonymous]
-        public async Task<ActionResult<IEnumerable<string>>> GetOpenActivitiesAsync(int id)
-        {
-            var sessionCode = Helpers.GetCurrentSession(_context);
-
-            var activity_codes = _activityService.GetOpenActivities(sessionCode, id);
-
-            var activities = new List<ActivityInfoViewModel>();
-
-            foreach (var code in activity_codes)
-            {
-                activities.Add(_activityService.Get(code));
-            }
+            var activities = _activityService.GetActivitiesByStatus(sessionCode, getOpen: true);
 
             return Ok(activities);
         }
@@ -156,47 +123,14 @@ namespace Gordon360.Controllers
         /// <summary>
         /// Get all the activities that are already closed out for the current session
         /// </summary>
-        /// <returns></returns>
+        /// <returns>Enumerable of ActivityInfo for each closed activity in the current session</returns>
         [HttpGet]
         [Route("closed")]
-        [AllowAnonymous]
-        public async Task<ActionResult<IEnumerable<string>>> GetClosedActivitiesAsync()
+        public ActionResult<IEnumerable<ActivityInfoViewModel>> GetClosedActivities()
         {
             var sessionCode = Helpers.GetCurrentSession(_context);
 
-            var activity_codes = _activityService.GetClosedActivities(sessionCode);
-
-            var activities = new List<ActivityInfoViewModel>();
-
-            foreach (var code in activity_codes)
-            {
-                activities.Add(_activityService.Get(code));
-            }
-
-            return Ok(activities);
-        }
-
-        /// <summary>
-        /// Get all the activities that are already closed out for the current session for
-        /// which a given user is group admin
-        /// </summary>
-        /// <param name="id">The id of the user who is group admin</param>
-        /// <returns></returns>
-        [HttpGet]
-        [Route("{id}/closed")]
-        [AllowAnonymous]
-        public async Task<ActionResult<IEnumerable<string>>> GetClosedActivitiesAsync(int id)
-        {
-            var sessionCode = Helpers.GetCurrentSession(_context);
-
-            var activity_codes = _activityService.GetClosedActivities(sessionCode, id);
-
-            var activities = new List<ActivityInfoViewModel>();
-
-            foreach (var code in activity_codes)
-            {
-                activities.Add(_activityService.Get(code));
-            }
+            var activities = _activityService.GetActivitiesByStatus(sessionCode, getOpen: false);
 
             return Ok(activities);
         }

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -96,33 +96,17 @@
             <param name="id"></param>
             <returns></returns>
         </member>
-        <member name="M:Gordon360.Controllers.ActivitiesController.GetOpenActivitiesAsync">
+        <member name="M:Gordon360.Controllers.ActivitiesController.GetOpenActivities">
             <summary>
-            Get all the activities that have not yet been closed out for the current session
+            Get all activities that have not yet been closed out for the current session
             </summary>
-            <returns></returns>
+            <returns>Enumerable of ActivityInfo for each open activity in the current session</returns>
         </member>
-        <member name="M:Gordon360.Controllers.ActivitiesController.GetOpenActivitiesAsync(System.Int32)">
-            <summary>
-            Get all the activities that have not yet been closed out for the current session for 
-            which a given user is the group admin
-            </summary>
-            <param name="id">The id of the user who is group admin</param>
-            <returns></returns>
-        </member>
-        <member name="M:Gordon360.Controllers.ActivitiesController.GetClosedActivitiesAsync">
+        <member name="M:Gordon360.Controllers.ActivitiesController.GetClosedActivities">
             <summary>
             Get all the activities that are already closed out for the current session
             </summary>
-            <returns></returns>
-        </member>
-        <member name="M:Gordon360.Controllers.ActivitiesController.GetClosedActivitiesAsync(System.Int32)">
-            <summary>
-            Get all the activities that are already closed out for the current session for
-            which a given user is group admin
-            </summary>
-            <param name="id">The id of the user who is group admin</param>
-            <returns></returns>
+            <returns>Enumerable of ActivityInfo for each closed activity in the current session</returns>
         </member>
         <member name="M:Gordon360.Controllers.ActivitiesController.Put(System.String,Gordon360.Models.ViewModels.InvolvementUpdateViewModel)">
             <summary>
@@ -1008,7 +992,7 @@
         </member>
         <member name="M:Gordon360.Controllers.RecIM.SeriesController.UpdateSeriesTeamRecordAsync(System.Int32,Gordon360.Models.ViewModels.RecIM.TeamRecordPatchViewModel)">
             <summary>
-            Gets all series winners
+            Updates team record manually (mitigates potential bugs)
             </summary>
             <param name="seriesID"></param>
             <param name="update">Updated team record</param>
@@ -1733,35 +1717,14 @@
             <param name="sessionCode">Code of the session to check</param>
             <returns></returns>
         </member>
-        <member name="M:Gordon360.Services.ActivityService.GetOpenActivities(System.String)">
+        <member name="M:Gordon360.Services.ActivityService.GetActivitiesByStatus(System.String,System.Boolean)">
             <summary>
-            Gets a collection of all the current open activities, by finding which activities have 
-            memberships with an END_DTE that is null
+            Gets all activities for a session with an open status matching the `getOpen` param
+            An activity is closed if it has a non-null `END_DTE`, and open otherwise
             </summary>
-            <returns>The collection of activity codes for open activities</returns>
-        </member>
-        <member name="M:Gordon360.Services.ActivityService.GetOpenActivities(System.String,System.Int32)">
-            <summary>
-            Gets a collection of all the current open activities for which a given user is group admin, by finding which activities have 
-            memberships with an END_DTE that is null
-            </summary>
-            <returns>The collection of activity codes for open activities</returns>
-        </member>
-        <member name="M:Gordon360.Services.ActivityService.GetClosedActivities(System.String)">
-            <summary>
-            Gets a collection of all the current activities already closed out, by finding which activities have 
-            memberships with an END_DTE that is not null
-            </summary>
-            <returns>The collection of activity codes for open activities</returns>
-        </member>
-        <member name="M:Gordon360.Services.ActivityService.GetClosedActivities(System.String,System.Int32)">
-            <summary>
-            Gets a collection of all the current closed activities for which a given user is group admin, by finding which activities have 
-            memberships with an END_DTE that is not null
-            </summary>
-            <param name="gordonID">The user's id</param>
-            <param name="sess_cde">The session we want to get the closed activities for</param>
-            <returns>The collection of activity codes for open activities</returns>
+            <param name="sess_cde">The session code of the session to find activities for</param>
+            <param name="getOpen">Whether to get open or closed activites</param>
+            <returns>Collection of activities for the specified session with a status matching the `getOpen` param</returns>
         </member>
         <member name="M:Gordon360.Services.ActivityService.Update(System.String,Gordon360.Models.ViewModels.InvolvementUpdateViewModel)">
             <summary>

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -125,10 +125,7 @@ namespace Gordon360.Services
         Task<IEnumerable<string>> GetActivityTypesForSessionAsync(string sessionCode);
         IEnumerable<ActivityInfoViewModel> GetAll();
         bool IsOpen(string activityCode, string sessionCode);
-        IEnumerable<string> GetOpenActivities(string sess_cde);
-        IEnumerable<string> GetOpenActivities(string sess_cde, int gordonID);
-        IEnumerable<string> GetClosedActivities(string sess_cde);
-        IEnumerable<string> GetClosedActivities(string sess_cde, int gordonID);
+        IQueryable<ActivityInfoViewModel> GetActivitiesByStatus(string sess_cde, bool getOpen);
         ACT_INFO Update(string activityCode, InvolvementUpdateViewModel activity);
         void CloseOutActivityForSession(string activityCode, string sess_cde);
         void OpenActivityForSession(string activityCode, string sess_cde);


### PR DESCRIPTION
The LINQ query for getting open and closed activities was broken, it was trying to select the full Group By aggregate (which can't be compiled to a valid SQL query). The solution is to only select the Activity Code column of the query (which was the only field being used from the output anyways).

I also noticed that we were selecting a list of activity codes, and then sending one query per code to get the full details of each activity - e.g. if there are 100 open activities, we were sending 101 SQL queries to load the data. I flattened this into one simple SQL query, so regardless of how many activities, we're only sending one query (with a `WHERE EXISTS` subquery) on the line.
The final query looks like this:
```sql
SELECT 
  [a].[ACT_CDE]
  , [a].[ACT_BLURB]
  , [a].[ACT_DESC]
  , [a].[ACT_IMG_PATH]
  , [a].[ACT_JOIN_INFO]
  , [a].[ACT_TYPE]
  , [a].[ACT_TYPE_DESC]
  , [a].[ACT_URL]
  , [a].[PRIVACY]
      FROM [ACT_INFO] AS [a]
      WHERE EXISTS (
          SELECT 1
          FROM [MEMBERSHIP] AS [m]
          WHERE (([m].[PART_CDE] <> 'GUEST')
            AND ([m].[SESS_CDE] = @__sess_cde_0))
            AND ([m].[END_DTE] IS NULL)
          GROUP BY [m].[ACT_CDE]
          HAVING [m].[ACT_CDE] = [a].[ACT_CDE])
```

In the refactoring process, I also simplified the code in two ways:
1. Since the only difference between getting open and closed activities is whether `END_DTE` is `null` or `not null`, I made this a parameter of the service method (currently the bool `getOpen` but maybe there's a clearer name?). That way we just add a `WHERE` clause to the `IQueryable` depending on that param.
2. We had dedicated routes for getting open and closed activities that a given user is a member of. These were never used - and I could not imagine a usecase for them that made sense. So I just deleted them. If we need this in the future, it's almost trivial to add a username param to the service method and recreate the routes.

I also fixed the return type of a couple methods, including the `ActivitiesController.Get()` method which is not relevant to these changes, but it's type was wrong.

Also, it's worth noting that the way this route works currently, you'll never see an activity that doesn't have any memberships. Because our activity tables are weirdly denormalized (because we're just mimicking parts of the Jenzabar schema), technically an activity in our database with no members is neither open nor closed. This is probably a bug, but one that is not immediately obvious how to solve.