### PR TITLE
Upgrade to .NET 8

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -9,10 +9,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup .NET Core SDK 6
-        uses: actions/setup-dotnet@v2
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '8.x'
 
       - name: Install dependencies
         run: dotnet restore
@@ -31,10 +31,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup .NET Core SDK 6
+      - name: Setup .NET SDK
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '8.x'
 
       - name: Install dependencies
         run: dotnet restore
@@ -60,10 +60,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup .NET Core SDK 6
+      - name: Setup .NET SDK
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '8.x'
 
       - name: Install dependencies
         run: dotnet restore

--- a/Gordon360/Gordon360.csproj
+++ b/Gordon360/Gordon360.csproj
@@ -1,43 +1,42 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-	<Target Name="GetGitHash" BeforeTargets="WriteGitHash" Condition="'$(BuildHash)' == ''">
-		<PropertyGroup>
-			<VerFile>$(IntermediateOutputPath)gitver</VerFile>
-			<BuildFile>$(IntermediateOutputPath)buildtime</BuildFile>
-		</PropertyGroup>
-		<Exec Command="git -C $(ProjectDir) describe --long --always &gt; $(VerFile)" />
-		<Exec Command="echo $([System.DateTime]::UtcNow) &gt; $(BuildFile)" />
-		<ReadLinesFromFile File="$(VerFile)">
-			<Output TaskParameter="Lines" ItemName="GitVersion" />
-		</ReadLinesFromFile>
-		<ReadLinesFromFile File="$(BuildFile)">
-			<Output TaskParameter="Lines" ItemName="BuildTime" />
-		</ReadLinesFromFile>
-		<PropertyGroup>
-			<BuildHash>@(GitVersion)</BuildHash>
-			<BuildTime>@(BuildTime)</BuildTime>
-		</PropertyGroup>
-	</Target>
-
-	<Target Name="WriteGitHash" BeforeTargets="CoreCompile">
-		<PropertyGroup>
-			<CustomAssemblyInfoFile>$(IntermediateOutputPath)CustomAssemblyInfo.cs</CustomAssemblyInfoFile>
-		</PropertyGroup>
-		<ItemGroup>
-			<Compile Include="$(CustomAssemblyInfoFile)" />
-		</ItemGroup>
-		<ItemGroup>
-			<AssemblyAttributes Include="AssemblyMetadata">
-				<_Parameter1>GitHash</_Parameter1>
-				<_Parameter2>$(BuildHash)</_Parameter2>
-			</AssemblyAttributes>
-			<AssemblyAttributes Include="AssemblyMetadata">
-				<_Parameter1>BuildTime</_Parameter1>
-				<_Parameter2>$(BuildTime)</_Parameter2>
-			</AssemblyAttributes>
-		</ItemGroup>
-		<WriteCodeFragment Language="C#" OutputFile="$(CustomAssemblyInfoFile)" AssemblyAttributes="@(AssemblyAttributes)" />
-	</Target>
-	<PropertyGroup>
+  <Target Name="GetGitHash" BeforeTargets="WriteGitHash" Condition="'$(BuildHash)' == ''">
+    <PropertyGroup>
+      <VerFile>$(IntermediateOutputPath)gitver</VerFile>
+      <BuildFile>$(IntermediateOutputPath)buildtime</BuildFile>
+    </PropertyGroup>
+    <Exec Command="git -C $(ProjectDir) describe --long --always &gt; $(VerFile)" />
+    <Exec Command="echo $([System.DateTime]::UtcNow) &gt; $(BuildFile)" />
+    <ReadLinesFromFile File="$(VerFile)">
+      <Output TaskParameter="Lines" ItemName="GitVersion" />
+    </ReadLinesFromFile>
+    <ReadLinesFromFile File="$(BuildFile)">
+      <Output TaskParameter="Lines" ItemName="BuildTime" />
+    </ReadLinesFromFile>
+    <PropertyGroup>
+      <BuildHash>@(GitVersion)</BuildHash>
+      <BuildTime>@(BuildTime)</BuildTime>
+    </PropertyGroup>
+  </Target>
+  <Target Name="WriteGitHash" BeforeTargets="CoreCompile">
+    <PropertyGroup>
+      <CustomAssemblyInfoFile>$(IntermediateOutputPath)CustomAssemblyInfo.cs</CustomAssemblyInfoFile>
+    </PropertyGroup>
+    <ItemGroup>
+      <Compile Include="$(CustomAssemblyInfoFile)" />
+    </ItemGroup>
+    <ItemGroup>
+      <AssemblyAttributes Include="AssemblyMetadata">
+        <_Parameter1>GitHash</_Parameter1>
+        <_Parameter2>$(BuildHash)</_Parameter2>
+      </AssemblyAttributes>
+      <AssemblyAttributes Include="AssemblyMetadata">
+        <_Parameter1>BuildTime</_Parameter1>
+        <_Parameter2>$(BuildTime)</_Parameter2>
+      </AssemblyAttributes>
+    </ItemGroup>
+    <WriteCodeFragment Language="C#" OutputFile="$(CustomAssemblyInfoFile)" AssemblyAttributes="@(AssemblyAttributes)" />
+  </Target>
+  <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
@@ -62,21 +61,16 @@
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="6.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.3" />
     <PackageReference Include="Microsoft.Graph" Version="4.27.0" />
     <PackageReference Include="Microsoft.Identity.Web" Version="1.23.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.DirectoryServices.AccountManagement" Version="8.0.0" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.DirectoryServices.AccountManagement" Version="6.0.0" />
-  </ItemGroup>
-  <PropertyGroup>
-    <StartupObject></StartupObject>
-  </PropertyGroup>
   <PropertyGroup>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
   </PropertyGroup>
@@ -96,7 +90,7 @@
   </PropertyGroup>
   <PropertyGroup />
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UserSecretsId>6b677d3a-d64b-4693-bfe1-4883788ecf0f</UserSecretsId>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
This Pull Request updates the API to use .NET 8 (the new Long-term Support version as of November 14, 2023). This version of .NET will be supported until 2026, and has MANY performance improvements (especially including the ones from .NET 7 as well).

While there are new features we can take advantage of by updating, they are not mandatory. After performing the upgrade with the .NET Upgrade Assistant (and testing it locally), there appear to be no breaking changes that affect our application.