### PR TITLE
Use primary constructors for Dependency Injection

### DIFF
--- a/Gordon360/Controllers/AcademicCheckInController.cs
+++ b/Gordon360/Controllers/AcademicCheckInController.cs
@@ -13,16 +13,8 @@ namespace Gordon360.Controllers.Api;
 [Route("api/checkIn")]
 [Authorize]
 [CustomExceptionFilter]
-public class AcademicCheckInController : ControllerBase
+public class AcademicCheckInController(IAcademicCheckInService academicCheckInService, IAccountService accountService) : ControllerBase
 {
-    private readonly IAcademicCheckInService _checkInService;
-    private readonly IAccountService _accountService;
-
-    public AcademicCheckInController(CCTContext context)
-    {
-        _checkInService = new AcademicCheckInService(context);
-        _accountService = new AccountService(context);
-    }
 
     /// <summary>Set emergency contacts for student</summary>
     /// <param name="data"> The contact data to be stored </param>
@@ -32,11 +24,11 @@ public class AcademicCheckInController : ControllerBase
     public async Task<ActionResult<EmergencyContactViewModel>> PutEmergencyContactAsync([FromBody] EmergencyContactViewModel data)
     {
         var username = AuthUtils.GetUsername(User);
-        var id = _accountService.GetAccountByUsername(username).GordonID;
+        var id = accountService.GetAccountByUsername(username).GordonID;
 
         try
         {
-            var result = await _checkInService.PutEmergencyContactAsync(data, id, username);
+            var result = await academicCheckInService.PutEmergencyContactAsync(data, id, username);
             return Created("Emergency Contact", result);
         }
         catch (System.Exception e)
@@ -57,11 +49,11 @@ public class AcademicCheckInController : ControllerBase
     public async Task<ActionResult<AcademicCheckInViewModel>> PutCellPhoneAsync([FromBody] AcademicCheckInViewModel data)
     {
         var username = AuthUtils.GetUsername(User);
-        var id = _accountService.GetAccountByUsername(username).GordonID;
+        var id = accountService.GetAccountByUsername(username).GordonID;
 
         try
         {
-            var result = await _checkInService.PutCellPhoneAsync(id, data);
+            var result = await academicCheckInService.PutCellPhoneAsync(id, data);
             return Ok(result);
         }
         catch (System.Exception e)
@@ -80,11 +72,11 @@ public class AcademicCheckInController : ControllerBase
     public async Task<ActionResult<AcademicCheckInViewModel>> PutDemographicAsync([FromBody] AcademicCheckInViewModel data)
     {
         var username = AuthUtils.GetUsername(User);
-        var id = _accountService.GetAccountByUsername(username).GordonID;
+        var id = accountService.GetAccountByUsername(username).GordonID;
 
         try
         {
-            var result = await _checkInService.PutDemographicAsync(id, data);
+            var result = await academicCheckInService.PutDemographicAsync(id, data);
             return Ok(result);
         }
         catch (System.Exception e)
@@ -102,11 +94,11 @@ public class AcademicCheckInController : ControllerBase
     public async Task<ActionResult<AcademicCheckInViewModel>> GetHoldsAsync()
     {
         var username = AuthUtils.GetUsername(User);
-        var id = _accountService.GetAccountByUsername(username).GordonID;
+        var id = accountService.GetAccountByUsername(username).GordonID;
 
         try
         {
-            var result = (await _checkInService.GetHoldsAsync(id)).First();
+            var result = (await academicCheckInService.GetHoldsAsync(id)).First();
             return Ok(result);
         }
         catch (System.Exception e)
@@ -124,11 +116,11 @@ public class AcademicCheckInController : ControllerBase
     public async Task<ActionResult> SetStatusAsync()
     {
         var username = AuthUtils.GetUsername(User);
-        var id = _accountService.GetAccountByUsername(username).GordonID;
+        var id = accountService.GetAccountByUsername(username).GordonID;
 
         try
         {
-            await _checkInService.SetStatusAsync(id);
+            await academicCheckInService.SetStatusAsync(id);
             return Ok();
         }
         catch (System.Exception e)
@@ -145,11 +137,11 @@ public class AcademicCheckInController : ControllerBase
     public async Task<ActionResult<AcademicCheckInViewModel>> GetStatusAsync()
     {
         var username = AuthUtils.GetUsername(User);
-        var id = _accountService.GetAccountByUsername(username).GordonID;
+        var id = accountService.GetAccountByUsername(username).GordonID;
 
         try
         {
-            var result = await _checkInService.GetStatusAsync(id);
+            var result = await academicCheckInService.GetStatusAsync(id);
             return Ok(result);
         }
         catch (System.Exception e)

--- a/Gordon360/Controllers/AccountsController.cs
+++ b/Gordon360/Controllers/AccountsController.cs
@@ -5,26 +5,20 @@ using Gordon360.Services;
 using Gordon360.Static.Names;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Gordon360.Controllers;
 
 [Route("api/[controller]")]
-public class AccountsController : GordonControllerBase
+public class AccountsController(IAccountService accountService) : GordonControllerBase
 {
-    private readonly IAccountService _accountService;
-
-    public AccountsController(IAccountService accountService)
-    {
-        _accountService = accountService;
-    }
-
     [HttpGet]
     [Route("email/{email}")]
     [StateYourBusiness(operation = Operation.READ_ONE, resource = Resource.ACCOUNT)]
     public ActionResult<AccountViewModel> GetByAccountEmail(string email)
     {
-        var result = _accountService.GetAccountByEmail(email);
+        var result = accountService.GetAccountByEmail(email);
 
         if (result == null)
         {
@@ -39,7 +33,7 @@ public class AccountsController : GordonControllerBase
     [StateYourBusiness(operation = Operation.READ_ONE, resource = Resource.ACCOUNT)]
     public ActionResult<AccountViewModel> GetByAccountUsername(string username)
     {
-        var result = _accountService.GetAccountByUsername(username);
+        var result = accountService.GetAccountByUsername(username);
 
         if (result == null)
         {
@@ -58,9 +52,9 @@ public class AccountsController : GordonControllerBase
     [Route("search/{searchString}")]
     public async Task<ActionResult<IEnumerable<BasicInfoViewModel>>> SearchAsync(string searchString)
     {
-        var accounts = await _accountService.GetAllBasicInfoExceptAlumniAsync();
+        var accounts = await accountService.GetAllBasicInfoExceptAlumniAsync();
 
-        var searchResults = _accountService.Search(searchString, accounts);
+        var searchResults = accountService.Search(searchString, accounts);
 
         return Ok(searchResults);
     }
@@ -75,9 +69,9 @@ public class AccountsController : GordonControllerBase
     [Route("search/{firstName}/{lastName}")]
     public async Task<ActionResult<IEnumerable<BasicInfoViewModel>>> SearchWithSpaceAsync(string firstName, string lastName)
     {
-        var accounts = await _accountService.GetAllBasicInfoExceptAlumniAsync();
+        var accounts = await accountService.GetAllBasicInfoExceptAlumniAsync();
 
-        var searchResults = _accountService.Search(firstName, lastName, accounts);
+        var searchResults = accountService.Search(firstName, lastName, accounts);
 
 
         return Ok(searchResults);
@@ -126,9 +120,9 @@ public class AccountsController : GordonControllerBase
     {
         IEnumerable<AuthGroup> viewerGroups = AuthUtils.GetGroups(User);
 
-        var accounts = _accountService.GetAccountsToSearch(accountTypes, viewerGroups, homeCity);
+        var accounts = accountService.GetAccountsToSearch(accountTypes, viewerGroups, homeCity);
 
-        var searchResults = _accountService.AdvancedSearch(
+        var searchResults = accountService.AdvancedSearch(
             accounts,
             firstname,
             lastname,

--- a/Gordon360/Controllers/ActivitiesController.cs
+++ b/Gordon360/Controllers/ActivitiesController.cs
@@ -1,4 +1,5 @@
 ﻿using Gordon360.Authorization;
+using Gordon360.Models.CCT;
 using Gordon360.Models.CCT.Context;
 using Gordon360.Models.ViewModels;
 using Gordon360.Services;
@@ -13,23 +14,14 @@ using System.Threading.Tasks;
 namespace Gordon360.Controllers;
 
 [Route("api/[controller]")]
-public class ActivitiesController : GordonControllerBase
+public class ActivitiesController(CCTContext context, IActivityService activityService) : GordonControllerBase
 {
-    private readonly IActivityService _activityService;
-    private readonly CCTContext _context;
-
-    public ActivitiesController(CCTContext context, IActivityService activityService)
-    {
-        _context = context;
-        _activityService = activityService;
-    }
-
     [HttpGet]
     [Route("")]
     [AllowAnonymous]
     public ActionResult<IEnumerable<ActivityInfoViewModel>> Get()
     {
-        var all = _activityService.GetAll();
+        var all = activityService.GetAll();
         return Ok(all);
     }
 
@@ -38,7 +30,7 @@ public class ActivitiesController : GordonControllerBase
     [AllowAnonymous]
     public ActionResult<ActivityInfoViewModel> Get(string id)
     {
-        var result = _activityService.Get(id);
+        var result = activityService.Get(id);
 
         if (result == null)
         {
@@ -57,7 +49,7 @@ public class ActivitiesController : GordonControllerBase
     [AllowAnonymous]
     public async Task<ActionResult<IEnumerable<ActivityInfoViewModel>>> GetActivitiesForSessionAsync(string id)
     {
-        var result = await _activityService.GetActivitiesForSessionAsync(id);
+        var result = await activityService.GetActivitiesForSessionAsync(id);
 
         if (result == null)
         {
@@ -77,7 +69,7 @@ public class ActivitiesController : GordonControllerBase
     [AllowAnonymous]
     public async Task<ActionResult<IEnumerable<string>>> GetActivityTypesForSessionAsync(string id)
     {
-        var result = await _activityService.GetActivityTypesForSessionAsync(id);
+        var result = await activityService.GetActivityTypesForSessionAsync(id);
 
         if (result == null)
         {
@@ -99,7 +91,7 @@ public class ActivitiesController : GordonControllerBase
     [AllowAnonymous]
     public ActionResult<bool> GetActivityStatus(string sessionCode, string id)
     {
-        var result = _activityService.IsOpen(id, sessionCode) ? "OPEN" : "CLOSED";
+        var result = activityService.IsOpen(id, sessionCode) ? "OPEN" : "CLOSED";
 
         return Ok(result);
     }
@@ -112,9 +104,9 @@ public class ActivitiesController : GordonControllerBase
     [Route("open")]
     public ActionResult<IEnumerable<ActivityInfoViewModel>> GetOpenActivities()
     {
-        var sessionCode = Helpers.GetCurrentSession(_context);
+        var sessionCode = Helpers.GetCurrentSession(context);
 
-        var activities = _activityService.GetActivitiesByStatus(sessionCode, getOpen: true);
+        var activities = activityService.GetActivitiesByStatus(sessionCode, getOpen: true);
 
         return Ok(activities);
     }
@@ -127,9 +119,9 @@ public class ActivitiesController : GordonControllerBase
     [Route("closed")]
     public ActionResult<IEnumerable<ActivityInfoViewModel>> GetClosedActivities()
     {
-        var sessionCode = Helpers.GetCurrentSession(_context);
+        var sessionCode = Helpers.GetCurrentSession(context);
 
-        var activities = _activityService.GetActivitiesByStatus(sessionCode, getOpen: false);
+        var activities = activityService.GetActivitiesByStatus(sessionCode, getOpen: false);
 
         return Ok(activities);
     }
@@ -144,7 +136,7 @@ public class ActivitiesController : GordonControllerBase
     [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.ACTIVITY_INFO)]
     public ActionResult<ActivityInfoViewModel> Put(string involvement_code, InvolvementUpdateViewModel involvement)
     {
-        var result = _activityService.Update(involvement_code, involvement);
+        var result = activityService.Update(involvement_code, involvement);
 
         if (result == null)
         {
@@ -159,7 +151,7 @@ public class ActivitiesController : GordonControllerBase
     [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.ACTIVITY_STATUS)]
     public ActionResult CloseSession(string id, string sess_cde)
     {
-        _activityService.CloseOutActivityForSession(id, sess_cde);
+        activityService.CloseOutActivityForSession(id, sess_cde);
 
         return Ok();
     }
@@ -169,7 +161,7 @@ public class ActivitiesController : GordonControllerBase
     [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.ACTIVITY_STATUS)]
     public ActionResult OpenSession(string id, string sess_cde)
     {
-        _activityService.OpenActivityForSession(id, sess_cde);
+        activityService.OpenActivityForSession(id, sess_cde);
 
         return Ok();
     }
@@ -185,14 +177,14 @@ public class ActivitiesController : GordonControllerBase
     [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.ACTIVITY_INFO)]
     public async Task<ActionResult<ActivityInfoViewModel>> PostImageAsync(string involvement_code, [FromForm] IFormFile image)
     {
-        var involvement = await _context.ACT_INFO.FindAsync(involvement_code);
+        var involvement = await context.ACT_INFO.FindAsync(involvement_code);
         if (involvement is null)
         {
             return NotFound("Involvement not found");
         }
 
-        ActivityInfoViewModel updatedInvolvement = await _activityService.UpdateActivityImageAsync(involvement, image);
-
+        ActivityInfoViewModel updatedInvolvement = await activityService.UpdateActivityImageAsync(involvement, image);
+        
         return Ok(updatedInvolvement);
     }
 
@@ -206,7 +198,7 @@ public class ActivitiesController : GordonControllerBase
     [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.ACTIVITY_INFO)]
     public ActionResult ResetImage(string involvement_code)
     {
-        _activityService.ResetActivityImage(involvement_code);
+        activityService.ResetActivityImage(involvement_code);
 
         return Ok();
     }
@@ -220,7 +212,7 @@ public class ActivitiesController : GordonControllerBase
     [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.ACTIVITY_INFO)]
     public ActionResult TogglePrivacy(string involvement_code, bool p)
     {
-        _activityService.TogglePrivacy(involvement_code, p);
+        activityService.TogglePrivacy(involvement_code, p);
         return Ok();
     }
 

--- a/Gordon360/Controllers/AddressesController.cs
+++ b/Gordon360/Controllers/AddressesController.cs
@@ -7,14 +7,8 @@ using System.Collections.Generic;
 namespace Gordon360.Controllers;
 
 [Route("api/[controller]")]
-public class AddressesController : GordonControllerBase
+public class AddressesController(IAddressesService addressesService) : GordonControllerBase
 {
-    private readonly IAddressesService _addressesService;
-
-    public AddressesController(IAddressesService addressesService)
-    {
-        _addressesService = addressesService;
-    }
 
     /// <summary>
     /// Pulls all states available from Jenzabar States Table
@@ -24,7 +18,7 @@ public class AddressesController : GordonControllerBase
     [Route("states")]
     public ActionResult<IEnumerable<States>> GetAllStates()
     {
-        var result = _addressesService.GetAllStates();
+        var result = addressesService.GetAllStates();
 
         return Ok(result);
     }
@@ -37,7 +31,7 @@ public class AddressesController : GordonControllerBase
     [Route("countries")]
     public ActionResult<IEnumerable<CountryViewModel>> GetAllCountries()
     {
-        var result = _addressesService.GetAllCountries();
+        var result = addressesService.GetAllCountries();
 
         return Ok(result);
     }

--- a/Gordon360/Controllers/AdminsController.cs
+++ b/Gordon360/Controllers/AdminsController.cs
@@ -1,4 +1,6 @@
 ﻿using Gordon360.Authorization;
+using Gordon360.Models.CCT.Context;
+using Gordon360.Models.CCT;
 using Gordon360.Models.ViewModels;
 using Gordon360.Services;
 using Gordon360.Static.Names;
@@ -8,14 +10,8 @@ using System.Collections.Generic;
 namespace Gordon360.Controllers;
 
 [Route("api/[controller]")]
-public class AdminsController : GordonControllerBase
+public class AdminsController(IAdministratorService adminService) : GordonControllerBase
 {
-    private readonly IAdministratorService _adminService;
-
-    public AdminsController(IAdministratorService adminService)
-    {
-        _adminService = adminService;
-    }
 
     /// <summary>
     /// Get all admins
@@ -32,7 +28,7 @@ public class AdminsController : GordonControllerBase
     [StateYourBusiness(operation = Operation.READ_ALL, resource = Resource.ADMIN)]
     public ActionResult<IEnumerable<AdminViewModel?>> GetAll()
     {
-        var result = _adminService.GetAll();
+        var result = adminService.GetAll();
         return Ok(result);
     }
 
@@ -46,7 +42,7 @@ public class AdminsController : GordonControllerBase
     [StateYourBusiness(operation = Operation.ADD, resource = Resource.ADMIN)]
     public ActionResult<AdminViewModel> Post([FromBody] AdminViewModel admin)
     {
-        var result = _adminService.Add(admin);
+        var result = adminService.Add(admin);
 
         if (result == null)
         {
@@ -65,7 +61,7 @@ public class AdminsController : GordonControllerBase
     [StateYourBusiness(operation = Operation.DELETE, resource = Resource.ADMIN)]
     public ActionResult<AdminViewModel> Delete(string username)
     {
-        var result = _adminService.Delete(username);
+        var result = adminService.Delete(username);
 
         if (result == null)
         {

--- a/Gordon360/Controllers/AdvancedSearchController.cs
+++ b/Gordon360/Controllers/AdvancedSearchController.cs
@@ -6,14 +6,8 @@ using System.Linq;
 namespace Gordon360.Controllers;
 
 [Route("api/[controller]")]
-public class AdvancedSearchController : GordonControllerBase
+public class AdvancedSearchController(CCTContext context) : GordonControllerBase
 {
-    private readonly CCTContext _context;
-
-    public AdvancedSearchController(CCTContext context)
-    {
-        _context = context;
-    }
 
     /// <summary>
     /// Return a list majors.
@@ -23,7 +17,7 @@ public class AdvancedSearchController : GordonControllerBase
     [Route("majors")]
     public ActionResult<IEnumerable<string>> GetMajors()
     {
-        var majors = _context.Majors.OrderBy(m => m.MajorDescription)
+        var majors = context.Majors.OrderBy(m => m.MajorDescription)
                              .Select(m => m.MajorDescription)
                              .Distinct();
         return Ok(majors);
@@ -37,7 +31,7 @@ public class AdvancedSearchController : GordonControllerBase
     [Route("minors")]
     public ActionResult<IEnumerable<string>> GetMinors()
     {
-        var minors = _context.Student.Select(s => s.Minor1Description)
+        var minors = context.Student.Select(s => s.Minor1Description)
                               .Distinct()
                               .Where(s => s != null);
         return Ok(minors);
@@ -51,7 +45,7 @@ public class AdvancedSearchController : GordonControllerBase
     [Route("halls")]
     public ActionResult<IEnumerable<string>> GetHalls()
     {
-        var halls = _context.Student.Select(s => s.BuildingDescription)
+        var halls = context.Student.Select(s => s.BuildingDescription)
                               .Distinct()
                               .Where(b => b != null)
                               .OrderBy(b => b);
@@ -68,9 +62,9 @@ public class AdvancedSearchController : GordonControllerBase
     [Route("states")]
     public ActionResult<IEnumerable<string>> DEPRECATED_GetStates()
     {
-        var studentStates = _context.Student.Select(s => s.HomeState).AsEnumerable();
-        var facStaffStates = _context.FacStaff.Select(fs => fs.HomeState).AsEnumerable();
-        var alumniStates = _context.Alumni.Select(a => a.HomeState).AsEnumerable();
+        var studentStates = context.Student.Select(s => s.HomeState).AsEnumerable();
+        var facStaffStates = context.FacStaff.Select(fs => fs.HomeState).AsEnumerable();
+        var alumniStates = context.Alumni.Select(a => a.HomeState).AsEnumerable();
 
         var states = studentStates
                               .Union(facStaffStates)
@@ -92,9 +86,9 @@ public class AdvancedSearchController : GordonControllerBase
     [Route("countries")]
     public ActionResult<IEnumerable<string>> DEPREACTED_GetCountries()
     {
-        var studentCountries = _context.Student.Select(s => s.Country).AsEnumerable();
-        var facstaffCountries = _context.FacStaff.Select(fs => fs.Country).AsEnumerable();
-        var alumniCountries = _context.Alumni.Select(a => a.Country).AsEnumerable();
+        var studentCountries = context.Student.Select(s => s.Country).AsEnumerable();
+        var facstaffCountries = context.FacStaff.Select(fs => fs.Country).AsEnumerable();
+        var alumniCountries = context.Alumni.Select(a => a.Country).AsEnumerable();
 
         var countries = studentCountries
                               .Union(facstaffCountries)
@@ -113,7 +107,7 @@ public class AdvancedSearchController : GordonControllerBase
     [Route("departments")]
     public ActionResult<IEnumerable<string>> GetDepartments()
     {
-        var departments = _context.FacStaff.Select(fs => fs.OnCampusDepartment)
+        var departments = context.FacStaff.Select(fs => fs.OnCampusDepartment)
                                .Distinct()
                                .Where(d => d != null)
                                .OrderBy(d => d);
@@ -129,7 +123,7 @@ public class AdvancedSearchController : GordonControllerBase
     [Route("buildings")]
     public ActionResult<IEnumerable<string>> GetBuildings()
     {
-        var buildings = _context.FacStaff.Select(fs => fs.BuildingDescription)
+        var buildings = context.FacStaff.Select(fs => fs.BuildingDescription)
                                .Distinct()
                                .Where(d => d != null)
                                .OrderBy(d => d);
@@ -144,7 +138,7 @@ public class AdvancedSearchController : GordonControllerBase
     [Route("involvements")]
     public ActionResult<IEnumerable<string>> GetInvolvements()
     {
-        var involvements = _context.MembershipView.Select(m => m.ActivityDescription)
+        var involvements = context.MembershipView.Select(m => m.ActivityDescription)
                                .Distinct()
                                .Where(d => d != null)
                                .OrderBy(d => d);

--- a/Gordon360/Controllers/CliftonStrengthsController.cs
+++ b/Gordon360/Controllers/CliftonStrengthsController.cs
@@ -1,28 +1,20 @@
-using Gordon360.Authorization;
-using Gordon360.Exceptions;
-using Gordon360.Models.CCT;
+using Microsoft.AspNetCore.Mvc;
 using Gordon360.Models.CCT.Context;
 using Gordon360.Models.ViewModels;
 using Gordon360.Services;
 using Gordon360.Static.Names;
-using Microsoft.AspNetCore.Mvc;
+using Gordon360.Authorization;
 using System.Collections.Generic;
 using System.Linq;
+using System;
+using Gordon360.Models.CCT;
+using Gordon360.Exceptions;
 
 namespace Gordon360.Controllers;
 
 [Route("api/[controller]")]
-public class CliftonStrengthsController : GordonControllerBase
+public class CliftonStrengthsController(CCTContext context, IAccountService accountService) : GordonControllerBase
 {
-    private readonly CCTContext _context;
-    private readonly IAccountService _accountsService;
-
-    public CliftonStrengthsController(CCTContext context, IAccountService accountService)
-    {
-        _context = context;
-        _accountsService = accountService;
-    }
-
     [HttpPost]
     [Route("")]
     [StateYourBusiness(operation = Operation.ADD, resource = Resource.CLIFTON_STRENGTHS)]
@@ -33,12 +25,11 @@ public class CliftonStrengthsController : GordonControllerBase
             AccountViewModel account;
             try
             {
-                account = _accountsService.GetAccountByEmail(cs.Email);
+                account = accountService.GetAccountByEmail(cs.Email);
             }
             catch (ResourceNotFoundException e)
             {
-                return new CliftonStrengthsUploadResultViewModel()
-                {
+                return new CliftonStrengthsUploadResultViewModel() {
                     Email = cs.Email,
                     AccessCode = cs.AccessCode,
                     UploadResult = "Not Found"
@@ -47,7 +38,7 @@ public class CliftonStrengthsController : GordonControllerBase
             int gordonID = int.Parse(account.GordonID);
             string rowState;
 
-            Clifton_Strengths? existing = _context.Clifton_Strengths.FirstOrDefault(x => x.ID_NUM == gordonID);
+            Clifton_Strengths? existing = context.Clifton_Strengths.FirstOrDefault(x => x.ID_NUM == gordonID);
 
             try
             {
@@ -59,11 +50,11 @@ public class CliftonStrengthsController : GordonControllerBase
                     existing.THEME_4 = cs.Themes[3];
                     existing.THEME_5 = cs.Themes[4];
                     existing.DTE_COMPLETED = cs.DateCompleted;
-                    rowState = _context.Clifton_Strengths.Update(existing).State.ToString();
+                    rowState = context.Clifton_Strengths.Update(existing).State.ToString();
                 }
                 else
                 {
-                    rowState = _context.Clifton_Strengths.Add(new Clifton_Strengths()
+                    rowState = context.Clifton_Strengths.Add(new Clifton_Strengths()
                     {
                         ACCESS_CODE = cs.AccessCode,
                         ID_NUM = gordonID,
@@ -72,20 +63,19 @@ public class CliftonStrengthsController : GordonControllerBase
                         THEME_3 = cs.Themes[2],
                         THEME_4 = cs.Themes[3],
                         THEME_5 = cs.Themes[4],
-                        DTE_COMPLETED = cs.DateCompleted,
+                    DTE_COMPLETED = cs.DateCompleted,
                         EMAIL = cs.Email,
                         Private = false
                     }).State.ToString();
                 }
-                _context.SaveChanges();
+                context.SaveChanges();
             }
             catch
             {
                 rowState = "Failed";
             }
 
-            return new CliftonStrengthsUploadResultViewModel()
-            {
+            return new CliftonStrengthsUploadResultViewModel() {
                 Email = cs.Email,
                 AccessCode = cs.AccessCode,
                 UploadResult = rowState

--- a/Gordon360/Controllers/ContentManagementController.cs
+++ b/Gordon360/Controllers/ContentManagementController.cs
@@ -1,9 +1,10 @@
 ﻿using Gordon360.Authorization;
-using Gordon360.Models.CCT;
 using Gordon360.Models.CCT.Context;
+using Gordon360.Models.CCT;
 using Gordon360.Models.ViewModels;
 using Gordon360.Services;
 using Gordon360.Static.Names;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
@@ -11,16 +12,9 @@ using System.Collections.Generic;
 namespace Gordon360.Controllers;
 
 [Route("api/[controller]")]
-public class ContentManagementController : GordonControllerBase
+public class ContentManagementController(CCTContext context, IWebHostEnvironment webHostEnvironment) : GordonControllerBase
 {
-    private readonly IContentManagementService _contentManagementService;
-    private readonly IWebHostEnvironment _webHostEnvironment;
-
-    public ContentManagementController(CCTContext context, IWebHostEnvironment webHostEnvironment)
-    {
-        _contentManagementService = new ContentManagementService(context);
-        _webHostEnvironment = webHostEnvironment;
-    }
+    private readonly IContentManagementService _contentManagementService = new ContentManagementService(context);
 
     /// <summary>Get all the banner slides for the dashboard banner</summary>
     /// <returns>A list of all the slides for the banner</returns>
@@ -46,7 +40,7 @@ public class ContentManagementController : GordonControllerBase
     public ActionResult<Slider_Images> PostBannerSlide(BannerSlidePostViewModel slide)
     {
         var serverURL = $"{Request.Scheme}://{Request.Host}{Request.PathBase}";
-        var result = _contentManagementService.AddBannerSlide(slide, serverURL, _webHostEnvironment.ContentRootPath);
+        var result = _contentManagementService.AddBannerSlide(slide, serverURL, webHostEnvironment.ContentRootPath);
         if (result == null)
         {
             return NotFound();

--- a/Gordon360/Controllers/DiningController.cs
+++ b/Gordon360/Controllers/DiningController.cs
@@ -3,26 +3,14 @@ using Gordon360.Models.CCT.Context;
 using Gordon360.Services;
 using Gordon360.Static.Methods;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Configuration;
 using System.Threading.Tasks;
 
 namespace Gordon360.Controllers;
 
 [Route("api/[controller]")]
-public class DiningController : GordonControllerBase
+public class DiningController(CCTContext context, IDiningService diningService, IAccountService accountService) : GordonControllerBase
 {
-    private readonly IDiningService _diningService;
-    private readonly IAccountService _accountService;
-    private readonly CCTContext _context;
-
     private const string FACSTAFF_MEALPLAN_ID = "7295";
-
-    public DiningController(IConfiguration config, CCTContext context)
-    {
-        _context = context;
-        _diningService = new DiningService(context, config);
-        _accountService = new AccountService(context);
-    }
 
     /// <summary>
     ///  Gets information about student's dining plan and balance
@@ -32,10 +20,10 @@ public class DiningController : GordonControllerBase
     [Route("")]
     public async Task<ActionResult<string>> GetAsync()
     {
-        var sessionCode = Helpers.GetCurrentSession(_context);
+        var sessionCode = Helpers.GetCurrentSession(context);
         var authenticatedUsername = AuthUtils.GetUsername(User);
-        var authenticatedUserId = int.Parse(_accountService.GetAccountByUsername(authenticatedUsername).GordonID);
-        var diningInfo = _diningService.GetDiningPlanInfo(authenticatedUserId, sessionCode);
+        var authenticatedUserId = int.Parse(accountService.GetAccountByUsername(authenticatedUsername).GordonID);
+        var diningInfo = diningService.GetDiningPlanInfo(authenticatedUserId, sessionCode);
 
         if (diningInfo == null)
         {

--- a/Gordon360/Controllers/EmailsController.cs
+++ b/Gordon360/Controllers/EmailsController.cs
@@ -9,21 +9,14 @@ using System.Collections.Generic;
 namespace Gordon360.Controllers;
 
 [Route("api/[controller]")]
-public class EmailsController : GordonControllerBase
+public class EmailsController(IEmailService emailService) : GordonControllerBase
 {
-    private readonly IEmailService _emailService;
-
-    public EmailsController(IEmailService emailService)
-    {
-        _emailService = emailService;
-    }
-
     [HttpGet]
     [Route("involvement/{activityCode}")]
     [StateYourBusiness(operation = Operation.READ_PARTIAL, resource = Resource.EMAILS_BY_ACTIVITY)]
     public ActionResult<IEnumerable<EmailViewModel>> GetEmailsForActivity(string activityCode, string? sessionCode = null, [FromQuery] List<string>? participationTypes = null)
     {
-        var result = _emailService.GetEmailsForActivity(activityCode, sessionCode, participationTypes);
+        var result = emailService.GetEmailsForActivity(activityCode, sessionCode, participationTypes);
 
         return Ok(result);
     }
@@ -34,7 +27,7 @@ public class EmailsController : GordonControllerBase
     [Obsolete("Use the new route that accepts a list of participation types instead")]
     public ActionResult<IEnumerable<EmailViewModel>> DEPRECATED_GetEmailsForActivity(string activityCode, string? sessionCode, string? participationType)
     {
-        var result = _emailService.GetEmailsForActivity(activityCode, sessionCode, new List<string> { participationType ?? "" });
+        var result = emailService.GetEmailsForActivity(activityCode, sessionCode, new List<string> { participationType ?? "" });
 
         return Ok(result);
     }
@@ -44,7 +37,7 @@ public class EmailsController : GordonControllerBase
     public ActionResult SendEmails([FromBody] EmailContentViewModel email)
     {
         var to_emails = email.ToAddress.Split(',');
-        _emailService.SendEmails(to_emails, email.FromAddress, email.Subject, email.Content, email.Password);
+        emailService.SendEmails(to_emails, email.FromAddress, email.Subject, email.Content, email.Password);
         return Ok();
     }
 
@@ -53,7 +46,7 @@ public class EmailsController : GordonControllerBase
     [StateYourBusiness(operation = Operation.READ_PARTIAL, resource = Resource.EMAILS_BY_ACTIVITY)]
     public ActionResult SendEmailToActivity(string id, string session, [FromBody] EmailContentViewModel email)
     {
-        _emailService.SendEmailToActivity(id, session, email.FromAddress, email.Subject, email.Content, email.Password);
+        emailService.SendEmailToActivity(id, session, email.FromAddress, email.Subject, email.Content, email.Password);
 
         return Ok();
     }

--- a/Gordon360/Controllers/EventsController.cs
+++ b/Gordon360/Controllers/EventsController.cs
@@ -1,22 +1,18 @@
 ﻿using Gordon360.Authorization;
+using Gordon360.Models.CCT.Context;
 using Gordon360.Models.ViewModels;
 using Gordon360.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Gordon360.Controllers;
 
 [Route("api/[controller]")]
-public class EventsController : GordonControllerBase
+public class EventsController(IEventService eventService) : GordonControllerBase
 {
-    private readonly IEventService _eventService;
-
-    public EventsController(IEventService eventService)
-    {
-        _eventService = eventService;
-    }
-
     [HttpGet]
     [Route("attended/{term}")]
     public ActionResult<IEnumerable<AttendedEventViewModel>> GetEventsByTerm(string term)
@@ -24,7 +20,7 @@ public class EventsController : GordonControllerBase
         //get token data from context, username is the username of current logged in person
         var authenticatedUserUsername = AuthUtils.GetUsername(User);
 
-        var result = _eventService.GetEventsForStudentByTerm(authenticatedUserUsername, term);
+        var result = eventService.GetEventsForStudentByTerm(authenticatedUserUsername, term);
 
         if (result == null)
         {
@@ -42,7 +38,7 @@ public class EventsController : GordonControllerBase
     [Route("")]
     public ActionResult<IEnumerable<EventViewModel>> GetAllEvents()
     {
-        var result = _eventService.GetAllEvents();
+        var result = eventService.GetAllEvents();
 
         if (result == null)
         {
@@ -57,7 +53,7 @@ public class EventsController : GordonControllerBase
     [Route("claw")]
     public ActionResult<IEnumerable<EventViewModel>> GetAllChapelEvents()
     {
-        var result = _eventService.GetCLAWEvents();
+        var result = eventService.GetCLAWEvents();
 
         if (result == null)
         {
@@ -73,7 +69,7 @@ public class EventsController : GordonControllerBase
     [Route("public")]
     public ActionResult<IEnumerable<EventViewModel>> GetAllPublicEvents()
     {
-        var result = _eventService.GetPublicEvents();
+        var result = eventService.GetPublicEvents();
 
         if (result == null)
         {

--- a/Gordon360/Controllers/GordonControllerBase.cs
+++ b/Gordon360/Controllers/GordonControllerBase.cs
@@ -23,6 +23,4 @@ namespace Gordon360.Controllers;
 [ApiController]
 [Authorize]
 [CustomExceptionFilter]
-public class GordonControllerBase : ControllerBase
-{
-}
+public class GordonControllerBase : ControllerBase {}

--- a/Gordon360/Controllers/LogController.cs
+++ b/Gordon360/Controllers/LogController.cs
@@ -8,14 +8,8 @@ using Microsoft.AspNetCore.Mvc;
 namespace Gordon360.Controllers;
 
 [Route("api/[controller]")]
-public class LogController : GordonControllerBase
+public class LogController(IErrorLogService errorLogService) : GordonControllerBase
 {
-    private readonly IErrorLogService _errorLogService;
-
-    public LogController(IErrorLogService errorLogService)
-    {
-        _errorLogService = errorLogService;
-    }
 
     /// <summary>Create a new error log item to be added to database</summary>
     /// <param name="error_message">The error message containing all required and relevant information</param>
@@ -32,7 +26,7 @@ public class LogController : GordonControllerBase
             throw new BadInputException();
         }
 
-        var result = _errorLogService.Log(error_message);
+        var result = errorLogService.Log(error_message);
 
         return Created("error log", result);
     }

--- a/Gordon360/Controllers/MembershipsController.cs
+++ b/Gordon360/Controllers/MembershipsController.cs
@@ -13,14 +13,8 @@ using System.Threading.Tasks;
 namespace Gordon360.Controllers;
 
 [Route("api/[controller]")]
-public class MembershipsController : GordonControllerBase
+public class MembershipsController(IMembershipService membershipService) : GordonControllerBase
 {
-    private readonly IMembershipService _membershipService;
-
-    public MembershipsController(IMembershipService membershipService)
-    {
-        _membershipService = membershipService;
-    }
 
     /// <summary>
     /// Get all the memberships associated with a given activity
@@ -37,7 +31,7 @@ public class MembershipsController : GordonControllerBase
         var authenticatedUserUsername = AuthUtils.GetUsername(User);
         var viewerGroups = AuthUtils.GetGroups(User);
 
-        var memberships = _membershipService.GetMemberships(
+        var memberships = membershipService.GetMemberships(
             activityCode: involvementCode,
             username: username,
             sessionCode: sessionCode,
@@ -49,7 +43,7 @@ public class MembershipsController : GordonControllerBase
             && !(viewerGroups.Contains(AuthGroup.SiteAdmin) || viewerGroups.Contains(AuthGroup.Police))
             )
         {
-            memberships = _membershipService.RemovePrivateMemberships(memberships, authenticatedUserUsername);
+            memberships = membershipService.RemovePrivateMemberships(memberships, authenticatedUserUsername);
         }
 
         return Ok(memberships);
@@ -68,7 +62,7 @@ public class MembershipsController : GordonControllerBase
     [StateYourBusiness(operation = Operation.READ_ONE, resource = Resource.MEMBERSHIP)]
     public ActionResult<int> GetMembershipCount(string? activityCode = null, string? username = null, string? sessionCode = null, [FromQuery] List<string>? participationTypes = null)
     {
-        var result = _membershipService
+        var result = membershipService
             .GetMemberships(
                 activityCode: activityCode,
                 username: username,
@@ -92,7 +86,7 @@ public class MembershipsController : GordonControllerBase
     [Obsolete("Use the new route at /api/memberships instead")]
     public ActionResult<IEnumerable<MembershipView>> GetMembershipsForActivityAndSession(string activityCode, string sessionCode)
     {
-        var result = _membershipService.GetMemberships(activityCode: activityCode, sessionCode: sessionCode);
+        var result = membershipService.GetMemberships(activityCode: activityCode, sessionCode: sessionCode);
 
         return Ok(result);
     }
@@ -108,7 +102,7 @@ public class MembershipsController : GordonControllerBase
     [Obsolete("Use the new route at /api/memberships instead")]
     public ActionResult<IEnumerable<MembershipView>> GetGroupAdminsForActivity(string activityCode, string sessionCode)
     {
-        var result = _membershipService.GetMemberships(
+        var result = membershipService.GetMemberships(
             activityCode: activityCode,
             sessionCode: sessionCode,
             participationTypes: new List<string> { Participation.GroupAdmin.GetCode() });
@@ -128,7 +122,7 @@ public class MembershipsController : GordonControllerBase
     [Obsolete("Use the new route at /api/memberships/count instead")]
     public ActionResult<int> GetActivitySubscribersCountForSession(string activityCode, string sessionCode)
     {
-        var result = _membershipService
+        var result = membershipService
             .GetMemberships(
                 activityCode: activityCode,
                 sessionCode: sessionCode,
@@ -151,7 +145,7 @@ public class MembershipsController : GordonControllerBase
     [Obsolete("Use the new route at /api/memberships/count instead")]
     public ActionResult<int> GetActivityMembersCountForSession(string activityCode, string sessionCode)
     {
-        var result = _membershipService
+        var result = membershipService
             .GetMemberships(
                 activityCode: activityCode,
                 sessionCode: sessionCode)
@@ -169,7 +163,7 @@ public class MembershipsController : GordonControllerBase
     [StateYourBusiness(operation = Operation.ADD, resource = Resource.MEMBERSHIP)]
     public async Task<ActionResult<MembershipView>> PostAsync([FromBody] MembershipUploadViewModel membershipUpload)
     {
-        var result = await _membershipService.AddAsync(membershipUpload);
+        var result = await membershipService.AddAsync(membershipUpload);
 
         if (result == null)
         {
@@ -190,7 +184,7 @@ public class MembershipsController : GordonControllerBase
     [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.MEMBERSHIP)]
     public async Task<ActionResult<MembershipView>> PutAsync(int membershipID, [FromBody] MembershipUploadViewModel membership)
     {
-        var result = await _membershipService.UpdateAsync(membershipID, membership);
+        var result = await membershipService.UpdateAsync(membershipID, membership);
 
         return Ok(result);
     }
@@ -205,7 +199,7 @@ public class MembershipsController : GordonControllerBase
     [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.MEMBERSHIP)]
     public async Task<ActionResult<MembershipView>> SetGroupAdminAsync(int membershipID, [FromBody] bool isGroupAdmin)
     {
-        var result = await _membershipService.SetGroupAdminAsync(membershipID, isGroupAdmin);
+        var result = await membershipService.SetGroupAdminAsync(membershipID, isGroupAdmin);
 
         return Ok(result);
     }
@@ -221,7 +215,7 @@ public class MembershipsController : GordonControllerBase
     public async Task<ActionResult<MembershipView>> SetPrivacyAsync(int membershipID, [FromBody] bool isPrivate)
     {
 
-        var updatedMembership = await _membershipService.SetPrivacyAsync(membershipID, isPrivate);
+        var updatedMembership = await membershipService.SetPrivacyAsync(membershipID, isPrivate);
         return Ok(updatedMembership);
     }
 
@@ -234,7 +228,7 @@ public class MembershipsController : GordonControllerBase
     [StateYourBusiness(operation = Operation.DELETE, resource = Resource.MEMBERSHIP)]
     public ActionResult<MembershipView> Delete(int membershipID)
     {
-        var result = _membershipService.Delete(membershipID);
+        var result = membershipService.Delete(membershipID);
 
         return Ok(result);
     }

--- a/Gordon360/Controllers/NewsController.cs
+++ b/Gordon360/Controllers/NewsController.cs
@@ -11,14 +11,8 @@ using System.Threading.Tasks;
 namespace Gordon360.Controllers;
 
 [Route("api/[controller]")]
-public class NewsController : GordonControllerBase
+public class NewsController(INewsService newsService) : GordonControllerBase
 {
-    private readonly INewsService _newsService;
-
-    public NewsController(INewsService newsService)
-    {
-        _newsService = newsService;
-    }
 
     /// <summary>Gets a news item by id from the database</summary>
     /// <param name="newsID">The id of the news item to retrieve</param>
@@ -30,7 +24,7 @@ public class NewsController : GordonControllerBase
     public ActionResult<StudentNewsViewModel> GetByID(int newsID)
     {
         // StateYourBusiness verifies that user is authenticated
-        var result = (StudentNewsViewModel)_newsService.Get(newsID);
+        var result = (StudentNewsViewModel)newsService.Get(newsID);
         if (result == null)
         {
             return NotFound();
@@ -48,7 +42,7 @@ public class NewsController : GordonControllerBase
     [Route("{newsID}/image")]
     public ActionResult<string> GetImage(int newsID)
     {
-        var result = (StudentNewsViewModel)_newsService.Get(newsID);
+        var result = (StudentNewsViewModel)newsService.Get(newsID);
         if (result == null)
         {
             return NotFound();
@@ -64,7 +58,7 @@ public class NewsController : GordonControllerBase
     [Route("not-expired")]
     public async Task<ActionResult<IOrderedEnumerable<StudentNewsViewModel>>> GetNotExpiredAsync()
     {
-        var result = await _newsService.GetNewsNotExpiredAsync();
+        var result = await newsService.GetNewsNotExpiredAsync();
         if (result == null)
         {
             return NotFound();
@@ -80,7 +74,7 @@ public class NewsController : GordonControllerBase
     [Route("new")]
     public async Task<ActionResult<IEnumerable<StudentNewsViewModel>>> GetNewAsync()
     {
-        var result = await _newsService.GetNewsNewAsync();
+        var result = await newsService.GetNewsNewAsync();
         if (result == null)
         {
             return NotFound();
@@ -94,7 +88,7 @@ public class NewsController : GordonControllerBase
     [Route("categories")]
     public ActionResult<IEnumerable<StudentNewsCategoryViewModel>> GetCategories()
     {
-        var result = _newsService.GetNewsCategories();
+        var result = newsService.GetNewsCategories();
         if (result == null)
         {
             return NotFound();
@@ -107,7 +101,7 @@ public class NewsController : GordonControllerBase
     [StateYourBusiness(operation = Operation.READ_ALL, resource = Resource.NEWS)]
     public ActionResult<IEnumerable<StudentNewsViewModel>> GetNewsUnapproved()
     {
-        var result = _newsService.GetNewsUnapproved();
+        var result = newsService.GetNewsUnapproved();
         return Ok(result);
     }
 
@@ -123,14 +117,14 @@ public class NewsController : GordonControllerBase
         var authenticatedUserUsername = AuthUtils.GetUsername(User);
 
         // Call appropriate service
-        var result = await _newsService.GetNewsPersonalUnapprovedAsync(authenticatedUserUsername);
+        var result = await newsService.GetNewsPersonalUnapprovedAsync(authenticatedUserUsername);
         if (result == null)
         {
             return NotFound();
         }
         return Ok(result);
     }
-
+  
     /** Create a new news item to be added to the database
      * @TODO: Remove redundant username/id from this and service
      * @TODO: fix documentation comments
@@ -152,7 +146,7 @@ public class NewsController : GordonControllerBase
         };
 
         // Call appropriate service
-        var result = _newsService.SubmitNews(newsItem, authenticatedUserUsername);
+        var result = newsService.SubmitNews(newsItem, authenticatedUserUsername);
         if (result == null)
         {
             return NotFound();
@@ -173,7 +167,7 @@ public class NewsController : GordonControllerBase
         // StateYourBusiness verifies that user is authenticated
         // Delete permission should be allowed only to authors of the news item
         // News item must not have already expired
-        var result = _newsService.DeleteNews(newsID);
+        var result = newsService.DeleteNews(newsID);
         // Shouldn't be necessary
         if (result == null)
         {
@@ -196,7 +190,7 @@ public class NewsController : GordonControllerBase
     public ActionResult<StudentNewsViewModel> EditPosting(int newsID, [FromBody] StudentNewsUploadViewModel studentNewsEdit)
     {
         // StateYourBusiness verifies that user is authenticated
-        var result = _newsService.EditPosting(newsID, studentNewsEdit);
+        var result = newsService.EditPosting(newsID, studentNewsEdit);
         return Ok(result);
     }
 
@@ -212,7 +206,7 @@ public class NewsController : GordonControllerBase
     [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.NEWS)]
     public ActionResult<StudentNewsViewModel> EditPostingImage(int newsID, [FromBody] string newImageData)
     {
-        var result = _newsService.EditImage(newsID, newImageData);
+        var result = newsService.EditImage(newsID, newImageData);
         return Ok(result);
     }
 
@@ -228,7 +222,7 @@ public class NewsController : GordonControllerBase
     [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.NEWS_APPROVAL)]
     public ActionResult<StudentNewsViewModel> UpdateAcceptedStatus(int newsID, [FromBody] bool newsStatusAccepted)
     {
-        var result = _newsService.AlterPostAcceptStatus(newsID, newsStatusAccepted);
+        var result = newsService.AlterPostAcceptStatus(newsID, newsStatusAccepted);
         return Ok(result);
     }
 }

--- a/Gordon360/Controllers/RecIM/ActivitiesController.cs
+++ b/Gordon360/Controllers/RecIM/ActivitiesController.cs
@@ -9,14 +9,8 @@ using System.Threading.Tasks;
 namespace Gordon360.Controllers.RecIM;
 
 [Route("api/recim/[controller]")]
-public class ActivitiesController : GordonControllerBase
+public class ActivitiesController(IActivityService activityService) : GordonControllerBase
 {
-    private readonly IActivityService _activityService;
-
-    public ActivitiesController(IActivityService activityService)
-    {
-        _activityService = activityService;
-    }
 
     ///<summary>Gets a list of all Activities by parameter </summary>
     ///<param name="active"> Optional active parameter denoting whether or not an activity has been completed </param>
@@ -26,15 +20,15 @@ public class ActivitiesController : GordonControllerBase
     [HttpGet]
     [Route("")]
     public ActionResult<IEnumerable<ActivityExtendedViewModel>> GetActivities([FromQuery] bool? active)
-    {
-        if (active is bool isActive)
+    {   
+        if ( active is bool isActive)
         {
             bool completed = !isActive;
-            var res = _activityService.GetActivitiesByCompletion(completed);
+            var res = activityService.GetActivitiesByCompletion(completed);
             return Ok(res);
 
         }
-        var result = _activityService.GetActivities();
+        var result = activityService.GetActivities();
         return Ok(result);
     }
 
@@ -47,7 +41,7 @@ public class ActivitiesController : GordonControllerBase
     [Route("{activityID}")]
     public ActionResult<ActivityExtendedViewModel> GetActivityByID(int activityID)
     {
-        var result = _activityService.GetActivityByID(activityID);
+        var result = activityService.GetActivityByID(activityID);
         return Ok(result);
     }
 
@@ -60,7 +54,7 @@ public class ActivitiesController : GordonControllerBase
     [Route("{activityID}/registerable")]
     public ActionResult<bool> GetActivityRegistrationStatus(int activityID)
     {
-        var result = !_activityService.ActivityRegistrationClosed(activityID);
+        var result = !activityService.ActivityRegistrationClosed(activityID);
         return Ok(result);
     }
 
@@ -68,7 +62,7 @@ public class ActivitiesController : GordonControllerBase
     [Route("lookup")]
     public ActionResult<IEnumerable<LookupViewModel>> GetActivityTypes(string type)
     {
-        var res = _activityService.GetActivityLookup(type);
+        var res = activityService.GetActivityLookup(type);
         if (res is not null)
         {
             return Ok(res);
@@ -86,7 +80,7 @@ public class ActivitiesController : GordonControllerBase
     [StateYourBusiness(operation = Operation.ADD, resource = Resource.RECIM_ACTIVITY)]
     public async Task<ActionResult<ActivityViewModel>> CreateActivityAsync(ActivityUploadViewModel newActivity)
     {
-        var activity = await _activityService.PostActivityAsync(newActivity);
+        var activity = await activityService.PostActivityAsync(newActivity);
         return CreatedAtAction(nameof(GetActivityByID), new { activityID = activity.ID }, activity);
     }
 
@@ -101,7 +95,7 @@ public class ActivitiesController : GordonControllerBase
     [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_ACTIVITY)]
     public async Task<ActionResult<ActivityViewModel>> UpdateActivityAsync(int activityID, ActivityPatchViewModel updatedActivity)
     {
-        var activity = await _activityService.UpdateActivityAsync(activityID, updatedActivity);
+        var activity = await activityService.UpdateActivityAsync(activityID, updatedActivity);
         return CreatedAtAction(nameof(GetActivityByID), new { activityID = activity.ID }, activity);
     }
 
@@ -115,7 +109,7 @@ public class ActivitiesController : GordonControllerBase
     [StateYourBusiness(operation = Operation.DELETE, resource = Resource.RECIM_ACTIVITY)]
     public async Task<ActionResult> DeleteActivityCascadeAsync(int activityID)
     {
-        var res = await _activityService.DeleteActivityCascade(activityID);
+        var res = await activityService.DeleteActivityCascade(activityID);
         return Ok(res);
     }
 }

--- a/Gordon360/Controllers/RecIM/AffiliationsController.cs
+++ b/Gordon360/Controllers/RecIM/AffiliationsController.cs
@@ -9,14 +9,8 @@ using System.Threading.Tasks;
 namespace Gordon360.Controllers.RecIM;
 
 [Route("api/recim/[controller]")]
-public class AffiliationsController : GordonControllerBase
+public class AffiliationsController(IAffiliationService affiliationService) : GordonControllerBase
 {
-    private readonly IAffiliationService _affiliationService;
-
-    public AffiliationsController(IAffiliationService affiliationService)
-    {
-        _affiliationService = affiliationService;
-    }
 
     /// <summary>
     /// Gets all stored affiliations/halls/clubs with associated
@@ -26,7 +20,7 @@ public class AffiliationsController : GordonControllerBase
     [Route("")]
     public ActionResult<IEnumerable<AffiliationExtendedViewModel>> GetAllAffiliationDetails()
     {
-        return Ok(_affiliationService.GetAllAffiliationDetails());
+        return Ok(affiliationService.GetAllAffiliationDetails());
     }
 
     /// <summary>
@@ -37,7 +31,7 @@ public class AffiliationsController : GordonControllerBase
     [Route("{affiliationName}")]
     public ActionResult<IEnumerable<AffiliationExtendedViewModel>> GetAffiliationDetailsByName(string affiliationName)
     {
-        return Ok(_affiliationService.GetAffiliationDetailsByName(affiliationName));
+        return Ok(affiliationService.GetAffiliationDetailsByName(affiliationName));
     }
 
     /// <summary>
@@ -50,7 +44,7 @@ public class AffiliationsController : GordonControllerBase
     [StateYourBusiness(operation = Operation.ADD, resource = Resource.RECIM_AFFILIATION)]
     public async Task<ActionResult> CreateAffiliation([FromBody] string affiliationName)
     {
-        var res = await _affiliationService.CreateAffiliation(affiliationName);
+        var res = await affiliationService.CreateAffiliation(affiliationName);
         return CreatedAtAction(nameof(GetAffiliationDetailsByName), new { affiliationName = res }, res);
     }
 
@@ -65,7 +59,7 @@ public class AffiliationsController : GordonControllerBase
     [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_AFFILIATION)]
     public async Task<ActionResult> UpdateAffiliation(string affiliationName, AffiliationPatchViewModel update)
     {
-        var res = await _affiliationService.UpdateAffiliationAsync(affiliationName, update);
+        var res = await affiliationService.UpdateAffiliationAsync(affiliationName, update);
         return CreatedAtAction(nameof(GetAffiliationDetailsByName), new { affiliationName = res }, res);
     }
 
@@ -81,7 +75,7 @@ public class AffiliationsController : GordonControllerBase
     [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_AFFILIATION)]
     public async Task<ActionResult> AddPointsToAffilliation(string affiliationName, AffiliationPointsUploadViewModel vm)
     {
-        var res = await _affiliationService.AddPointsToAffilliationAsync(affiliationName, vm);
+        var res = await affiliationService.AddPointsToAffilliationAsync(affiliationName, vm);
         return CreatedAtAction(nameof(GetAffiliationDetailsByName), new { affiliationName = res }, res);
     }
 
@@ -94,7 +88,7 @@ public class AffiliationsController : GordonControllerBase
     [StateYourBusiness(operation = Operation.DELETE, resource = Resource.RECIM_AFFILIATION)]
     public async Task<ActionResult> DeleteAffiliation(string affiliationName)
     {
-        await _affiliationService.DeleteAffiliationAsync(affiliationName);
+        await affiliationService.DeleteAffiliationAsync(affiliationName);
         return Ok();
     }
 }

--- a/Gordon360/Controllers/RecIM/MatchesController.cs
+++ b/Gordon360/Controllers/RecIM/MatchesController.cs
@@ -9,16 +9,8 @@ using System.Threading.Tasks;
 namespace Gordon360.Controllers.RecIM;
 
 [Route("api/recim/[controller]")]
-public class MatchesController : GordonControllerBase
+public class MatchesController(IMatchService matchService, ITeamService teamService) : GordonControllerBase
 {
-    private readonly IMatchService _matchService;
-    private readonly ITeamService _teamService;
-
-    public MatchesController(IMatchService matchService, ITeamService teamService)
-    {
-        _matchService = matchService;
-        _teamService = teamService;
-    }
 
     /// <summary>
     /// Get all matches
@@ -28,7 +20,7 @@ public class MatchesController : GordonControllerBase
     [Route("")]
     public ActionResult<MatchExtendedViewModel> GetMatches()
     {
-        var matches = _matchService.GetAllMatches();
+        var matches = matchService.GetAllMatches();
         return Ok(matches);
     }
 
@@ -41,7 +33,7 @@ public class MatchesController : GordonControllerBase
     [Route("{matchID}/attendance")]
     public ActionResult<IEnumerable<ParticipantAttendanceViewModel>> GetMatchAttendanceByMatchID(int matchID)
     {
-        var res = _matchService.GetMatchAttendance(matchID);
+        var res = matchService.GetMatchAttendance(matchID);
         return Ok(res);
     }
 
@@ -54,7 +46,7 @@ public class MatchesController : GordonControllerBase
     [Route("{matchID}")]
     public ActionResult<MatchExtendedViewModel> GetMatchByID(int matchID)
     {
-        var match = _matchService.GetMatchByID(matchID);
+        var match = matchService.GetMatchByID(matchID);
         return Ok(match);
     }
 
@@ -67,7 +59,7 @@ public class MatchesController : GordonControllerBase
     [Route("lookup")]
     public ActionResult<IEnumerable<LookupViewModel>> GetMatchTypes(string type)
     {
-        var res = _matchService.GetMatchLookup(type);
+        var res = matchService.GetMatchLookup(type);
         if (res is not null)
         {
             return Ok(res);
@@ -83,7 +75,7 @@ public class MatchesController : GordonControllerBase
     [Route("surfaces")]
     public ActionResult<IEnumerable<SurfaceViewModel>> GetSurfaces()
     {
-        return Ok(_matchService.GetSurfaces());
+        return Ok(matchService.GetSurfaces());
     }
 
     /// <summary>
@@ -97,7 +89,7 @@ public class MatchesController : GordonControllerBase
     public async Task<ActionResult<SurfaceViewModel>> PostSurfaceAsync(SurfaceUploadViewModel newSurface)
     {
         if (newSurface.Name is null && newSurface.Description is null) return BadRequest("Surface has to have name or description filled out");
-        var res = await _matchService.PostSurfaceAsync(newSurface);
+        var res = await matchService.PostSurfaceAsync(newSurface);
         return CreatedAtAction(nameof(GetSurfaces), new { surfaceID = res.ID }, res);
     }
 
@@ -115,7 +107,7 @@ public class MatchesController : GordonControllerBase
         if (surfaceID == 1) //default to be decided surface
             return UnprocessableEntity("Default surface cannot be modified or deleted");
         if (updatedSurface.Name is null && updatedSurface.Description is null) return BadRequest("Surface has to have name or description filled out");
-        var res = await _matchService.UpdateSurfaceAsync(surfaceID, updatedSurface);
+        var res = await matchService.UpdateSurfaceAsync(surfaceID, updatedSurface);
         return CreatedAtAction(nameof(GetSurfaces), new { surfaceID = res.ID }, res);
     }
 
@@ -132,7 +124,7 @@ public class MatchesController : GordonControllerBase
     {
         if (surfaceID == 1) //default to be decided surface
             return UnprocessableEntity("Default surface cannot be modified or deleted");
-        await _matchService.DeleteSurfaceAsync(surfaceID);
+        await matchService.DeleteSurfaceAsync(surfaceID);
         return NoContent();
     }
 
@@ -147,7 +139,7 @@ public class MatchesController : GordonControllerBase
     [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_MATCH)]
     public async Task<ActionResult<MatchTeamViewModel>> UpdateStatsAsync(int matchID, MatchStatsPatchViewModel updatedMatch)
     {
-        var stats = await _matchService.UpdateTeamStatsAsync(matchID, updatedMatch);
+        var stats = await matchService.UpdateTeamStatsAsync(matchID, updatedMatch);
         return Ok(stats);
     }
 
@@ -162,7 +154,7 @@ public class MatchesController : GordonControllerBase
     [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_MATCH)]
     public async Task<ActionResult<MatchViewModel>> UpdateMatchAsync(int matchID, MatchPatchViewModel updatedMatch)
     {
-        var match = await _matchService.UpdateMatchAsync(matchID, updatedMatch);
+        var match = await matchService.UpdateMatchAsync(matchID, updatedMatch);
         return CreatedAtAction(nameof(GetMatchByID), new { matchID = match.ID }, match);
     }
 
@@ -176,7 +168,7 @@ public class MatchesController : GordonControllerBase
     [StateYourBusiness(operation = Operation.ADD, resource = Resource.RECIM_MATCH)]
     public async Task<ActionResult<MatchViewModel>> CreateMatchAsync(MatchUploadViewModel newMatch)
     {
-        var match = await _matchService.PostMatchAsync(newMatch);
+        var match = await matchService.PostMatchAsync(newMatch);
         return CreatedAtAction(nameof(GetMatchByID), new { matchID = match.ID }, match);
     }
 
@@ -190,7 +182,7 @@ public class MatchesController : GordonControllerBase
     [StateYourBusiness(operation = Operation.DELETE, resource = Resource.RECIM_MATCH)]
     public async Task<ActionResult> DeleteMatchCascadeAsync(int matchID)
     {
-        var res = await _matchService.DeleteMatchCascadeAsync(matchID);
+        var res = await matchService.DeleteMatchCascadeAsync(matchID);
         return Ok(res);
     }
 
@@ -207,7 +199,7 @@ public class MatchesController : GordonControllerBase
     [StateYourBusiness(operation = Operation.UPDATE, resource = Resource.RECIM_MATCH)]
     public async Task<ActionResult<IEnumerable<MatchAttendance>>> PutParticipantAttendanceAsync(int matchID, ParticipantAttendanceViewModel teamAttendanceList)
     {
-        var attendance = await _teamService.PutParticipantAttendanceAsync(matchID, teamAttendanceList);
+        var attendance = await teamService.PutParticipantAttendanceAsync(matchID, teamAttendanceList);
         return CreatedAtAction(nameof(GetMatchAttendanceByMatchID), new { matchID = matchID }, attendance);
     }
 
@@ -223,7 +215,7 @@ public class MatchesController : GordonControllerBase
     [StateYourBusiness(operation = Operation.ADD, resource = Resource.RECIM_MATCH)]
     public async Task<ActionResult<IEnumerable<MatchAttendance>>> AddParticipantAttendanceAsync(int matchID, MatchAttendance attendee)
     {
-        var attendance = await _matchService.AddParticipantAttendanceAsync(matchID, attendee);
+        var attendance = await matchService.AddParticipantAttendanceAsync(matchID, attendee);
         return Ok(attendance);
     }
 
@@ -238,7 +230,7 @@ public class MatchesController : GordonControllerBase
     [StateYourBusiness(operation = Operation.DELETE, resource = Resource.RECIM_MATCH)]
     public async Task<ActionResult<IEnumerable<MatchAttendance>>> DeleteParticipantAttendanceAsync(int matchID, MatchAttendance attendee)
     {
-        await _matchService.DeleteParticipantAttendanceAsync(matchID, attendee);
+        await matchService.DeleteParticipantAttendanceAsync(matchID, attendee);
         return NoContent();
     }
 }

--- a/Gordon360/Controllers/RecIM/RecIMController.cs
+++ b/Gordon360/Controllers/RecIM/RecIMController.cs
@@ -8,13 +8,8 @@ using System;
 namespace Gordon360.Controllers.RecIM;
 
 [Route("api/recim/admin")]
-public class RecIMAdminController : GordonControllerBase
+public class RecIMAdminController(IRecIMService recimService) : GordonControllerBase
 {
-    private readonly IRecIMService _recimService;
-    public RecIMAdminController(IRecIMService recimService)
-    {
-        _recimService = recimService;
-    }
 
     /// <summary>
     /// Rec-IM Reporting:
@@ -34,7 +29,7 @@ public class RecIMAdminController : GordonControllerBase
     [StateYourBusiness(operation = Operation.READ_ALL, resource = Resource.RECIM)]
     public ActionResult<RecIMGeneralReportViewModel> GetReport(DateTime startTime, DateTime endTime)
     {
-        var res = _recimService.GetReport(startTime, endTime);
+        var res = recimService.GetReport(startTime, endTime);
         return Ok(res);
     }
 

--- a/Gordon360/Controllers/RecIM/SportsController.cs
+++ b/Gordon360/Controllers/RecIM/SportsController.cs
@@ -9,14 +9,8 @@ using System.Threading.Tasks;
 namespace Gordon360.Controllers.RecIM;
 
 [Route("api/recim/[controller]")]
-public class SportsController : GordonControllerBase
+public class SportsController(ISportService sportService) : GordonControllerBase
 {
-    private readonly ISportService _sportService;
-
-    public SportsController(ISportService sportService)
-    {
-        _sportService = sportService;
-    }
     /// <summary>
     /// Fetches all Sports in the RecIM database
     /// </summary>
@@ -25,7 +19,7 @@ public class SportsController : GordonControllerBase
     [Route("")]
     public ActionResult<IEnumerable<SportViewModel>> GetSports()
     {
-        var res = _sportService.GetSports();
+        var res = sportService.GetSports();
         return Ok(res);
     }
     /// <summary>
@@ -37,7 +31,7 @@ public class SportsController : GordonControllerBase
     [Route("{sportID}")]
     public ActionResult<SportViewModel> GetSportByID(int sportID)
     {
-        var res = _sportService.GetSportByID(sportID);
+        var res = sportService.GetSportByID(sportID);
         return Ok(res);
     }
     /// <summary>
@@ -52,7 +46,7 @@ public class SportsController : GordonControllerBase
     public async Task<ActionResult<SportViewModel>> UpdateSportAsync(int sportID, SportPatchViewModel updatedSport)
     {
         if (sportID == 0) return UnprocessableEntity("Default sport cannot be modified");
-        var sport = await _sportService.UpdateSportAsync(sportID, updatedSport);
+        var sport = await sportService.UpdateSportAsync(sportID,updatedSport);
         return CreatedAtAction(nameof(GetSportByID), new { sportID = sport.ID }, sport);
     }
 
@@ -67,7 +61,7 @@ public class SportsController : GordonControllerBase
     public async Task<ActionResult<SportViewModel>> DeleteSportAsync(int sportID)
     {
         if (sportID == 0) return UnprocessableEntity("Default sport cannot be modified");
-        var res = await _sportService.DeleteSportAsync(sportID);
+        var res = await sportService.DeleteSportAsync(sportID);
         return Ok(res);
     }
     /// <summary>
@@ -80,7 +74,7 @@ public class SportsController : GordonControllerBase
     [StateYourBusiness(operation = Operation.ADD, resource = Resource.RECIM_SPORT)]
     public async Task<ActionResult<SportViewModel>> CreateSportAsync(SportUploadViewModel newSport)
     {
-        var sport = await _sportService.PostSportAsync(newSport);
+        var sport = await sportService.PostSportAsync(newSport);
         return CreatedAtAction(nameof(GetSportByID), new { sportID = sport.ID }, sport);
     }
 

--- a/Gordon360/Controllers/RequestsController.cs
+++ b/Gordon360/Controllers/RequestsController.cs
@@ -1,23 +1,18 @@
 ﻿using Gordon360.Authorization;
-using Gordon360.Exceptions;
 using Gordon360.Models.CCT;
 using Gordon360.Services;
 using Gordon360.Static.Names;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Gordon360.Exceptions;
 
 namespace Gordon360.Controllers;
 
 [Route("api/[controller]")]
-public class RequestsController : GordonControllerBase
+public class RequestsController(IMembershipRequestService membershipRequestService) : GordonControllerBase
 {
-    public IMembershipRequestService _membershipRequestService;
-
-    public RequestsController(IMembershipRequestService membershipRequestService)
-    {
-        _membershipRequestService = membershipRequestService;
-    }
+    public IMembershipRequestService _membershipRequestService = membershipRequestService;
 
     /// <summary>
     /// Gets all Membership Request Objects

--- a/Gordon360/Controllers/ScheduleController.cs
+++ b/Gordon360/Controllers/ScheduleController.cs
@@ -1,6 +1,5 @@
 ﻿using Gordon360.Authorization;
 using Gordon360.Enums;
-using Gordon360.Models.CCT.Context;
 using Gordon360.Models.ViewModels;
 using Gordon360.Services;
 using Microsoft.AspNetCore.Mvc;
@@ -11,15 +10,8 @@ using System.Threading.Tasks;
 namespace Gordon360.Controllers;
 
 [Route("api/[controller]")]
-public class ScheduleController : ControllerBase
+public class ScheduleController(IScheduleService scheduleService) : ControllerBase
 {
-
-    private readonly IScheduleService _scheduleService;
-
-    public ScheduleController(CCTContext context)
-    {
-        _scheduleService = new ScheduleService(context);
-    }
 
     /// <summary>
     ///  Gets all session objects for a user
@@ -29,7 +21,7 @@ public class ScheduleController : ControllerBase
     [Route("{username}/allcourses")]
     public async Task<ActionResult<CoursesBySessionViewModel>> GetAllCourses(string username)
     {
-        IEnumerable<CoursesBySessionViewModel> result = await _scheduleService.GetAllCoursesAsync(username);
+        IEnumerable<CoursesBySessionViewModel> result = await scheduleService.GetAllCoursesAsync(username);
         return Ok(result);
 
     }

--- a/Gordon360/Controllers/SessionsController.cs
+++ b/Gordon360/Controllers/SessionsController.cs
@@ -1,5 +1,4 @@
-﻿using Gordon360.Models.CCT.Context;
-using Gordon360.Models.ViewModels;
+﻿using Gordon360.Models.ViewModels;
 using Gordon360.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -8,14 +7,8 @@ using System.Collections.Generic;
 namespace Gordon360.Controllers;
 
 [Route("api/[controller]")]
-public class SessionsController : GordonControllerBase
+public class SessionsController(ISessionService sessionService) : GordonControllerBase
 {
-    private readonly ISessionService _sessionService;
-
-    public SessionsController(CCTContext context)
-    {
-        _sessionService = new SessionService(context);
-    }
 
     /// <summary>Get a list of all sessions</summary>
     /// <returns>All sessions within the database</returns>
@@ -26,7 +19,7 @@ public class SessionsController : GordonControllerBase
     [AllowAnonymous]
     public ActionResult<IEnumerable<SessionViewModel>> Get()
     {
-        var all = _sessionService.GetAll();
+        var all = sessionService.GetAll();
         return Ok(all);
     }
 
@@ -40,7 +33,7 @@ public class SessionsController : GordonControllerBase
     [AllowAnonymous]
     public ActionResult<SessionViewModel> Get(string id)
     {
-        var result = _sessionService.Get(id);
+        var result = sessionService.Get(id);
 
         if (result == null)
         {
@@ -59,7 +52,7 @@ public class SessionsController : GordonControllerBase
     [AllowAnonymous]
     public ActionResult<SessionViewModel> GetCurrentSession()
     {
-        var currentSession = _sessionService.GetCurrentSession();
+        var currentSession = sessionService.GetCurrentSession();
         if (currentSession == null)
         {
             return NotFound();
@@ -77,7 +70,7 @@ public class SessionsController : GordonControllerBase
     [AllowAnonymous]
     public ActionResult<double[]> GetDaysLeftInSemester()
     {
-        var days = _sessionService.GetDaysLeft();
+        var days = sessionService.GetDaysLeft();
         if (days[1] == 0 && days[2] == 0 || days == null)
         {
             return NotFound();

--- a/Gordon360/Controllers/StudentEmploymentController.cs
+++ b/Gordon360/Controllers/StudentEmploymentController.cs
@@ -1,5 +1,4 @@
 using Gordon360.Authorization;
-using Gordon360.Models.CCT.Context;
 using Gordon360.Models.ViewModels;
 using Gordon360.Services;
 using Microsoft.AspNetCore.Mvc;
@@ -8,15 +7,8 @@ using System.Threading.Tasks;
 namespace Gordon360.Controllers;
 
 [Route("api/[controller]")]
-public class StudentEmploymentController : GordonControllerBase
+public class StudentEmploymentController(IStudentEmploymentService studentEmploymentService) : GordonControllerBase
 {
-    //declare services we are going to use.
-    private readonly IStudentEmploymentService _studentEmploymentService;
-
-    public StudentEmploymentController(CCTContext context)
-    {
-        _studentEmploymentService = new StudentEmploymentService(context);
-    }
 
     /// <summary>
     ///  Gets student employment information about the user
@@ -28,7 +20,7 @@ public class StudentEmploymentController : GordonControllerBase
     {
         var authenticatedUserUsername = AuthUtils.GetUsername(User);
 
-        var result = await _studentEmploymentService.GetEmploymentAsync(authenticatedUserUsername);
+        var result = await studentEmploymentService.GetEmploymentAsync(authenticatedUserUsername);
         if (result == null)
         {
             return NotFound();

--- a/Gordon360/Controllers/VersionController.cs
+++ b/Gordon360/Controllers/VersionController.cs
@@ -1,8 +1,8 @@
-﻿using Gordon360.Models.ViewModels;
-using Microsoft.AspNetCore.Mvc;
-using System;
+﻿using Microsoft.AspNetCore.Mvc;
 using System.Linq;
 using System.Reflection;
+using Gordon360.Models.ViewModels;
+using System;
 
 namespace Gordon360.Controllers;
 

--- a/Gordon360/Controllers/VictoryPromiseController.cs
+++ b/Gordon360/Controllers/VictoryPromiseController.cs
@@ -1,5 +1,4 @@
 ﻿using Gordon360.Authorization;
-using Gordon360.Models.CCT.Context;
 using Gordon360.Models.ViewModels;
 using Gordon360.Services;
 using Microsoft.AspNetCore.Mvc;
@@ -9,14 +8,8 @@ using System.Threading.Tasks;
 namespace Gordon360.Controllers;
 
 [Route("api/[controller]")]
-public class VictoryPromiseController : ControllerBase
+public class VictoryPromiseController(IVictoryPromiseService victoryPromiseService) : ControllerBase
 {
-    private readonly IVictoryPromiseService _victoryPromiseService;
-
-    public VictoryPromiseController(CCTContext context)
-    {
-        _victoryPromiseService = new VictoryPromiseService(context);
-    }
 
     /// <summary>
     ///  Gets current victory promise scores
@@ -28,7 +21,7 @@ public class VictoryPromiseController : ControllerBase
     {
         var username = AuthUtils.GetUsername(User);
 
-        var result = await _victoryPromiseService.GetVPScoresAsync(username);
+        var result = await victoryPromiseService.GetVPScoresAsync(username);
 
         if (result == null)
         {

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -1332,6 +1332,12 @@
             </summary>
             
         </member>
+        <member name="M:Gordon360.Services.AcademicCheckInService.#ctor(Gordon360.Models.CCT.Context.CCTContext)">
+            <summary>
+            Service Class that facilitates data transactions between the AcademicCheckInController and the CheckIn database model.
+            </summary>
+            
+        </member>
         <member name="M:Gordon360.Services.AcademicCheckInService.PutEmergencyContactAsync(Gordon360.Models.ViewModels.EmergencyContactViewModel,System.String,System.String)">
             <summary> Stores the emergency contact information of a particular user </summary>
             <param name="data"> The object that stores the contact info </param>
@@ -1378,6 +1384,11 @@
             <returns> The formatted number </returns>
         </member>
         <member name="T:Gordon360.Services.AccountService">
+            <summary>
+            Service Class that facilitates data transactions between the AccountsController and the Account database model.
+            </summary>
+        </member>
+        <member name="M:Gordon360.Services.AccountService.#ctor(Gordon360.Models.CCT.Context.CCTContext)">
             <summary>
             Service Class that facilitates data transactions between the AccountsController and the Account database model.
             </summary>
@@ -1453,6 +1464,13 @@
             <returns>BasicInfoViewModel of all accounts except alumni</returns>
         </member>
         <member name="T:Gordon360.Services.ActivityService">
+            <summary>
+            Service Class that facilitates data transactions between the ActivitiesController and the ACT_INFO database model.
+            ACT_INFO is basically a copy of the ACT_CLUB_DEF domain model in TmsEPrd but with extra fields that we want to store (activity image, blurb etc...)
+            Activity Info and ACtivity may be talked about interchangeably.
+            </summary>
+        </member>
+        <member name="M:Gordon360.Services.ActivityService.#ctor(Gordon360.Models.CCT.Context.CCTContext,Microsoft.Extensions.Configuration.IConfiguration,Microsoft.AspNetCore.Hosting.IWebHostEnvironment,Gordon360.Utilities.ServerUtils)">
             <summary>
             Service Class that facilitates data transactions between the ActivitiesController and the ACT_INFO database model.
             ACT_INFO is basically a copy of the ACT_CLUB_DEF domain model in TmsEPrd but with extra fields that we want to store (activity image, blurb etc...)
@@ -1554,6 +1572,11 @@
             Service class to facilitate interacting with the Admin table.
             </summary>
         </member>
+        <member name="M:Gordon360.Services.AdministratorService.#ctor(Gordon360.Models.CCT.Context.CCTContext,Gordon360.Services.IAccountService)">
+            <summary>
+            Service class to facilitate interacting with the Admin table.
+            </summary>
+        </member>
         <member name="M:Gordon360.Services.AdministratorService.GetAll">
             <summary>
             Fetches all the administrators from the database
@@ -1589,6 +1612,11 @@
             <returns>True if the admin is valid. Throws ResourceNotFoundException if not. Exception is cauth in an Exception Filter</returns>
         </member>
         <member name="T:Gordon360.Services.ContentManagementService">
+            <summary>
+            Service class that facilitates data (specifically, site content) passing between the ContentManagementController and the database model.
+            </summary>
+        </member>
+        <member name="M:Gordon360.Services.ContentManagementService.#ctor(Gordon360.Models.CCT.Context.CCTContext)">
             <summary>
             Service class that facilitates data (specifically, site content) passing between the ContentManagementController and the database model.
             </summary>
@@ -1643,6 +1671,11 @@
             Service class to facilitate getting emails for members of an activity.
             </summary>
         </member>
+        <member name="M:Gordon360.Services.EmailService.#ctor(Gordon360.Models.CCT.Context.CCTContext,Gordon360.Services.IMembershipService,Microsoft.Extensions.Configuration.IConfiguration)">
+            <summary>
+            Service class to facilitate getting emails for members of an activity.
+            </summary>
+        </member>
         <member name="M:Gordon360.Services.EmailService.GetEmailsForActivity(System.String,System.String,System.Collections.Generic.List{System.String})">
             <summary>
             Get a list of the emails for all members in the activity during the current session.
@@ -1680,6 +1713,11 @@
             Service Class that facilitates data transactions between the ErrorLogController and the ERROR_LOG database model.
             </summary>
         </member>
+        <member name="M:Gordon360.Services.ErrorLogService.#ctor(Gordon360.Models.CCT.Context.CCTContext)">
+            <summary>
+            Service Class that facilitates data transactions between the ErrorLogController and the ERROR_LOG database model.
+            </summary>
+        </member>
         <member name="M:Gordon360.Services.ErrorLogService.Add(Gordon360.Models.CCT.ERROR_LOG)">
             <summary>
             Adds a new error log to storage.
@@ -1695,6 +1733,11 @@
             <returns>The newly added error_log object</returns>
         </member>
         <member name="T:Gordon360.Services.EventService">
+            <summary>
+            Service that allows for event control
+            </summary>
+        </member>
+        <member name="M:Gordon360.Services.EventService.#ctor(Gordon360.Models.CCT.Context.CCTContext,Microsoft.Extensions.Caching.Memory.IMemoryCache,Gordon360.Services.IAccountService)">
             <summary>
             Service that allows for event control
             </summary>
@@ -1843,6 +1886,11 @@
             Service class to facilitate data transactions between the MembershipRequestController and the database
             </summary>
         </member>
+        <member name="M:Gordon360.Services.MembershipRequestService.#ctor(Gordon360.Models.CCT.Context.CCTContext,Gordon360.Services.IMembershipService,Gordon360.Services.IAccountService)">
+            <summary>
+            Service class to facilitate data transactions between the MembershipRequestController and the database
+            </summary>
+        </member>
         <member name="M:Gordon360.Services.MembershipRequestService.AddAsync(Gordon360.Models.CCT.RequestUploadViewModel)">
             <summary>
             Generate a new request to join an activity at a participation level higher than 'Guest'
@@ -1916,6 +1964,11 @@
             <returns>A RequestView object of the updated request</returns>
         </member>
         <member name="T:Gordon360.Services.MembershipService">
+            <summary>
+            Service Class that facilitates data transactions between the MembershipsController and the Membership database model.
+            </summary>
+        </member>
+        <member name="M:Gordon360.Services.MembershipService.#ctor(Gordon360.Models.CCT.Context.CCTContext,Gordon360.Services.IAccountService,Gordon360.Services.IActivityService)">
             <summary>
             Service Class that facilitates data transactions between the MembershipsController and the Membership database model.
             </summary>
@@ -2274,6 +2327,11 @@
             Service Class that facilitates data transactions between the SchedulesController and the Schedule part of the database model.
             </summary>
         </member>
+        <member name="M:Gordon360.Services.ScheduleService.#ctor(Gordon360.Models.CCT.Context.CCTContext,Gordon360.Services.ISessionService)">
+            <summary>
+            Service Class that facilitates data transactions between the SchedulesController and the Schedule part of the database model.
+            </summary>
+        </member>
         <member name="M:Gordon360.Services.ScheduleService.GetAllCoursesAsync(System.String)">
             <summary>
             Fetch the session item whose id specified by the parameter
@@ -2281,7 +2339,19 @@
             <param name="username">The AD Username of the user</param>
             <returns>CoursesBySessionViewModel if found, null if not found</returns>
         </member>
+        <member name="M:Gordon360.Services.ServicesExtensions.Add360Services(Microsoft.Extensions.DependencyInjection.IServiceCollection)">
+            <summary>
+            Add our Gordon 360 Services as scoped services to the dependency injection container.
+            </summary>
+            <param name="services">Service container</param>
+            <returns>The service container that has our services added.</returns>
+        </member>
         <member name="T:Gordon360.Services.SessionService">
+            <summary>
+            Service class to facilitate data transactions between the Controller and the database model.
+            </summary>
+        </member>
+        <member name="M:Gordon360.Services.SessionService.#ctor(Gordon360.Models.CCT.Context.CCTContext)">
             <summary>
             Service class to facilitate data transactions between the Controller and the database model.
             </summary>

--- a/Gordon360/Program.cs
+++ b/Gordon360/Program.cs
@@ -83,29 +83,9 @@ builder.Services.AddDbContext<CCTContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("webSQL"))
 );
 
-builder.Services.AddScoped<IAccountService, AccountService>();
-builder.Services.AddScoped<IActivityService, ActivityService>();
-builder.Services.AddScoped<IEventService, EventService>();
-builder.Services.AddScoped<IErrorLogService, ErrorLogService>();
-builder.Services.AddScoped<IProfileService, ProfileService>();
-builder.Services.AddScoped<IAddressesService, AddressesService>();
-builder.Services.AddScoped<IMembershipService, MembershipService>();
-builder.Services.AddScoped<IMembershipRequestService, MembershipRequestService>();
-builder.Services.AddScoped<IAdministratorService, AdministratorService>();
-builder.Services.AddScoped<IEmailService, EmailService>();
-builder.Services.AddScoped<INewsService, NewsService>();
-builder.Services.AddScoped<ISessionService, SessionService>();
-builder.Services.AddScoped<ServerUtils, ServerUtils>();
+builder.Services.Add360Services();
 builder.Services.AddHostedService<EventCacheRefreshService>();
-builder.Services.AddScoped<RecIM.IActivityService, RecIM.ActivityService>();
-builder.Services.AddScoped<RecIM.ISeriesService, RecIM.SeriesService>();
-builder.Services.AddScoped<RecIM.IMatchService, RecIM.MatchService>();
-builder.Services.AddScoped<RecIM.ITeamService, RecIM.TeamService>();
-builder.Services.AddScoped<RecIM.IParticipantService, RecIM.ParticipantService>();
-builder.Services.AddScoped<RecIM.ISportService, RecIM.SportService>();
-builder.Services.AddScoped<RecIM.IRecIMService, RecIM.RecIMService>();
-builder.Services.AddScoped<RecIM.IAffiliationService, RecIM.AffiliationService>();
-
+builder.Services.AddScoped<ServerUtils, ServerUtils>();
 
 builder.Services.AddMemoryCache();
 

--- a/Gordon360/Services/AcademicCheckInService.cs
+++ b/Gordon360/Services/AcademicCheckInService.cs
@@ -11,14 +11,9 @@ namespace Gordon360.Services;
 /// <summary>
 /// Service Class that facilitates data transactions between the AcademicCheckInController and the CheckIn database model.
 /// </summary>
-/// 
-public class AcademicCheckInService : IAcademicCheckInService
+	/// 
+public class AcademicCheckInService(CCTContext context) : IAcademicCheckInService
 {
-    private readonly CCTContext _context;
-    public AcademicCheckInService(CCTContext context)
-    {
-        _context = context;
-    }
 
 
     /// <summary> Stores the emergency contact information of a particular user </summary>
@@ -29,7 +24,7 @@ public class AcademicCheckInService : IAcademicCheckInService
     {
         var splitUsername = username.Split('.');
 
-        var result = await _context.Procedures.UPDATE_EMRGCONTACTAsync(
+        var result = await context.Procedures.UPDATE_EMRGCONTACTAsync(
             int.Parse(id),
             data.SEQ_NUMBER,
             data.LastName,
@@ -81,7 +76,7 @@ public class AcademicCheckInService : IAcademicCheckInService
     /// <returns> The stored data </returns>
     public async Task<AcademicCheckInViewModel> PutCellPhoneAsync(string id, AcademicCheckInViewModel data)
     {
-        var result = await _context.Procedures.FINALIZATION_UPDATECELLPHONEAsync(id, FormatNumber(data.PersonalPhone), data.MakePrivate, data.NoPhone);
+        var result = await context.Procedures.FINALIZATION_UPDATECELLPHONEAsync(id, FormatNumber(data.PersonalPhone), data.MakePrivate, data.NoPhone);
         if (result == null)
         {
             throw new ResourceNotFoundException() { ExceptionMessage = "The data was not found." };
@@ -95,7 +90,7 @@ public class AcademicCheckInService : IAcademicCheckInService
     /// <returns> The stored data </returns>
     public async Task<AcademicCheckInViewModel> PutDemographicAsync(string id, AcademicCheckInViewModel data)
     {
-        var result = await _context.Procedures.FINALIZATION_UPDATEDEMOGRAPHICAsync(id, data.Race, data.Ethnicity);
+        var result = await context.Procedures.FINALIZATION_UPDATEDEMOGRAPHICAsync(id, data.Race, data.Ethnicity);
         if (result == null)
         {
             throw new ResourceNotFoundException() { ExceptionMessage = "The data was not found." };
@@ -108,7 +103,7 @@ public class AcademicCheckInService : IAcademicCheckInService
     /// <returns> The stored data </returns>
     public async Task<IEnumerable<AcademicCheckInViewModel>> GetHoldsAsync(string id)
     {
-        var result = await _context.Procedures.FINALIZATION_GETHOLDSBYIDAsync(int.Parse(id));
+        var result = await context.Procedures.FINALIZATION_GETHOLDSBYIDAsync(int.Parse(id));
 
         if (result == null)
         {
@@ -135,7 +130,7 @@ public class AcademicCheckInService : IAcademicCheckInService
     /// <param name="id"> The id of the user who is to be marked as checked in </param>
     public async Task SetStatusAsync(string id)
     {
-        var result = await _context.Procedures.FINALIZATION_MARK_AS_CURRENTLY_COMPLETEDAsync(id);
+        var result = await context.Procedures.FINALIZATION_MARK_AS_CURRENTLY_COMPLETEDAsync(id);
 
         if (result == null)
         {
@@ -147,7 +142,7 @@ public class AcademicCheckInService : IAcademicCheckInService
     /// <param name="id"> The id of the user for which the data is to be found for </param>
     public async Task<bool> GetStatusAsync(string id)
     {
-        var result = await _context.Procedures.FINALIZATION_GET_FINALIZATION_STATUSAsync(int.Parse(id));
+        var result = await context.Procedures.FINALIZATION_GET_FINALIZATION_STATUSAsync(int.Parse(id));
 
         if (result.Count() == 0)
         {

--- a/Gordon360/Services/AddressesService.cs
+++ b/Gordon360/Services/AddressesService.cs
@@ -7,16 +7,9 @@ using System.Linq;
 
 namespace Gordon360.Services;
 
-public class AddressesService : IAddressesService
+public class AddressesService(CCTContext context) : IAddressesService
 {
-    private readonly CCTContext _context;
+    public IEnumerable<States> GetAllStates() => context.States.AsEnumerable();
 
-    public AddressesService(CCTContext context)
-    {
-        _context = context;
-    }
-
-    public IEnumerable<States> GetAllStates() => _context.States.AsEnumerable();
-
-    public IEnumerable<CountryViewModel> GetAllCountries() => _context.Countries.Select<Countries, CountryViewModel>(c => c);
+    public IEnumerable<CountryViewModel> GetAllCountries() => context.Countries.Select<Countries, CountryViewModel>(c => c);
 }

--- a/Gordon360/Services/AdministratorService.cs
+++ b/Gordon360/Services/AdministratorService.cs
@@ -1,6 +1,6 @@
-﻿using Gordon360.Exceptions;
+﻿using Gordon360.Models.CCT.Context;
+using Gordon360.Exceptions;
 using Gordon360.Models.CCT;
-using Gordon360.Models.CCT.Context;
 using Gordon360.Models.ViewModels;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,23 +10,15 @@ namespace Gordon360.Services;
 /// <summary>
 /// Service class to facilitate interacting with the Admin table.
 /// </summary>
-public class AdministratorService : IAdministratorService
+public class AdministratorService(CCTContext context, IAccountService accountService) : IAdministratorService
 {
-    private CCTContext _context;
-    private IAccountService _accountService;
-
-    public AdministratorService(CCTContext context, IAccountService accountService)
-    {
-        _context = context;
-        _accountService = accountService;
-    }
     /// <summary>
     /// Fetches all the administrators from the database
     /// </summary>
     /// <returns>Returns a list of administrators. If no administrators were found, an empty list is returned.</returns>
     public IEnumerable<AdminViewModel?> GetAll()
     {
-        return _context.ADMIN.Select<ADMIN, AdminViewModel?>(a => a);
+        return context.ADMIN.Select<ADMIN,AdminViewModel?>(a => a);
     }
 
     /// <summary>
@@ -35,7 +27,7 @@ public class AdministratorService : IAdministratorService
     /// <returns>Returns a list of administrators. If no administrators were found, an empty list is returned.</returns>
     public AdminViewModel? GetByUsername(string username)
     {
-        var admin = _context.ADMIN.FirstOrDefault(a => a.USER_NAME == username);
+        var admin = context.ADMIN.FirstOrDefault(a => a.USER_NAME == username);
         return admin;
     }
 
@@ -50,17 +42,17 @@ public class AdministratorService : IAdministratorService
         // validate returns a boolean value.
         validateAdmin(adminView);
 
-        var gordonId = int.Parse(_accountService.GetAccountByUsername(adminView.Username).GordonID);
+        var gordonId = int.Parse(accountService.GetAccountByUsername(adminView.Username).GordonID);
 
         // The Add() method returns the added membership.
-        var payload = _context.ADMIN.Add(adminView.ToAdmin(gordonId));
+        var payload = context.ADMIN.Add(adminView.ToAdmin(gordonId));
 
         // There is a unique constraint in the Database on columns (ID_NUM, PART_LVL, SESS_CDE and ACT_CDE)
         if (payload == null)
         {
             throw new ResourceCreationException() { ExceptionMessage = "There was an error creating the admin." };
         }
-        _context.SaveChanges();
+        context.SaveChanges();
 
         return adminView;
 
@@ -73,14 +65,14 @@ public class AdministratorService : IAdministratorService
     /// <returns>The admin that was just deleted</returns>
     public AdminViewModel Delete(string username)
     {
-        var result = _context.ADMIN.FirstOrDefault(a => a.USER_NAME == username);
+        var result = context.ADMIN.FirstOrDefault(a => a.USER_NAME == username);
         if (result == null)
         {
             throw new ResourceNotFoundException() { ExceptionMessage = "The Admin was not found." };
         }
-        _context.ADMIN.Remove(result);
+        context.ADMIN.Remove(result);
 
-        _context.SaveChanges();
+        context.SaveChanges();
 
         return (AdminViewModel)result;
     }
@@ -92,13 +84,13 @@ public class AdministratorService : IAdministratorService
     /// <returns>True if the admin is valid. Throws ResourceNotFoundException if not. Exception is cauth in an Exception Filter</returns>
     private bool validateAdmin(AdminViewModel adminView)
     {
-        var personExists = _context.ACCOUNT.Where(a => a.AD_Username == adminView.Username).Count() > 0;
+        var personExists = context.ACCOUNT.Where(a => a.AD_Username == adminView.Username).Count() > 0;
         if (!personExists)
         {
             throw new ResourceNotFoundException() { ExceptionMessage = "The Person was not found." };
         }
 
-        var personIsAlreadyAdmin = _context.ADMIN.Any(a => a.USER_NAME == adminView.Username);
+        var personIsAlreadyAdmin = context.ADMIN.Any(a => a.USER_NAME == adminView.Username);
         if (personIsAlreadyAdmin)
         {
             throw new ResourceCreationException() { ExceptionMessage = "This person is already an admin." };

--- a/Gordon360/Services/ContentManagementService.cs
+++ b/Gordon360/Services/ContentManagementService.cs
@@ -1,5 +1,5 @@
-﻿using Gordon360.Models.CCT;
-using Gordon360.Models.CCT.Context;
+﻿using Gordon360.Models.CCT.Context;
+using Gordon360.Models.CCT;
 using Gordon360.Models.ViewModels;
 using Gordon360.Utilities;
 using System.Collections.Generic;
@@ -11,23 +11,15 @@ namespace Gordon360.Services;
 /// <summary>
 /// Service class that facilitates data (specifically, site content) passing between the ContentManagementController and the database model.
 /// </summary>
-public class ContentManagementService : IContentManagementService
+public class ContentManagementService(CCTContext context) : IContentManagementService
 {
-    private CCTContext _context;
-
     private readonly string SlideUploadPath = "browseable/slider";
-
-
-    public ContentManagementService(CCTContext context)
-    {
-        _context = context;
-    }
 
     /// <summary>
     /// Retrieve all banner slides from the database
     /// </summary>
     /// <returns>An IEnumerable of the slides in the database</returns>
-    public IEnumerable<Slider_Images> GetBannerSlides() => _context.Slider_Images.AsEnumerable();
+    public IEnumerable<Slider_Images> GetBannerSlides() => context.Slider_Images.AsEnumerable();
 
     /// <summary>
     /// Inserts a banner slide in the database and uploads the image to the local slider folder
@@ -55,8 +47,8 @@ public class ContentManagementService : IContentManagementService
             Width = 1500,
             Height = 600
         };
-        _context.Slider_Images.Add(entry);
-        _context.SaveChanges();
+        context.Slider_Images.Add(entry);
+        context.SaveChanges();
         return entry;
     }
 
@@ -66,10 +58,10 @@ public class ContentManagementService : IContentManagementService
     /// <returns>The deleted slide</returns>
     public Slider_Images DeleteBannerSlide(int slideID)
     {
-        var slide = _context.Slider_Images.Find(slideID);
+        var slide = context.Slider_Images.Find(slideID);
         ImageUtils.DeleteImage(slide.Path);
-        _context.Slider_Images.Remove(slide);
-        _context.SaveChanges();
+        context.Slider_Images.Remove(slide);
+        context.SaveChanges();
         return slide;
     }
 }

--- a/Gordon360/Services/DiningService.cs
+++ b/Gordon360/Services/DiningService.cs
@@ -1,5 +1,5 @@
-﻿using Gordon360.Exceptions;
-using Gordon360.Models.CCT.Context;
+﻿using Gordon360.Models.CCT.Context;
+using Gordon360.Exceptions;
 using Gordon360.Models.ViewModels;
 using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json.Linq;
@@ -21,8 +21,6 @@ namespace Gordon360.Services;
 /// </summary>
 public class DiningService : IDiningService
 {
-    private readonly IConfiguration _config;
-
     private CCTContext _context;
     private static string issuerID;
     private static string applicationId;
@@ -34,10 +32,9 @@ public class DiningService : IDiningService
     public DiningService(CCTContext context, IConfiguration config)
     {
         _context = context;
-        _config = config;
-        issuerID = _config["BonAppetit:IssuerID"];
-        applicationId = _config["BonAppetit:ApplicationID"];
-        secret = _config["BonAppetit:Secret"];
+        issuerID = config["BonAppetit:IssuerID"];
+        applicationId = config["BonAppetit:ApplicationID"];
+        secret = config["BonAppetit:Secret"];
     }
 
     private static string getTimestamp()

--- a/Gordon360/Services/EmailService.cs
+++ b/Gordon360/Services/EmailService.cs
@@ -12,18 +12,8 @@ namespace Gordon360.Services;
 /// <summary>
 /// Service class to facilitate getting emails for members of an activity.
 /// </summary>
-public class EmailService : IEmailService
+public class EmailService(CCTContext context, IMembershipService membershipService, IConfiguration config) : IEmailService
 {
-    private readonly CCTContext _context;
-    private readonly IMembershipService _membershipService;
-    private readonly IConfiguration _config;
-
-    public EmailService(CCTContext context, IMembershipService membershipService, IConfiguration config)
-    {
-        _context = context;
-        _membershipService = membershipService;
-        _config = config;
-    }
 
     /// <summary>
     /// Get a list of the emails for all members in the activity during the current session.
@@ -34,14 +24,14 @@ public class EmailService : IEmailService
     /// <returns>A list of emails (along with first and last name) associated with that activity</returns>
     public IEnumerable<EmailViewModel> GetEmailsForActivity(string activityCode, string? sessionCode = null, List<string>? participationTypes = null)
     {
-        sessionCode ??= Helpers.GetCurrentSession(_context);
+        sessionCode ??= Helpers.GetCurrentSession(context);
 
-        var memberships = _membershipService.GetMemberships(
+        var memberships = membershipService.GetMemberships(
             activityCode: activityCode,
             sessionCode: sessionCode,
             participationTypes: participationTypes);
 
-        return memberships.Join(_context.ACCOUNT, m => m.Username, a => a.AD_Username, (m, a) => new EmailViewModel
+        return memberships.Join(context.ACCOUNT, m => m.Username, a => a.AD_Username, (m, a) => new EmailViewModel
         {
             Email = a.email,
             FirstName = a.firstname,
@@ -68,7 +58,7 @@ public class EmailService : IEmailService
             Password = password
         };
         smtp.Credentials = credential;
-        smtp.Host = _config["SmtpHost"];
+        smtp.Host = config["SmtpHost"];
         smtp.Port = 587;
         smtp.EnableSsl = true;
 
@@ -109,7 +99,7 @@ public class EmailService : IEmailService
         using var smtp = new SmtpClient
         {
             Credentials = credential,
-            Host = _config["SmtpHost"],
+            Host = config["SmtpHost"],
             Port = 587,
             EnableSsl = true,
         };

--- a/Gordon360/Services/ErrorLogService.cs
+++ b/Gordon360/Services/ErrorLogService.cs
@@ -1,6 +1,6 @@
-﻿using Gordon360.Exceptions;
+﻿using Gordon360.Models.CCT.Context;
+using Gordon360.Exceptions;
 using Gordon360.Models.CCT;
-using Gordon360.Models.CCT.Context;
 using System;
 
 namespace Gordon360.Services;
@@ -8,14 +8,8 @@ namespace Gordon360.Services;
 /// <summary>
 /// Service Class that facilitates data transactions between the ErrorLogController and the ERROR_LOG database model.
 /// </summary>
-public class ErrorLogService : IErrorLogService
+public class ErrorLogService(CCTContext context) : IErrorLogService
 {
-    private CCTContext _context;
-
-    public ErrorLogService(CCTContext context)
-    {
-        _context = context;
-    }
 
     /// <summary>
     /// Adds a new error log to storage.
@@ -26,13 +20,13 @@ public class ErrorLogService : IErrorLogService
     {
 
         // The Add() method returns the added error_log.
-        var payload = _context.ERROR_LOG.Add(error_log);
+        var payload = context.ERROR_LOG.Add(error_log);
 
         if (payload == null)
         {
             throw new ResourceCreationException() { ExceptionMessage = "There was an error creating the error_log. Perhaps the error is a duplicate." };
         }
-        _context.SaveChanges();
+        context.SaveChanges();
 
         return error_log;
 
@@ -59,13 +53,13 @@ public class ErrorLogService : IErrorLogService
         };
 
         // The Add() method returns the added error_log.
-        var payload = _context.ERROR_LOG.Add(error_log);
+        var payload = context.ERROR_LOG.Add(error_log);
 
         if (payload == null)
         {
             throw new ResourceCreationException() { ExceptionMessage = "There was an error creating the error_log. Perhaps the error is a duplicate." };
         }
-        _context.SaveChanges();
+        context.SaveChanges();
 
         return error_log;
 

--- a/Gordon360/Services/EventCacheRefreshService.cs
+++ b/Gordon360/Services/EventCacheRefreshService.cs
@@ -1,24 +1,18 @@
-﻿using Gordon360.Models.ViewModels;
-using Gordon360.Static_Classes;
+﻿using Gordon360.Static_Classes;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Hosting;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Threading;
 using System.Threading.Tasks;
+using System.Threading;
+using System;
+using System.Diagnostics;
+using Gordon360.Models.ViewModels;
+using System.Collections.Generic;
 
 namespace Gordon360.Services;
 
-public class EventCacheRefreshService : IHostedService, IDisposable
+public class EventCacheRefreshService(IMemoryCache cache) : IHostedService, IDisposable
 {
-    private readonly IMemoryCache _cache;
     private Timer? _timer = null;
-
-    public EventCacheRefreshService(IMemoryCache cache)
-    {
-        _cache = cache;
-    }
 
     public Task StartAsync(CancellationToken stoppingToken)
     {
@@ -39,7 +33,7 @@ public class EventCacheRefreshService : IHostedService, IDisposable
         {
             Debug.WriteLine(ex.Message);
         }
-        _cache.Set(CacheKeys.Events, events);
+        cache.Set(CacheKeys.Events, events);
     }
 
     public Task StopAsync(CancellationToken stoppingToken)

--- a/Gordon360/Services/RecIM/AffiliationService.cs
+++ b/Gordon360/Services/RecIM/AffiliationService.cs
@@ -1,36 +1,28 @@
-﻿using Gordon360.Exceptions;
-using Gordon360.Models.CCT;
+﻿using Gordon360.Models.CCT;
 using Gordon360.Models.CCT.Context;
 using Gordon360.Models.ViewModels.RecIM;
 using Microsoft.EntityFrameworkCore;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Gordon360.Exceptions;
 
 
 namespace Gordon360.Services.RecIM;
 
-public class AffiliationService : IAffiliationService
+public class AffiliationService(CCTContext context) : IAffiliationService
 {
-
-    private readonly CCTContext _context;
-
-    public AffiliationService(CCTContext context)
-    {
-        _context = context;
-    }
-
     public async Task<string> AddPointsToAffilliationAsync(string affiliationName, AffiliationPointsUploadViewModel vm)
     {
-        var affiliation = _context.Affiliation.Find(affiliationName);
+        var affiliation = context.Affiliation.Find(affiliationName);
         if (affiliation is null) throw new ResourceNotFoundException();
 
-        var exist = _context.AffiliationPoints.FirstOrDefault(ap => ap.SeriesID == vm.SeriesID && ap.TeamID == vm.TeamID);
+        var exist = context.AffiliationPoints.FirstOrDefault(ap => ap.SeriesID == vm.SeriesID && ap.TeamID == vm.TeamID);
 
-        if (exist is not null)
+        if (exist is not null) 
             exist.Points = vm.Points ?? 0;
         else
-            _context.AffiliationPoints.Add(new AffiliationPoints
+            context.AffiliationPoints.Add(new AffiliationPoints
             {
                 AffiliationName = affiliationName,
                 TeamID = vm.TeamID,
@@ -38,44 +30,44 @@ public class AffiliationService : IAffiliationService
                 Points = vm.Points ?? 0,
             });
 
-        await _context.SaveChangesAsync();
+        await context.SaveChangesAsync();
 
         return affiliationName;
     }
 
     public async Task DeleteAffiliationAsync(string affiliationName)
     {
-        var teams = _context.Team
+        var teams = context.Team
             .Where(t => t.Affiliation == affiliationName);
         await teams.ForEachAsync(t => t.Affiliation = null);
 
-        var affiliationPoints = _context.AffiliationPoints
+        var affiliationPoints = context.AffiliationPoints
             .Where(ap => ap.AffiliationName == affiliationName);
-        _context.AffiliationPoints.RemoveRange(affiliationPoints);
+        context.AffiliationPoints.RemoveRange(affiliationPoints);
 
         //required to remove fk constraints before proper removal
-        await _context.SaveChangesAsync();
+        await context.SaveChangesAsync();
 
-        var affiliation = _context.Affiliation.Find(affiliationName);
-        if (affiliation is Affiliation a) _context.Remove(a);
-        await _context.SaveChangesAsync();
+        var affiliation = context.Affiliation.Find(affiliationName);
+        if (affiliation is Affiliation a) context.Remove(a);
+        await context.SaveChangesAsync();
 
     }
 
     public IEnumerable<AffiliationExtendedViewModel> GetAllAffiliationDetails()
     {
-        return _context.Affiliation
+        return context.Affiliation
              .Select(a => new AffiliationExtendedViewModel
              {
                  Name = a.Name,
-                 Points = _context.AffiliationPoints
+                 Points = context.AffiliationPoints
                      .Where(ap => ap.AffiliationName == a.Name)
                      .Select(ap => ap.Points)
                      .AsEnumerable()
                      .Sum(),
-                 Series = _context.AffiliationPoints
+                 Series = context.AffiliationPoints
                       .Where(_ap => _ap.AffiliationName == a.Name)
-                      .Select(ap => (SeriesViewModel)ap.Series)
+                      .Select(ap => (SeriesViewModel) ap.Series)
                       .AsEnumerable()
              })
              .AsEnumerable();
@@ -83,44 +75,44 @@ public class AffiliationService : IAffiliationService
 
     public AffiliationExtendedViewModel GetAffiliationDetailsByName(string name)
     {
-        var affiliation = _context.Affiliation.Find(name);
+        var affiliation = context.Affiliation.Find(name);
         if (affiliation is null) throw new ResourceNotFoundException();
 
         return new AffiliationExtendedViewModel()
         {
             Name = name,
-            Points = _context.AffiliationPoints
+            Points = context.AffiliationPoints
                      .Where(ap => ap.AffiliationName == name)
                      .Select(ap => ap.Points)
                      .AsEnumerable()
                      .Sum(),
-            Series = _context.AffiliationPoints
+            Series = context.AffiliationPoints
                       .Where(_ap => _ap.AffiliationName == name)
-                      .Select(ap => (SeriesViewModel)ap.Series)
+                      .Select(ap => (SeriesViewModel) ap.Series)
                       .AsEnumerable()
         };
     }
 
     public async Task<string> CreateAffiliation(string affiliationName)
     {
-        var existing = _context.Affiliation.Find(affiliationName);
+        var existing = context.Affiliation.Find(affiliationName);
 
         if (existing is not null) throw new BadInputException() { ExceptionMessage = "Affiliation already exists" };
 
-        _context.Affiliation.Add(new Affiliation { Name = affiliationName });
-        await _context.SaveChangesAsync();
+        context.Affiliation.Add(new Affiliation { Name = affiliationName });
+        await context.SaveChangesAsync();
 
         return affiliationName;
     }
 
     public async Task<string> UpdateAffiliationAsync(string affiliationName, AffiliationPatchViewModel update)
     {
-        var affiliation = _context.Affiliation.Find(affiliationName);
+        var affiliation = context.Affiliation.Find(affiliationName);
         if (affiliation is null) throw new ResourceNotFoundException();
         affiliation.Name = update.Name ?? affiliation.Name;
         affiliation.Logo = update.Logo ?? affiliation.Logo;
 
-        await _context.SaveChangesAsync();
+        await context.SaveChangesAsync();
         return affiliation.Name;
     }
 }

--- a/Gordon360/Services/RecIM/RecIMService.cs
+++ b/Gordon360/Services/RecIM/RecIMService.cs
@@ -1,55 +1,39 @@
-﻿using Gordon360.Exceptions;
+﻿using Gordon360.Models.ViewModels.RecIM;
 using Gordon360.Models.CCT.Context;
-using Gordon360.Models.ViewModels.RecIM;
-using Microsoft.Extensions.Configuration;
 using System;
-using System.Collections.Generic;
+using Gordon360.Exceptions;
 using System.Linq;
+using System.Collections.Generic;
 
 namespace Gordon360.Services.RecIM;
 
-public class RecIMService : IRecIMService
+public class RecIMService(CCTContext context, IParticipantService participantSerivce) : IRecIMService
 {
-    private readonly CCTContext _context;
-    private readonly IMatchService _matchService;
-    private readonly IParticipantService _participantService;
-    private readonly IAccountService _accountService;
-    private readonly IConfiguration _config;
-
-    public RecIMService(CCTContext context, IConfiguration config, IParticipantService participantSerivce, IMatchService matchService, IAccountService accountService)
-    {
-        _context = context;
-        _config = config;
-        _matchService = matchService;
-        _accountService = accountService;
-        _participantService = participantSerivce;
-    }
-
     public RecIMGeneralReportViewModel GetReport(DateTime start, DateTime end)
     {
         if (start > end) new UnprocessibleEntity { ExceptionMessage = $"End date cannot occur before the start date" };
 
-        var activities = _context.Activity
+        var activities = context.Activity
             .Where(a => a.RegistrationStart > start && a.RegistrationEnd < end)
             .Select(a =>
             new ActivityReportViewModel
-            {
-                NumberOfParticipants = _context.ParticipantTeam.
+                {
+                    NumberOfParticipants = context.ParticipantTeam.
                         Where(pt => pt.Team.ActivityID == a.ID && pt.Team.StatusID != 0 && pt.RoleTypeID != 0)
                         .Count(),
-                Activity = a
-            });
+                    Activity = a
+                });
 
-        var newParticipants = _context.ParticipantStatusHistory
+        var newParticipants =  context.ParticipantStatusHistory
             .Where(p => p.StatusID == 4 && p.StartDate > start)
                 .Select(p => p.ParticipantUsername)
             .Distinct()
             .Select(username => new ParticipantReportViewModel
             {
-                UserAccount = _participantService.GetUnaffiliatedAccountByUsername(username),
+                UserAccount = participantSerivce.GetUnaffiliatedAccountByUsername(username),
                 NumberOfActivitiesParticipated =
-                    _context.ParticipantTeam
-                    .Where(pt =>
+                    context.ParticipantTeam
+                    .Where(pt => 
                         pt.ParticipantUsername == username
                         && pt.RoleTypeID != 0
                         && pt.RoleTypeID != 2
@@ -60,11 +44,11 @@ public class RecIMService : IRecIMService
             });
 
         //active within timeframe
-        var activeParticipants = _context.ParticipantTeam
+        var activeParticipants = context.ParticipantTeam
             .Where(pt => pt.SignDate > start && pt.SignDate < end && pt.RoleTypeID != 0)
             .Select(pt => pt.ParticipantUsername)
             .Distinct()
-            .Select(username => (ParticipantReducedReportViewModel)_context.Participant.FirstOrDefault(p => p.Username == username));
+            .Select(username => (ParticipantReducedReportViewModel)context.Participant.FirstOrDefault(p => p.Username == username));
 
         return new RecIMGeneralReportViewModel()
         {

--- a/Gordon360/Services/ScheduleService.cs
+++ b/Gordon360/Services/ScheduleService.cs
@@ -10,16 +10,8 @@ namespace Gordon360.Services;
 /// <summary>
 /// Service Class that facilitates data transactions between the SchedulesController and the Schedule part of the database model.
 /// </summary>
-public class ScheduleService : IScheduleService
+public class ScheduleService(CCTContext context, ISessionService sessionService) : IScheduleService
 {
-    private readonly CCTContext _context;
-    private readonly ISessionService _sessionService;
-
-    public ScheduleService(CCTContext context)
-    {
-        _context = context;
-        _sessionService = new SessionService(context);
-    }
 
     /// <summary>
     /// Fetch the session item whose id specified by the parameter
@@ -28,9 +20,9 @@ public class ScheduleService : IScheduleService
     /// <returns>CoursesBySessionViewModel if found, null if not found</returns>
     public async Task<IEnumerable<CoursesBySessionViewModel>> GetAllCoursesAsync(string username)
     {
-        List<UserCoursesViewModel> courses = await _context.UserCourses.Where(x => x.Username == username).Select(c => (UserCoursesViewModel)c).ToListAsync();
+        List<UserCoursesViewModel> courses = await context.UserCourses.Where(x => x.Username == username).Select(c => (UserCoursesViewModel)c).ToListAsync();
 
-        IEnumerable<SessionViewModel> sessions = _sessionService.GetAll();
+        IEnumerable<SessionViewModel> sessions = sessionService.GetAll();
         IEnumerable<CoursesBySessionViewModel> coursesBySession = sessions
             .GroupJoin(courses,
                        s => s.SessionCode,

--- a/Gordon360/Services/ServicesExtensions.cs
+++ b/Gordon360/Services/ServicesExtensions.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace Gordon360.Services;
+
+public static class ServicesExtensions
+{
+    /// <summary>
+    /// Add our Gordon 360 Services as scoped services to the dependency injection container.
+    /// </summary>
+    /// <param name="services">Service container</param>
+    /// <returns>The service container that has our services added.</returns>
+    public static IServiceCollection Add360Services(this IServiceCollection services)
+    {
+        services.AddScoped<IAcademicCheckInService, AcademicCheckInService>();
+        services.AddScoped<IAccountService, AccountService>();
+        services.AddScoped<IActivityService, ActivityService>();
+        services.AddScoped<IAddressesService, AddressesService>();
+        services.AddScoped<IAdministratorService, AdministratorService>();
+        services.AddScoped<IContentManagementService, ContentManagementService>();
+        services.AddScoped<IDiningService, DiningService>();
+        services.AddScoped<IEmailService, EmailService>();
+        services.AddScoped<IErrorLogService, ErrorLogService>();
+        services.AddScoped<IEventService, EventService>();
+        services.AddScoped<IHousingService, HousingService>();
+        services.AddScoped<IMembershipRequestService, MembershipRequestService>();
+        services.AddScoped<IMembershipService, MembershipService>();
+        services.AddScoped<INewsService, NewsService>();
+        services.AddScoped<IProfileService, ProfileService>();
+        services.AddScoped<INewsService, NewsService>();
+        services.AddScoped<IScheduleService, ScheduleService>();
+        services.AddScoped<ISessionService, SessionService>();
+        services.AddScoped<IStudentEmploymentService, StudentEmploymentService>();
+        services.AddScoped<IVictoryPromiseService, VictoryPromiseService>();
+        services.AddScoped<RecIM.IActivityService, RecIM.ActivityService>();
+        services.AddScoped<RecIM.ISeriesService, RecIM.SeriesService>();
+        services.AddScoped<RecIM.IMatchService, RecIM.MatchService>();
+        services.AddScoped<RecIM.ITeamService, RecIM.TeamService>();
+        services.AddScoped<RecIM.IParticipantService, RecIM.ParticipantService>();
+        services.AddScoped<RecIM.ISportService, RecIM.SportService>();
+        services.AddScoped<RecIM.IRecIMService, RecIM.RecIMService>();
+        services.AddScoped<RecIM.IAffiliationService, RecIM.AffiliationService>();
+
+        return services;
+    }
+}

--- a/Gordon360/Services/SessionService.cs
+++ b/Gordon360/Services/SessionService.cs
@@ -11,14 +11,8 @@ namespace Gordon360.Services;
 /// <summary>
 /// Service class to facilitate data transactions between the Controller and the database model.
 /// </summary>
-public class SessionService : ISessionService
+public class SessionService(CCTContext context) : ISessionService
 {
-    private CCTContext _context;
-
-    public SessionService(CCTContext context)
-    {
-        _context = context;
-    }
 
     /// <summary>
     /// Get the session record whose sesssion code matches the parameter.
@@ -27,7 +21,7 @@ public class SessionService : ISessionService
     /// <returns>A SessionViewModel if found, null if not found.</returns>
     public SessionViewModel Get(string sessionCode)
     {
-        var query = _context.CM_SESSION_MSTR.Where(s => s.SESS_CDE == sessionCode).FirstOrDefault();
+        var query = context.CM_SESSION_MSTR.Where(s => s.SESS_CDE == sessionCode).FirstOrDefault();
         if (query == null)
         {
             throw new ResourceNotFoundException() { ExceptionMessage = "The Session was not found." };
@@ -37,7 +31,7 @@ public class SessionService : ISessionService
 
     public SessionViewModel GetCurrentSession()
     {
-        return _context.CM_SESSION_MSTR.Where(s => DateTime.Now > s.SESS_BEGN_DTE).OrderByDescending(s => s.SESS_BEGN_DTE).First();
+        return context.CM_SESSION_MSTR.Where(s => DateTime.Now > s.SESS_BEGN_DTE).OrderByDescending(s => s.SESS_BEGN_DTE).First();
     }
 
     // Return the days left in the semester, and the total days in the current session
@@ -68,7 +62,7 @@ public class SessionService : ISessionService
     /// <returns>A SessionViewModel IEnumerable. If nothing is found, an empty IEnumerable is returned.</returns>
     public IEnumerable<SessionViewModel> GetAll()
     {
-        return _context.CM_SESSION_MSTR.Select<CM_SESSION_MSTR, SessionViewModel>(s => s);
+        return context.CM_SESSION_MSTR.Select<CM_SESSION_MSTR, SessionViewModel>(s => s);
     }
 
 

--- a/Gordon360/Services/StudentEmploymentService.cs
+++ b/Gordon360/Services/StudentEmploymentService.cs
@@ -1,5 +1,5 @@
-using Gordon360.Exceptions;
 using Gordon360.Models.CCT.Context;
+using Gordon360.Exceptions;
 using Gordon360.Models.ViewModels;
 using System;
 using System.Collections.Generic;
@@ -8,16 +8,8 @@ using System.Threading.Tasks;
 
 namespace Gordon360.Services;
 
-public class StudentEmploymentService : IStudentEmploymentService
+public class StudentEmploymentService(CCTContext context, IAccountService accountService) : IStudentEmploymentService
 {
-    private readonly CCTContext _context;
-    private readonly IAccountService _accountService;
-
-    public StudentEmploymentService(CCTContext context)
-    {
-        _context = context;
-        _accountService = new AccountService(context);
-    }
 
     /// <summary>
     /// get Student Employment records of given user
@@ -26,9 +18,9 @@ public class StudentEmploymentService : IStudentEmploymentService
     /// <returns>VictoryPromiseViewModel if found, null if not found</returns>
     public async Task<IEnumerable<StudentEmploymentViewModel>> GetEmploymentAsync(string username)
     {
-        var account = _accountService.GetAccountByUsername(username);
+        var account = accountService.GetAccountByUsername(username);
 
-        var result = await _context.Procedures.STUDENT_JOBS_PER_ID_NUMAsync(int.Parse(account.GordonID));
+        var result = await context.Procedures.STUDENT_JOBS_PER_ID_NUMAsync(int.Parse(account.GordonID));
         if (result == null)
         {
             throw new ResourceNotFoundException() { ExceptionMessage = "The data was not found." };

--- a/Gordon360/Services/VictoryPromiseService.cs
+++ b/Gordon360/Services/VictoryPromiseService.cs
@@ -7,14 +7,8 @@ using System.Threading.Tasks;
 
 namespace Gordon360.Services;
 
-public class VictoryPromiseService : IVictoryPromiseService
+public class VictoryPromiseService(CCTContext context) : IVictoryPromiseService
 {
-    private readonly CCTContext _context;
-
-    public VictoryPromiseService(CCTContext context)
-    {
-        _context = context;
-    }
 
     /// <summary>
     /// get victory promise scores
@@ -23,13 +17,13 @@ public class VictoryPromiseService : IVictoryPromiseService
     /// <returns>VictoryPromiseViewModel if found, null if not found</returns>
     public async Task<IEnumerable<VictoryPromiseViewModel>> GetVPScoresAsync(string username)
     {
-        var account = _context.ACCOUNT.FirstOrDefault(x => x.AD_Username == username);
+        var account = context.ACCOUNT.FirstOrDefault(x => x.AD_Username == username);
         if (account == null)
         {
             throw new ResourceNotFoundException() { ExceptionMessage = "The account was not found." };
         }
 
-        var result = await _context.Procedures.VICTORY_PROMISE_BY_STUDENT_IDAsync(int.Parse(account.gordon_id));
+        var result = await context.Procedures.VICTORY_PROMISE_BY_STUDENT_IDAsync(int.Parse(account.gordon_id));
         if (result == null)
         {
             throw new ResourceNotFoundException() { ExceptionMessage = "The data was not found." };


### PR DESCRIPTION
.NET 8's new Primary Constructor syntax adds a much cleaner way to declare a class that takes some inputs for construction and stores those inputs throughout the lifetime of the object.

This is ideal for Dependency Injection, because we can replace private readonly fields initialized in the constructor with inputs defined in the primary constructor. This syntax is simpler, easier to read and write, and familiar because it mimics function signatures. It is also the recommended way to write classes with these kinds of dependencies, such that Microsoft even created a linting rule for it that is automatically enabled from .NET 8 onwards.