### PR TITLE
Introduce robust logging technique

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -271,3 +271,6 @@ paket-files/
 # Environment Specific app settings
 appsettings.*.json
 secrets.config
+
+# Logs
+Gordon360/Logs/*

--- a/Gordon360/Controllers/AccountsController.cs
+++ b/Gordon360/Controllers/AccountsController.cs
@@ -4,6 +4,7 @@ using Gordon360.Models.ViewModels;
 using Gordon360.Services;
 using Gordon360.Static.Names;
 using Microsoft.AspNetCore.Mvc;
+using Serilog;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -118,6 +119,8 @@ public class AccountsController(IAccountService accountService) : GordonControll
         string? building,
         string? involvement)
     {
+        Log.Information("Advanced People Search with params {Params}", HttpContext.Request.Query);
+
         IEnumerable<AuthGroup> viewerGroups = AuthUtils.GetGroups(User);
 
         var accounts = accountService.GetAccountsToSearch(accountTypes, viewerGroups, homeCity);

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -1454,7 +1454,7 @@
             Activity Info and ACtivity may be talked about interchangeably.
             </summary>
         </member>
-        <member name="M:Gordon360.Services.ActivityService.#ctor(Gordon360.Models.CCT.Context.CCTContext,Microsoft.Extensions.Configuration.IConfiguration,Microsoft.Extensions.Logging.ILogger{Gordon360.Services.ActivityService},Microsoft.AspNetCore.Hosting.IWebHostEnvironment,Gordon360.Utilities.ServerUtils)">
+        <member name="M:Gordon360.Services.ActivityService.#ctor(Gordon360.Models.CCT.Context.CCTContext,Microsoft.Extensions.Configuration.IConfiguration,Microsoft.AspNetCore.Hosting.IWebHostEnvironment,Gordon360.Utilities.ServerUtils)">
             <summary>
             Service Class that facilitates data transactions between the ActivitiesController and the ACT_INFO database model.
             ACT_INFO is basically a copy of the ACT_CLUB_DEF domain model in TmsEPrd but with extra fields that we want to store (activity image, blurb etc...)

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -148,28 +148,6 @@
             </summary>
             <returns></returns>
         </member>
-        <member name="M:Gordon360.Controllers.AdminsController.GetAll">
-            <summary>
-            Get all admins
-            </summary>
-            <returns>
-            A list of all admins
-            </returns>
-            <remarks>
-            Server makes call to the database and returns all admins
-            </remarks>
-        </member>
-        <member name="M:Gordon360.Controllers.AdminsController.Post(Gordon360.Models.ViewModels.AdminViewModel)">
-            <summary>Create a new admin to be added to database</summary>
-            <param name="admin">The admin item containing all required and relevant information</param>
-            <returns></returns>
-            <remarks>Posts a new admin to the server to be added into the database</remarks>
-        </member>
-        <member name="M:Gordon360.Controllers.AdminsController.Delete(System.String)">
-            <summary>Delete an existing admin</summary>
-            <param name="username">The username of the user to demote</param>
-            <remarks>Calls the server to make a call and remove the given admin from the database</remarks>
-        </member>
         <member name="M:Gordon360.Controllers.AdvancedSearchController.GetMajors">
             <summary>
             Return a list majors.
@@ -1476,7 +1454,7 @@
             Activity Info and ACtivity may be talked about interchangeably.
             </summary>
         </member>
-        <member name="M:Gordon360.Services.ActivityService.#ctor(Gordon360.Models.CCT.Context.CCTContext,Microsoft.Extensions.Configuration.IConfiguration,Microsoft.AspNetCore.Hosting.IWebHostEnvironment,Gordon360.Utilities.ServerUtils)">
+        <member name="M:Gordon360.Services.ActivityService.#ctor(Gordon360.Models.CCT.Context.CCTContext,Microsoft.Extensions.Configuration.IConfiguration,Microsoft.Extensions.Logging.ILogger{Gordon360.Services.ActivityService},Microsoft.AspNetCore.Hosting.IWebHostEnvironment,Gordon360.Utilities.ServerUtils)">
             <summary>
             Service Class that facilitates data transactions between the ActivitiesController and the ACT_INFO database model.
             ACT_INFO is basically a copy of the ACT_CLUB_DEF domain model in TmsEPrd but with extra fields that we want to store (activity image, blurb etc...)
@@ -1572,50 +1550,6 @@
             </summary>
             <param name="activityCode">The activity code</param>
             <param name="isPrivate">activity private or not</param>
-        </member>
-        <member name="T:Gordon360.Services.AdministratorService">
-            <summary>
-            Service class to facilitate interacting with the Admin table.
-            </summary>
-        </member>
-        <member name="M:Gordon360.Services.AdministratorService.#ctor(Gordon360.Models.CCT.Context.CCTContext,Gordon360.Services.IAccountService)">
-            <summary>
-            Service class to facilitate interacting with the Admin table.
-            </summary>
-        </member>
-        <member name="M:Gordon360.Services.AdministratorService.GetAll">
-            <summary>
-            Fetches all the administrators from the database
-            </summary>
-            <returns>Returns a list of administrators. If no administrators were found, an empty list is returned.</returns>
-        </member>
-        <member name="M:Gordon360.Services.AdministratorService.GetByUsername(System.String)">
-            <summary>
-            Fetches a specific admin from the database
-            </summary>
-            <returns>Returns a list of administrators. If no administrators were found, an empty list is returned.</returns>
-        </member>
-        <member name="M:Gordon360.Services.AdministratorService.Add(Gordon360.Models.ViewModels.AdminViewModel)">
-            <summary>
-            Adds a new Administrator record to storage. Since we can't establish foreign key constraints and relationships on the database side,
-            we do it here by using the validateAdmin() method.
-            </summary>
-            <param name="adminView">The admin to be added</param>
-            <returns>The newly added Admin object</returns>
-        </member>
-        <member name="M:Gordon360.Services.AdministratorService.Delete(System.String)">
-            <summary>
-            Delete the admin whose id is specified by the parameter.
-            </summary>
-            <param name="username">The username of the admin to demote</param>
-            <returns>The admin that was just deleted</returns>
-        </member>
-        <member name="M:Gordon360.Services.AdministratorService.validateAdmin(Gordon360.Models.ViewModels.AdminViewModel)">
-            <summary>
-            Helper method to Validate an admin
-            </summary>
-            <param name="admin">The admin to validate</param>
-            <returns>True if the admin is valid. Throws ResourceNotFoundException if not. Exception is cauth in an Exception Filter</returns>
         </member>
         <member name="T:Gordon360.Services.ContentManagementService">
             <summary>

--- a/Gordon360/Gordon360.csproj
+++ b/Gordon360/Gordon360.csproj
@@ -63,6 +63,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Graph" Version="4.27.0" />
     <PackageReference Include="Microsoft.Identity.Web" Version="1.23.1" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="2.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.0" />
@@ -70,6 +75,9 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.DirectoryServices.AccountManagement" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Logs\" />
   </ItemGroup>
   <PropertyGroup>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>

--- a/Gordon360/Gordon360.csproj
+++ b/Gordon360/Gordon360.csproj
@@ -66,6 +66,7 @@
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="2.0.0" />
+    <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
@@ -75,9 +76,6 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.DirectoryServices.AccountManagement" Version="8.0.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Logs\" />
   </ItemGroup>
   <PropertyGroup>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>

--- a/Gordon360/Program.cs
+++ b/Gordon360/Program.cs
@@ -29,10 +29,7 @@ try
     builder.Services.AddSerilog((services, lc) => lc
         .ReadFrom.Configuration(builder.Configuration)
         .ReadFrom.Services(services)
-        .Enrich.FromLogContext()
-        .WriteTo.Console()
-        .WriteTo.File(new CompactJsonFormatter(), "./Logs/info.json", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 14, rollOnFileSizeLimit: true)
-        .WriteTo.File(new CompactJsonFormatter(), "./Logs/error.json", restrictedToMinimumLevel: Serilog.Events.LogEventLevel.Error, rollingInterval: RollingInterval.Day));
+        .Enrich.FromLogContext());
 
     builder.Services.AddMicrosoftIdentityWebApiAuthentication(builder.Configuration, "AzureAd");
 

--- a/Gordon360/Program.cs
+++ b/Gordon360/Program.cs
@@ -12,109 +12,137 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Identity.Web;
 using Microsoft.OpenApi.Models;
+using Serilog;
+using Serilog.Formatting.Compact;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using RecIM = Gordon360.Services.RecIM;
 
-var builder = WebApplication.CreateBuilder(args);
+const string CorsPolicy = "360UI";
 
-var azureConfig = builder.Configuration.GetSection("AzureAd").Get<AzureAdConfig>();
+Log.Logger = new LoggerConfiguration().WriteTo.Console().CreateBootstrapLogger();
 
-// Add services to the container.
-builder.Services.AddMicrosoftIdentityWebApiAuthentication(builder.Configuration, "AzureAd");
-
-builder.Services.AddControllers(options =>
+try
 {
-    options.OutputFormatters.RemoveType<StringOutputFormatter>(); // Return strings as application/json instead of text/plain
-    options.OutputFormatters.RemoveType<HttpNoContentOutputFormatter>(); // Return null as 200 Ok null instead of 204 No Content
-}).AddNewtonsoftJson(options => options.UseMemberCasing());
+    var builder = WebApplication.CreateBuilder(args);
 
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen(c =>
-{
-    c.AddSecurityDefinition("oauth2", new OpenApiSecurityScheme
+    builder.Services.AddSerilog((services, lc) => lc
+        .ReadFrom.Configuration(builder.Configuration)
+        .ReadFrom.Services(services)
+        .Enrich.FromLogContext()
+        .WriteTo.Console()
+        .WriteTo.File(new CompactJsonFormatter(), "./Logs/info.json", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 14, rollOnFileSizeLimit: true)
+        .WriteTo.File(new CompactJsonFormatter(), "./Logs/error.json", restrictedToMinimumLevel: Serilog.Events.LogEventLevel.Error, rollingInterval: RollingInterval.Day));
+
+    builder.Services.AddMicrosoftIdentityWebApiAuthentication(builder.Configuration, "AzureAd");
+
+    builder.Services.AddControllers(options =>
     {
-        Type = SecuritySchemeType.OAuth2,
-        Flows = new OpenApiOAuthFlows()
+        options.OutputFormatters.RemoveType<StringOutputFormatter>(); // Return strings as application/json instead of text/plain
+        options.OutputFormatters.RemoveType<HttpNoContentOutputFormatter>(); // Return null as 200 Ok null instead of 204 No Content
+    }).AddNewtonsoftJson(options => options.UseMemberCasing());
+
+    builder.Services.AddEndpointsApiExplorer();
+
+    var azureConfig = builder.Configuration.GetSection("AzureAd").Get<AzureAdConfig>();
+
+    builder.Services.AddSwaggerGen(c =>
+    {
+        c.AddSecurityDefinition("oauth2", new OpenApiSecurityScheme
         {
-            AuthorizationCode = new OpenApiOAuthFlow()
+            Type = SecuritySchemeType.OAuth2,
+            Flows = new OpenApiOAuthFlows()
             {
-                AuthorizationUrl = new Uri($"https://login.microsoftonline.com/{azureConfig.TenantId}/oauth2/v2.0/authorize"),
-                TokenUrl = new Uri($"https://login.microsoftonline.com/{azureConfig.TenantId}/oauth2/v2.0/token"),
-                Scopes = new Dictionary<string, string> {
+                AuthorizationCode = new OpenApiOAuthFlow()
+                {
+                    AuthorizationUrl = new Uri($"https://login.microsoftonline.com/{azureConfig.TenantId}/oauth2/v2.0/authorize"),
+                    TokenUrl = new Uri($"https://login.microsoftonline.com/{azureConfig.TenantId}/oauth2/v2.0/token"),
+                    Scopes = new Dictionary<string, string> {
                 {
                     $"{azureConfig.Audience}/access_as_user",
                     "Access 360 as you."
                 }
             }
+                }
             }
-        }
-    });
-    c.AddSecurityRequirement(new OpenApiSecurityRequirement() {
-    {
-        new OpenApiSecurityScheme {
-            Reference = new OpenApiReference {
-                    Type = ReferenceType.SecurityScheme,
-                        Id = "oauth2"
+        });
+        c.AddSecurityRequirement(new OpenApiSecurityRequirement() {
+            {
+                new OpenApiSecurityScheme {
+                    Reference = new OpenApiReference {
+                            Type = ReferenceType.SecurityScheme,
+                            Id = "oauth2"
+                        },
+                        Scheme = "oauth2",
+                        Name = "oauth2",
+                        In = ParameterLocation.Header
                 },
-                Scheme = "oauth2",
-                Name = "oauth2",
-                In = ParameterLocation.Header
-        },
-        new List < string > ()
-    }
-});
+                new List<string>()
+            }
+        });
+    });
+
+    builder.Services.AddCors(p => p.AddPolicy(name: CorsPolicy, corsBuilder =>
+    {
+        corsBuilder.WithOrigins(builder.Configuration.GetValue<string>("AllowedOrigin")).AllowAnyMethod().AllowAnyHeader();
+    }));
+
+    builder.Services.AddDbContext<CCTContext>(options =>
+        options.UseSqlServer(builder.Configuration.GetConnectionString("CCT"))
+    ).AddDbContext<MyGordonContext>(options =>
+        options.UseSqlServer(builder.Configuration.GetConnectionString("MyGordon"))
+    ).AddDbContext<webSQLContext>(options =>
+        options.UseSqlServer(builder.Configuration.GetConnectionString("webSQL"))
+    );
+
+    builder.Services.Add360Services();
+    builder.Services.AddHostedService<EventCacheRefreshService>();
+    builder.Services.AddScoped<ServerUtils, ServerUtils>();
+
+    builder.Services.AddMemoryCache();
+
+    var app = builder.Build();
+
+    // Configure the HTTP request pipeline.
+
+    app.UseSwagger();
+    app.UseSwaggerUI(c =>
+    {
+        c.OAuthClientId(azureConfig.ClientId);
+        c.OAuthScopes($"{azureConfig.Audience}/access_as_user");
+        c.OAuthUsePkce();
+    });
+
+    app.UseSerilogRequestLogging();
+
+    app.UseStaticFiles(new StaticFileOptions
+    {
+        FileProvider = new PhysicalFileProvider(
+            Path.Combine(builder.Environment.ContentRootPath, "browseable")),
+        RequestPath = "/browseable"
+    });
+
+    app.UseRouting();
+
+    app.UseAuthentication();
+    app.UseAuthorization();
+
+    app.UseCors(CorsPolicy);
+
+    app.MapControllers();
+
+    app.Run();
+
+    // Only runs once the app shutsdown
+    return 0;
 }
-);
-
-string corsPolicy = "360UI";
-builder.Services.AddCors(p => p.AddPolicy(name: corsPolicy, corsBuilder =>
+catch (Exception ex)
 {
-    corsBuilder.WithOrigins(builder.Configuration.GetValue<string>("AllowedOrigin")).AllowAnyMethod().AllowAnyHeader();
-}));
-
-builder.Services.AddDbContext<CCTContext>(options =>
-    options.UseSqlServer(builder.Configuration.GetConnectionString("CCT"))
-).AddDbContext<MyGordonContext>(options =>
-    options.UseSqlServer(builder.Configuration.GetConnectionString("MyGordon"))
-).AddDbContext<webSQLContext>(options =>
-    options.UseSqlServer(builder.Configuration.GetConnectionString("webSQL"))
-);
-
-builder.Services.Add360Services();
-builder.Services.AddHostedService<EventCacheRefreshService>();
-builder.Services.AddScoped<ServerUtils, ServerUtils>();
-
-builder.Services.AddMemoryCache();
-
-var app = builder.Build();
-
-// Configure the HTTP request pipeline.
-
-app.UseSwagger();
-app.UseSwaggerUI(c =>
+    Log.Fatal(ex, "An unhandled exception occurred during startup");
+    return 1;
+}
+finally
 {
-    c.OAuthClientId(azureConfig.ClientId);
-    c.OAuthScopes($"{azureConfig.Audience}/access_as_user");
-    c.OAuthUsePkce();
-});
+    Log.CloseAndFlush();
+}
 
-app.UseStaticFiles(new StaticFileOptions
-{
-    FileProvider = new PhysicalFileProvider(
-        Path.Combine(builder.Environment.ContentRootPath, "browseable")),
-    RequestPath = "/browseable"
-});
-
-app.UseRouting();
-
-app.UseAuthentication();
-app.UseAuthorization();
-
-app.UseCors(corsPolicy);
-
-app.MapControllers();
-
-app.Run();

--- a/Gordon360/appsettings.json
+++ b/Gordon360/appsettings.json
@@ -1,6 +1,6 @@
 {
   "AllowedHosts": "localhost;360.gordon.edu",
-  "AllowedOrigin":  "<Default>",
+  "AllowedOrigin": "<Default>",
   "AzureAd": {
     "Instance": "<Default>",
     "ClientId": "<Default>",
@@ -35,6 +35,17 @@
       "Default": "Information",
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "Serilog": {
+    "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.File" ],
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft.AspNetCore.Mvc": "Warning",
+        "Microsoft.AspNetCore.Routing": "Warning",
+        "Microsoft.AspNetCore.Hosting": "Warning"
+      }
     }
   },
   "SmtpHost": "smtp.gordon.edu"

--- a/Gordon360/appsettings.json
+++ b/Gordon360/appsettings.json
@@ -38,13 +38,40 @@
     }
   },
   "Serilog": {
-    "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.File" ],
     "MinimumLevel": {
-      "Default": "Information",
+      "Default": "Debug",
       "Override": {
-        "Microsoft.AspNetCore.Mvc": "Warning",
-        "Microsoft.AspNetCore.Routing": "Warning",
-        "Microsoft.AspNetCore.Hosting": "Warning"
+        "Microsoft": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information"
+      }
+    },
+    "WriteTo": {
+      "ConsoleSink": "Console",
+      "AsyncSinks": {
+        "Name": "Async",
+        "Args": {
+          "configure": [
+            {
+              "Name": "File",
+              "Args": {
+                "path": "./Logs/info-.json",
+                "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact",
+                "rollingInterval": "Day",
+                "retainedFileCountLimt": 14,
+                "rollOnFileSizeLimit": true
+              }
+            },
+            {
+              "Name": "File",
+              "Args": {
+                "path": "./Logs/error-.json",
+                "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact",
+                "rollingInterval": "Day",
+                "restrictedToMinimumLevel": "Error"
+              }
+            }
+          ]
+        }
       }
     }
   },


### PR DESCRIPTION
I have added Serilog for "Simple .NET logging with fully-structured events". With a relatively simple setup, Serilog enables us to write structured log data to the console (for development and live debugging) as well as to files in JSON format. Since the logs are structured, we can ingest the JSON files easily for analysis (such as what is mentioned in #940).

I have currently configured Serilog to log all debug or more important level events produced in our code (currently only the one I added as a demo), as well as any warnings, errors, or critical failures produced from Microsoft's frameworks. It is trivial to update these settings and we can make them more nuanced as time goes on, including filtering logs to certain sinks based on the properties of each log.

The current sinks are:
1. The Console, which captures all logs of the minimum level. This is useful for development and debugging. We can choose to turn it off in production if we desire.
2. An error JSON log file, which will only capture Error and Fatal level events. This is useful for quick diagnosis of issues. 
3. An info JSON log file that is broadly capturing logs in a structured format. Currently, a new file will be created each day, or each time the current file reaches 1GB in size. Only the 14 most recent log files will be kept, to prevent logs from filling our server's storage.

Possibly Closes #940, since this enables us to not only add logs wherever is useful in our source code, but also configure any kind of logging middleware (in addition to or replacing Serilog's default request logging middleware). Also, Serilog supports writing logs to SQL Server if we decide we want that.