### PR TITLE
Ignore missing birthdays

### DIFF
--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -2125,7 +2125,7 @@
             get a user's birthday
             </summary>
             <param name="username">The username of the person to get the birthdate of</param>
-            <returns>Date the user's date of birth, if available, or a default time of 0 ticks.</returns>
+            <returns>Date the user's date of birth, if available, or a default of 1/1/1800.</returns>
         </member>
         <member name="M:Gordon360.Services.ProfileService.GetAdvisorsAsync(System.String)">
             <summary>

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -2125,7 +2125,7 @@
             get a user's birthday
             </summary>
             <param name="username">The username of the person to get the birthdate of</param>
-            <returns>Date the user's date of birth</returns>
+            <returns>Date the user's date of birth, if available, or a default time of 0 ticks.</returns>
         </member>
         <member name="M:Gordon360.Services.ProfileService.GetAdvisorsAsync(System.String)">
             <summary>

--- a/Gordon360/Services/ProfileService.cs
+++ b/Gordon360/Services/ProfileService.cs
@@ -80,7 +80,7 @@ public class ProfileService(CCTContext context, IConfiguration config, IAccountS
 
         if (birthdate == null)
         {
-            return new DateTime(0L);  // Ignore missing birthday.
+            return new DateTime();  // Ignore missing birthday.
         }
 
         try

--- a/Gordon360/Services/ProfileService.cs
+++ b/Gordon360/Services/ProfileService.cs
@@ -73,14 +73,14 @@ public class ProfileService(CCTContext context, IConfiguration config, IAccountS
     /// get a user's birthday
     /// </summary>
     /// <param name="username">The username of the person to get the birthdate of</param>
-    /// <returns>Date the user's date of birth</returns>
+    /// <returns>Date the user's date of birth, if available, or a default time of 0 ticks.</returns>
     public DateTime GetBirthdate(string username)
     {
         var birthdate = context.ACCOUNT.FirstOrDefault(a => a.AD_Username == username)?.Birth_Date;
 
         if (birthdate == null)
         {
-            throw new ResourceNotFoundException() { ExceptionMessage = "A birthday was not found for this user." };
+            return new DateTime(0L);  // Ignore missing birthday.
         }
 
         try

--- a/Gordon360/Services/ProfileService.cs
+++ b/Gordon360/Services/ProfileService.cs
@@ -73,14 +73,14 @@ public class ProfileService(CCTContext context, IConfiguration config, IAccountS
     /// get a user's birthday
     /// </summary>
     /// <param name="username">The username of the person to get the birthdate of</param>
-    /// <returns>Date the user's date of birth, if available, or a default time of 0 ticks.</returns>
+    /// <returns>Date the user's date of birth, if available, or a default of 1/1/1800.</returns>
     public DateTime GetBirthdate(string username)
     {
         var birthdate = context.ACCOUNT.FirstOrDefault(a => a.AD_Username == username)?.Birth_Date;
 
         if (birthdate == null)
         {
-            return new DateTime();  // Ignore missing birthday.
+            return new DateTime(1800, 1, 1);
         }
 
         try


### PR DESCRIPTION
Over 1000 users have missing birthdays, in prod and train. Instead of throwing an exception that is ultimately ignored, just return a default value (0 ticks).

UI only uses this for birthday confetti.  Is it better to do that on the wrong day, or never?  The UI can decide.