### PR TITLE
S24 mailbox information

### DIFF
--- a/Gordon360/Controllers/ProfilesController.cs
+++ b/Gordon360/Controllers/ProfilesController.cs
@@ -200,12 +200,12 @@ public class ProfilesController(IProfileService profileService,
     /// <summary>Gets the mailbox information of currently logged in user</summary>
     /// <returns></returns>
     [HttpGet]
-    [Route("mailbox-combination")]
+    [Route("mailbox-information")]
     public ActionResult<MailboxViewModel> GetMailInfo()
     {
         var username = AuthUtils.GetUsername(User);
 
-        var result = profileService.GetMailboxCombination(username);
+        var result = profileService.GetMailboxInformation(username);
         return Ok(result);
     }
 

--- a/Gordon360/Controllers/ProfilesController.cs
+++ b/Gordon360/Controllers/ProfilesController.cs
@@ -201,6 +201,7 @@ public class ProfilesController(IProfileService profileService,
     /// <returns></returns>
     [HttpGet]
     [Route("mailbox-information")]
+    [Route("mailbox-combination")] // 2024-06-26: Route Deprecated - remove once UI has been updated
     public ActionResult<MailboxViewModel> GetMailInfo()
     {
         var username = AuthUtils.GetUsername(User);

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -2113,9 +2113,9 @@
             <param name="username">username</param>
             <returns>AlumniProfileViewModel if found, null if not found</returns>
         </member>
-        <member name="M:Gordon360.Services.ProfileService.GetMailboxCombination(System.String)">
+        <member name="M:Gordon360.Services.ProfileService.GetMailboxInformation(System.String)">
             <summary>
-            get mailbox combination
+            get mailbox information (contains box combination)
             </summary>
             <param name="username">The current user's username</param>
             <returns>MailboxViewModel with the combination</returns>

--- a/Gordon360/Services/ProfileService.cs
+++ b/Gordon360/Services/ProfileService.cs
@@ -59,14 +59,7 @@ public class ProfileService(CCTContext context, IConfiguration config, IAccountS
             .FirstOrDefault(x => x.AD_Username.ToLower() == username.ToLower())
             .Mail_Location;
 
-        var combo = context.Mailboxes.FirstOrDefault(m => m.BoxNo == mailboxNumber);
-
-        if (combo == null)
-        {
-            throw new ResourceNotFoundException() { ExceptionMessage = "A combination was not found for the specified mailbox number." };
-        }
-
-        return combo;
+        return context.Mailboxes.FirstOrDefault(m => m.BoxNo == mailboxNumber);
     }
 
     /// <summary>

--- a/Gordon360/Services/ProfileService.cs
+++ b/Gordon360/Services/ProfileService.cs
@@ -48,11 +48,11 @@ public class ProfileService(CCTContext context, IConfiguration config, IAccountS
     }
 
     /// <summary>
-    /// get mailbox combination
+    /// get mailbox information (contains box combination)
     /// </summary>
     /// <param name="username">The current user's username</param>
     /// <returns>MailboxViewModel with the combination</returns>
-    public MailboxViewModel GetMailboxCombination(string username)
+    public MailboxViewModel GetMailboxInformation(string username)
     {
         var mailboxNumber =
             context.Student

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -22,7 +22,7 @@ namespace Gordon360.Services
         StudentProfileViewModel? GetStudentProfileByUsername(string username);
         FacultyStaffProfileViewModel? GetFacultyStaffProfileByUsername(string username);
         AlumniProfileViewModel? GetAlumniProfileByUsername(string username);
-        MailboxViewModel GetMailboxCombination(string username);
+        MailboxViewModel GetMailboxInformation(string username);
         DateTime GetBirthdate(string username);
         Task<IEnumerable<AdvisorViewModel>> GetAdvisorsAsync(string username);
         CliftonStrengthsViewModel? GetCliftonStrengths(int id);


### PR DESCRIPTION
Every time a student profile is loaded by the UI, the API is asked for the student's mailbox combination.  This request is impossible to fulfill if the student does not have a mailbox number.  While probably not an issue for actual students, it does mean that when we authenticate using our test student account (360.StudentTest) the API always halts with a thrown exception.  We can safely ignore this exception as the API will merely return the mailbox information with an empty combination string.

While making that fix, it seemed reasonable to change the API route name and several function names to more accurately reflect the fact that the request is for mailbox information (which includes the combination, if it exists) rather than only the mailbox combination.

See PR 2334 in gordon-360-ui