### PR TITLE
Removed deprecated api/profiles/mailbox-combination route

### DIFF
--- a/Gordon360/Controllers/ProfilesController.cs
+++ b/Gordon360/Controllers/ProfilesController.cs
@@ -201,7 +201,6 @@ public class ProfilesController(IProfileService profileService,
     /// <returns></returns>
     [HttpGet]
     [Route("mailbox-information")]
-    [Route("mailbox-combination")] // 2024-06-26: Route Deprecated - remove once UI has been updated
     public ActionResult<MailboxViewModel> GetMailInfo()
     {
         var username = AuthUtils.GetUsername(User);

--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -376,7 +376,7 @@ Differences from GoSite:
 
 `api/profiles/clifton/{username}` Get the Clifton Strengths of a user with username `username` as a parameter.
 
-`api/profiles/mailbox-combination` Get the mailbox combination of the current logged in user.
+`api/profiles/mailbox-information` Get the mailbox information, including combination, of the current logged in user.
 
 `api/profiles/Image` Get profile image of the current logged in user. Image is stored in a base 64 string.
 


### PR DESCRIPTION
Previously the route `api/profiles/mailbox-combination` was changed in both the UI and API to `api/profiles/mailbox-information`.  The UI has since been updated and deployed so now we can remove the old route from the API.