### PR TITLE
Users less than 1 day old are given artificial birthday

### DIFF
--- a/Gordon360/Services/ProfileService.cs
+++ b/Gordon360/Services/ProfileService.cs
@@ -70,10 +70,20 @@ public class ProfileService(CCTContext context, IConfiguration config, IAccountS
     public DateTime GetBirthdate(string username)
     {
         var birthdate = context.ACCOUNT.FirstOrDefault(a => a.AD_Username == username)?.Birth_Date;
+        var impossible_birthdate = new DateTime(1800, 1, 1);
 
         if (birthdate == null)
         {
-            return new DateTime(1800, 1, 1);
+            return impossible_birthdate;
+        }
+
+        // Test accounts always have current date and time as birthday, so
+        // treat this the same as no birthday
+        // Comment this out to see "happy birthday" banner in test accounts
+        var lifetime = DateTime.Now - (DateTime) birthdate;
+        if (lifetime.Days < 1) // no valid user was born within the last 24 hours
+        {
+            return impossible_birthdate;
         }
 
         try


### PR DESCRIPTION
The 360.StudentTest and 360.FacultyTest accounts are configured to always have the current date-time for their `Birth_Date` in the CCT dbo.ACCOUNTS database view.  This means that the "Happy Birthday" banner always shows on their home profile.  To disable this, the API now checks to see if the user is less than 1 day old and, if so, returns an impossible birthday (Jan 1 1800).