### PR TITLE
Remove Newtonsoft.Json Dependency

### DIFF
--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -1222,6 +1222,7 @@
             <param name="timeZoneID">String timezoneinfo location</param>
             <returns>Converted DateTime with kind UTC</returns>
         </member>
+        <!-- Badly formed XML comment ignored for member "M:Gordon360.Extensions.SystemTextJsonMergeExtensions.Merge(System.Text.Json.Nodes.JsonNode,System.Text.Json.Nodes.JsonNode)" -->
         <member name="P:Gordon360.Models.CCT.Clifton_Strengths.Private">
             <summary>
             Whether the user wants their strengths to be private (not shown to other users)

--- a/Gordon360/Extensions/SystemTextJsonMergeExtensions.cs
+++ b/Gordon360/Extensions/SystemTextJsonMergeExtensions.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Nodes;
+using System.Text.Json;
+using System;
+using System.Linq;
+
+namespace Gordon360.Extensions;
+
+public static class SystemTextJsonMergeExtensions
+{
+    /// <summary>
+    /// Merges the specified Json Node into the base JsonNode for which this method is called.
+    /// It is null safe and can be easily used with null-check & null coalesce operators for fluent calls.
+    /// NOTE: JsonNodes are context aware and track their parent relationships therefore to merge the values both JsonNode objects
+    ///         specified are mutated. The Base is mutated with new data while the source is mutated to remove references to all
+    ///         fields so that they can be added to the base.
+    ///
+    /// Source taken directly from the open-source Gist here:
+    /// https://gist.github.com/cajuncoding/bf78bdcf790782090d231590cbc2438f
+    ///
+    /// </summary>
+    /// <param name="jsonBase"></param>
+    /// <param name="jsonMerge"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentException"></exception>
+    public static JsonNode Merge(this JsonNode jsonBase, JsonNode jsonMerge)
+    {
+        if (jsonBase == null || jsonMerge == null)
+            return jsonBase;
+
+        switch (jsonBase)
+        {
+            case JsonObject jsonBaseObj when jsonMerge is JsonObject jsonMergeObj:
+                {
+                    //NOTE: We must materialize the set (e.g. to an Array), and then clear the merge array so the node can then be 
+                    //      re-assigned to the target/base Json; clearing the Object seems to be the most efficient approach...
+                    var mergeNodesArray = jsonMergeObj.ToArray();
+                    jsonMergeObj.Clear();
+
+                    foreach (var prop in mergeNodesArray)
+                    {
+                        jsonBaseObj[prop.Key] = jsonBaseObj[prop.Key] switch
+                        {
+                            JsonObject jsonBaseChildObj when prop.Value is JsonObject jsonMergeChildObj => jsonBaseChildObj.Merge(jsonMergeChildObj),
+                            JsonArray jsonBaseChildArray when prop.Value is JsonArray jsonMergeChildArray => jsonBaseChildArray.Merge(jsonMergeChildArray),
+                            JsonValue jsonBaseValue when prop.Value is null => jsonBaseValue,
+                            _ => prop.Value
+                        };
+                    }
+                    break;
+                }
+            case JsonArray jsonBaseArray when jsonMerge is JsonArray jsonMergeArray:
+                {
+                    //NOTE: We must materialize the set (e.g. to an Array), and then clear the merge array,
+                    //      so they can then be re-assigned to the target/base Json...
+                    var mergeNodesArray = jsonMergeArray.ToArray();
+                    jsonMergeArray.Clear();
+                    foreach (var mergeNode in mergeNodesArray) jsonBaseArray.Add(mergeNode);
+                    break;
+                }
+            default:
+                throw new ArgumentException($"The JsonNode type [{jsonBase.GetType().Name}] is incompatible for merging with the target/base " +
+                                                    $"type [{jsonMerge.GetType().Name}]; merge requires the types to be the same.");
+
+        }
+
+        return jsonBase;
+    }
+}

--- a/Gordon360/Gordon360.csproj
+++ b/Gordon360/Gordon360.csproj
@@ -71,10 +71,8 @@
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.DirectoryServices.AccountManagement" Version="8.0.0" />
   </ItemGroup>
   <PropertyGroup>

--- a/Gordon360/Models/ViewModels/ProfileImageViewModel.cs
+++ b/Gordon360/Models/ViewModels/ProfileImageViewModel.cs
@@ -1,0 +1,4 @@
+﻿namespace Gordon360.Models.ViewModels;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "UI depends on lowercase properties")]
+public record ProfileImageViewModel(string? def, string? pref);

--- a/Gordon360/Program.cs
+++ b/Gordon360/Program.cs
@@ -37,7 +37,10 @@ try
     {
         options.OutputFormatters.RemoveType<StringOutputFormatter>(); // Return strings as application/json instead of text/plain
         options.OutputFormatters.RemoveType<HttpNoContentOutputFormatter>(); // Return null as 200 Ok null instead of 204 No Content
-    }).AddNewtonsoftJson(options => options.UseMemberCasing());
+    }).AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.PropertyNamingPolicy = null; // Prevent System.Text.Json converting PascalCase to camelCase when serializing objects to JSON in endpoints responses
+    });
 
     builder.Services.AddEndpointsApiExplorer();
 

--- a/Gordon360/Services/DiningService.cs
+++ b/Gordon360/Services/DiningService.cs
@@ -2,7 +2,6 @@
 using Gordon360.Exceptions;
 using Gordon360.Models.ViewModels;
 using Microsoft.Extensions.Configuration;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Data;
 using System.IO;
@@ -10,6 +9,7 @@ using System.Linq;
 using System.Net;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json.Nodes;
 
 // <summary>
 // We use this service to pull meal data from blackboard and parse it
@@ -96,7 +96,6 @@ public class DiningService : IDiningService
 
             // Get the response.  
             WebResponse response = request.GetResponse();
-            Console.WriteLine(((HttpWebResponse)response).StatusDescription);
 
             // Get the stream containing content returned by the server.  
             dataStream = response.GetResponseStream();
@@ -104,12 +103,8 @@ public class DiningService : IDiningService
             // Read the content. 
             StreamReader reader = new StreamReader(dataStream);
             string responseFromServer = reader.ReadToEnd();
-            JObject json = JObject.Parse(responseFromServer);
-            string balance = json["balance"].ToString();
-
-            // Display the content.  
-            Console.WriteLine(responseFromServer);
-            Console.WriteLine("Balance: " + balance);
+            JsonNode? json = JsonNode.Parse(responseFromServer);
+            string balance = json?["balance"]?.GetValue<string>() ?? "0";
 
             // Clean up the streams.  
             reader.Close();

--- a/Gordon360/Services/ProfileService.cs
+++ b/Gordon360/Services/ProfileService.cs
@@ -1,16 +1,18 @@
 ﻿using Gordon360.Exceptions;
+using Gordon360.Extensions;
 using Gordon360.Models.CCT;
 using Gordon360.Models.CCT.Context;
 using Gordon360.Models.ViewModels;
 using Gordon360.Models.webSQL.Context;
 using Microsoft.Extensions.Configuration;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Net;
 using System.Net.Mail;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 
 namespace Gordon360.Services;
@@ -412,35 +414,35 @@ public class ProfileService(CCTContext context, IConfiguration config, IAccountS
 
     public ProfileViewModel? ComposeProfile(object? student, object? alumni, object? faculty, object? customInfo)
     {
-        var profile = new JObject();
+        var profile = new JsonObject();
         var personType = "";
 
         if (student != null)
         {
-            MergeProfile(profile, JObject.FromObject(student));
+            profile.Merge(JsonSerializer.SerializeToNode(student)!);
             personType += "stu";
         }
 
         if (alumni != null)
         {
-            MergeProfile(profile, JObject.FromObject(alumni));
+            profile.Merge(JsonSerializer.SerializeToNode(alumni)!);
             personType += "alu";
         }
 
         if (faculty != null)
         {
-            MergeProfile(profile, JObject.FromObject(faculty));
+            profile.Merge(JsonSerializer.SerializeToNode(faculty)!);
             personType += "fac";
         }
 
         if (customInfo != null)
         {
-            MergeProfile(profile, JObject.FromObject(customInfo));
+            profile.Merge(JsonSerializer.SerializeToNode(customInfo)!);
         }
 
         profile.Add("PersonType", personType);
 
-        return profile.ToObject<ProfileViewModel>();
+        return JsonSerializer.Deserialize<ProfileViewModel>(profile);
     }
 
     public async Task InformationChangeRequest(string username, ProfileFieldViewModel[] updatedFields)
@@ -489,15 +491,6 @@ public class ProfileService(CCTContext context, IConfiguration config, IAccountS
         }
 
         smtpClient.Send(message);
-    }
-
-    private static JObject MergeProfile(JObject profile, JObject profileInfo)
-    {
-        profile.Merge(profileInfo, new JsonMergeSettings
-        {
-            MergeArrayHandling = MergeArrayHandling.Union
-        });
-        return profile;
     }
 
     public IEnumerable<string> GetMailStopsAsync()


### PR DESCRIPTION
Prior to .NET Core, there was no support for JSON serialization/deserialization in the C# standard library. Therefore, it was standard practice to use an external JSON library, and 360 used the most popular and well known of these, Newtonsoft.Json.

However, Microsoft added the System.Text.Json library in the early versions of .NET Core, which was built from the ground up to be significantly more performant and standards-compliant than Newtonsoft.Json and is now feature-complete enough that it ships as the default JSON serialization/deserialization library for ASP.NET Core.

Newtonsoft.Json is gradually becoming less viable as a dependency, and continuing to depend on it complicates our environment as well as increasing our security surface. I have therefore replaced it with System.Text.Json. I verified that serialization and deserialization are handled identically, after tweaking some of the defaults as necessary. There may be potential edge cases, but that is unlikely since our use of Newtonsoft.Json was very simple.