### PR TITLE
RecIM: Include Participant's Hall in Admin view of Team's Participants

### DIFF
--- a/Gordon360/Controllers/RecIM/TeamsController.cs
+++ b/Gordon360/Controllers/RecIM/TeamsController.cs
@@ -34,7 +34,12 @@ public class TeamsController(ITeamService teamService, IActivityService activity
     [Route("{teamID}")]
     public ActionResult<TeamExtendedViewModel> GetTeamByID(int teamID)
     {
-        var team = teamService.GetTeamByID(teamID);
+
+        var viewerUsername = AuthUtils.GetUsername(User);
+        var viewerParticipation = participantService.GetParticipantByUsername(viewerUsername);
+        var isAdmin = viewerParticipation?.IsAdmin == true || AuthUtils.UserIsInGroup(User, Enums.AuthGroup.RecIMSuperAdmin);
+
+        var team = teamService.GetTeamByID(teamID, isAdmin);
 
         if (team == null)
         {

--- a/Gordon360/Models/CCT/Context/CCTContext.cs
+++ b/Gordon360/Models/CCT/Context/CCTContext.cs
@@ -468,6 +468,7 @@ public partial class CCTContext : DbContext
         {
             entity.ToView("ParticipantView", "RecIM");
 
+            entity.Property(e => e.Hall).IsFixedLength();
             entity.Property(e => e.SpecifiedGender).IsFixedLength();
         });
 

--- a/Gordon360/Models/CCT/RecIM/ParticipantView.cs
+++ b/Gordon360/Models/CCT/RecIM/ParticipantView.cs
@@ -42,4 +42,8 @@ public partial class ParticipantView
     public string LastName { get; set; }
 
     public int CurrentStatus { get; set; }
+
+    [StringLength(45)]
+    [Unicode(false)]
+    public string Hall { get; set; }
 }

--- a/Gordon360/Models/ViewModels/RecIM/ParticipantExtendedViewModel.cs
+++ b/Gordon360/Models/ViewModels/RecIM/ParticipantExtendedViewModel.cs
@@ -3,20 +3,21 @@ using System.Collections.Generic;
 
 namespace Gordon360.Models.ViewModels.RecIM;
 
-public class ParticipantExtendedViewModel
+public sealed record ParticipantExtendedViewModel
 {
-    public string Username { get; set; }
+    public required string Username { get; set; }
     public string? Email { get; set; }
     public string? Role { get; set; }
     public int? GamesAttended { get; set; }
-    public string Status { get; set; }
-    public IEnumerable<ParticipantNotificationViewModel> Notification { get; set; }
+    public string? Status { get; set; }
+    public IEnumerable<ParticipantNotificationViewModel>? Notification { get; set; }
     public bool IsAdmin { get; set; }
     public bool AllowEmails { get; set; }
-    public string SpecifiedGender { get; set; }
+    public string? SpecifiedGender { get; set; }
     public bool IsCustom { get; set; }
     public string? FirstName { get; set; }
     public string? LastName { get; set; }
+    public string? Hall { get; set; }
 
     public static implicit operator ParticipantExtendedViewModel(ACCOUNT a)
     {
@@ -25,14 +26,11 @@ public class ParticipantExtendedViewModel
             Username = a.AD_Username.Trim() ?? "",
             Email = a.email ?? "",
         };
-
     }
 
-    public static implicit operator ParticipantExtendedViewModel?(ParticipantView? p)
+    public static ParticipantExtendedViewModel? From(ParticipantView p, bool isAdminView = false)
     {
-        if (p is null) return null;
-
-        return new ParticipantExtendedViewModel
+        var result = new ParticipantExtendedViewModel
         {
             Username = p.Username,
             Email = p.Email,
@@ -41,9 +39,12 @@ public class ParticipantExtendedViewModel
             AllowEmails = p.AllowEmails,
             IsCustom = p.IsCustom,
             FirstName = p.FirstName,
-            LastName = p.LastName
+            LastName = p.LastName,
         };
 
-    }
+        // only admin viewers can see a participant's hall
+        if (isAdminView == true) result.Hall = p.Hall;
 
+        return result;
+    }
 }

--- a/Gordon360/Services/RecIM/MatchService.cs
+++ b/Gordon360/Services/RecIM/MatchService.cs
@@ -166,7 +166,7 @@ public class MatchService(CCTContext context, IParticipantService participantSer
                         Status = mt.Status.Description,
                         Participant = mt.Team.ParticipantTeam
                             .Where(pt => !new int[] { 0, 1, 2 }.Contains(pt.RoleTypeID)) //roletype is either deleted, invalid, invited to join
-                            .Select(pt => participantService.GetParticipantByUsername(pt.ParticipantUsername, pt.RoleType.Description)),
+                            .Select(pt => participantService.GetParticipantByUsername(pt.ParticipantUsername, pt.RoleType.Description, false)),
                     })
             }).FirstOrDefault();
             return multiTeamMatch;
@@ -229,7 +229,7 @@ public class MatchService(CCTContext context, IParticipantService participantSer
                         Status = mt.Status.Description,
                         Participant = mt.Team.ParticipantTeam
                             .Where(pt => !new int[] {0,1,2}.Contains(pt.RoleTypeID)) //roletype is either deleted, invalid, invited to join
-                            .Select(pt => participantService.GetParticipantByUsername(pt.ParticipantUsername, pt.RoleType.Description)),
+                            .Select(pt => participantService.GetParticipantByUsername(pt.ParticipantUsername, pt.RoleType.Description, false)),
                         MatchHistory = context.MatchTeam.Where(_mt => _mt.TeamID == mt.TeamID && _mt.Match.StatusID == 6)
                             .OrderByDescending(mt => mt.Match.StartTime)
                             .Take(5)

--- a/Gordon360/Services/RecIM/ParticipantService.cs
+++ b/Gordon360/Services/RecIM/ParticipantService.cs
@@ -56,9 +56,13 @@ public class ParticipantService(CCTContext context) : IParticipantService
         return account;
     }
 
-    public ParticipantExtendedViewModel? GetParticipantByUsername(string username, string? roleType = null)
+    public ParticipantExtendedViewModel? GetParticipantByUsername(string username, string? roleType = null, bool isAdminView = false)
     {
-        ParticipantExtendedViewModel? participant = context.ParticipantView.FirstOrDefault(pv => pv.Username == username);
+        ParticipantExtendedViewModel? participant = context.ParticipantView
+            .Where(pv => pv.Username == username)
+            .Select(pv => ParticipantExtendedViewModel.From(pv, isAdminView))
+            .FirstOrDefault();
+
         if (participant is null) return null;
 
         participant.Role = roleType;

--- a/Gordon360/Services/RecIM/TeamService.cs
+++ b/Gordon360/Services/RecIM/TeamService.cs
@@ -85,8 +85,6 @@ public class TeamService(CCTContext context,
                 Affiliation = t.Affiliation,
                 Status = t.Status.Description,
                 Logo = t.Logo,
-                Participant = t.ParticipantTeam.Where(pt => pt.RoleTypeID != 0) // 0 is deleted
-                    .Select(pt => participantSerivce.GetParticipantByUsername(pt.ParticipantUsername, pt.RoleType.Description)),
                 TeamRecord = t.SeriesTeam
                     .Select(st => (TeamRecordViewModel)st)
                     .AsEnumerable(),

--- a/Gordon360/Services/RecIM/TeamService.cs
+++ b/Gordon360/Services/RecIM/TeamService.cs
@@ -69,9 +69,9 @@ public class TeamService(CCTContext context,
 
     public IEnumerable<TeamExtendedViewModel> GetTeams(bool active)
     {
-        var teamQuery = active 
+        var teamQuery = active
             ? context.Team.Where(t => t.Activity.Completed != active && t.StatusID != 0) // 0 is deleted
-            : context.Team.Where(t => t.StatusID != 0);    
+            : context.Team.Where(t => t.StatusID != 0);
 
         var teams = teamQuery
             .Include(t => t.SeriesTeam)
@@ -102,78 +102,81 @@ public class TeamService(CCTContext context,
                             m => m.ID,
                             mt => mt.MatchID,
                             (m, mt) => mt.SportsmanshipScore
-                        ).Average() 
+                        ).Average()
             })
             .AsEnumerable();
         return teams;
     }
-    public TeamExtendedViewModel GetTeamByID(int teamID)
-    {
-        var team = context.Team
-                        .Where(t => t.ID == teamID && t.StatusID != 0)
-                        .Include(t => t.Activity)
-                            .ThenInclude(t => t.Type)
-                        .Include(t => t.SeriesTeam)
-                            .ThenInclude(t => t.Team)
-                        .Select(t => new TeamExtendedViewModel
-                        {
-                            ID = teamID,
-                            Activity = t.Activity,
-                            Name = t.Name,
-                            Affiliation = t.Affiliation,
-                            Status = t.Status.Description,
-                            Logo = t.Logo,
-                            Match = t.MatchTeam
-                                .Where(mt => mt.Match.StatusID != 0)
-                                .Select(mt => matchService.GetMatchForTeamByMatchID(mt.MatchID)).AsEnumerable(),
-                            Participant = t.ParticipantTeam.Where(pt => pt.RoleTypeID != 0)
-                                            .Select(pt => participantSerivce.GetParticipantByUsername(pt.ParticipantUsername, pt.RoleType.Description)),
-                            MatchHistory = context.Match.Where(m => m.StatusID == 6 || m.StatusID == 4) // completed or forfeited status
-                                            .Join(context.MatchTeam
-                                                .Where(mt => mt.TeamID == teamID)
 
-                                                    .Join(
-                                                        context.MatchTeam.Where(mt => mt.TeamID != teamID),
-                                                        mt0 => mt0.MatchID,
-                                                        mt1 => mt1.MatchID,
-                                                        (mt0, mt1) => new
+    public TeamExtendedViewModel GetTeamByID(int teamID, bool isAdminView = false)
+    {
+        var team =
+            context.Team
+                .Where(t => t.ID == teamID && t.StatusID != 0)
+                .Include(t => t.Activity)
+                    .ThenInclude(t => t.Type)
+                .Include(t => t.SeriesTeam)
+                    .ThenInclude(t => t.Team)
+                .Select(t => new TeamExtendedViewModel
+                {
+                    ID = teamID,
+                    Activity = t.Activity,
+                    Name = t.Name,
+                    Affiliation = t.Affiliation,
+                    Status = t.Status.Description,
+                    Logo = t.Logo,
+                    Match = t.MatchTeam
+                        .Where(mt => mt.Match.StatusID != 0)
+                        .Select(mt => matchService.GetMatchForTeamByMatchID(mt.MatchID)).AsEnumerable(),
+                    Participant = t.ParticipantTeam.Where(pt => pt.RoleTypeID != 0)
+                                    .Select(pt => participantSerivce.GetParticipantByUsername(pt.ParticipantUsername, pt.RoleType.Description, isAdminView)),
+                    MatchHistory = context.Match.Where(m => m.StatusID == 6 || m.StatusID == 4) // completed or forfeited status
+                                    .Join(context.MatchTeam
+                                        .Where(mt => mt.TeamID == teamID)
+
+                                            .Join(
+                                                context.MatchTeam.Where(mt => mt.TeamID != teamID),
+                                                mt0 => mt0.MatchID,
+                                                mt1 => mt1.MatchID,
+                                                (mt0, mt1) => new
+                                                {
+                                                    TeamID = mt0.TeamID,
+                                                    MatchID = mt0.MatchID,
+                                                    OwnScore = mt0.Score,
+                                                    OpposingTeamID = mt1.TeamID,
+                                                    OpposingTeamScore = mt1.Score,
+                                                    Status = mt0.Score > mt1.Score
+                                                            ? "Win"
+                                                            : mt0.Score < mt1.Score
+                                                                ? "Lose"
+                                                                : "Tie"
+                                                }),
+                                                match => match.ID,
+                                                matchTeamJoin => matchTeamJoin.MatchID,
+                                                (match, matchTeamJoin) => new TeamMatchHistoryViewModel
+                                                {
+                                                    TeamID = matchTeamJoin.TeamID,
+                                                    MatchID = match.ID,
+                                                    Opponent = context.Team.Where(t => t.ID == matchTeamJoin.OpposingTeamID)
+                                                        .Select(o => new TeamExtendedViewModel
                                                         {
-                                                            TeamID = mt0.TeamID,
-                                                            MatchID = mt0.MatchID,
-                                                            OwnScore = mt0.Score,
-                                                            OpposingTeamID = mt1.TeamID,
-                                                            OpposingTeamScore = mt1.Score,
-                                                            Status = mt0.Score > mt1.Score
-                                                                    ? "Win"
-                                                                    : mt0.Score < mt1.Score
-                                                                        ? "Lose"
-                                                                        : "Tie"
-                                                        }),
-                                                        match => match.ID,
-                                                        matchTeamJoin => matchTeamJoin.MatchID,
-                                                        (match, matchTeamJoin) => new TeamMatchHistoryViewModel
-                                                        {
-                                                            TeamID = matchTeamJoin.TeamID,
-                                                            MatchID = match.ID,
-                                                            Opponent = context.Team.Where(t => t.ID == matchTeamJoin.OpposingTeamID)
-                                                                .Select(o => new TeamExtendedViewModel
-                                                                {
-                                                                    ID = o.ID,
-                                                                    Name = o.Name,
-                                                                    Logo = o.Logo
-                                                                }).FirstOrDefault(),
-                                                            TeamScore = matchTeamJoin.OwnScore,
-                                                            OpposingTeamScore = matchTeamJoin.OpposingTeamScore,
-                                                            Status = matchTeamJoin.Status,
-                                                            MatchStatusID = match.StatusID,
-                                                            MatchStartTime = match.StartTime.SpecifyUtc()
-                                                        }
-                                            ).AsEnumerable(),
-                            TeamRecord = t.SeriesTeam
-                                        .Select(st =>  (TeamRecordViewModel)st)
-                                        .AsEnumerable(),
-                            SportsmanshipRating = GetTeamSportsmanshipScore(teamID)
-                        }).FirstOrDefault();
+                                                            ID = o.ID,
+                                                            Name = o.Name,
+                                                            Logo = o.Logo
+                                                        }).FirstOrDefault(),
+                                                    TeamScore = matchTeamJoin.OwnScore,
+                                                    OpposingTeamScore = matchTeamJoin.OpposingTeamScore,
+                                                    Status = matchTeamJoin.Status,
+                                                    MatchStatusID = match.StatusID,
+                                                    MatchStartTime = match.StartTime.SpecifyUtc()
+                                                }
+                                    ).AsEnumerable(),
+                    TeamRecord = t.SeriesTeam
+                                .Select(st => (TeamRecordViewModel)st)
+                                .AsEnumerable(),
+                    SportsmanshipRating = GetTeamSportsmanshipScore(teamID)
+                }).FirstOrDefault();
+
         return team;
     }
 
@@ -182,7 +185,7 @@ public class TeamService(CCTContext context,
         var participantStatus = participantSerivce.GetParticipantByUsername(username)?.Status;
         if (participantStatus is null) return Enumerable.Empty<TeamExtendedViewModel>();
 
-        if (participantStatus == "Banned" || participantStatus == "Suspended") 
+        if (participantStatus == "Banned" || participantStatus == "Suspended")
             throw new UnauthorizedAccessException($"{username} is currented {participantStatus}. If you would like to dispute this, please contact Rec.IM@gordon.edu");
 
         var teamInvites = context.ParticipantTeam
@@ -197,9 +200,9 @@ public class TeamService(CCTContext context,
                 .AsEnumerable();
 
         return teamInvites;
-;
+        ;
     }
-    
+
     public ParticipantTeamViewModel GetParticipantTeam(int teamID, string username)
     {
         var participantStatus = participantSerivce.GetParticipantByUsername(username).Status;
@@ -225,8 +228,8 @@ public class TeamService(CCTContext context,
         var participantStatus = participantSerivce.GetParticipantByUsername(username).Status;
         if (participantStatus == "Banned" || participantStatus == "Suspended")
             throw new UnauthorizedAccessException($"{username} is currented {participantStatus}. If you would like to dispute this, please contact Rec.IM@gordon.edu");
-        
-        if(context.Activity.Find(newTeam.ActivityID).Team.Any(team => team.Name == newTeam.Name))
+
+        if (context.Activity.Find(newTeam.ActivityID).Team.Any(team => team.Name == newTeam.Name))
             throw new UnprocessibleEntity
             { ExceptionMessage = $"Team name {newTeam.Name} has already been taken by another team in this activity" };
 
@@ -242,7 +245,8 @@ public class TeamService(CCTContext context,
         await AddParticipantToTeamAsync(team.ID, captain);
 
         var existingSeries = context.Series.Where(s => s.ActivityID == newTeam.ActivityID).OrderBy(s => s.StartDate)?.FirstOrDefault();
-        if (existingSeries is not null) {
+        if (existingSeries is not null)
+        {
             var seriesTeam = new SeriesTeam
             {
                 TeamID = team.ID,
@@ -272,7 +276,7 @@ public class TeamService(CCTContext context,
             (pt, t) => pt);
 
         //if captain or inactive on another team, delete this participant team (admins can bypass)
-        if (otherInstances.Any(pt => new int[] { 5,6 }.Contains(pt.RoleTypeID) && !participantSerivce.IsAdmin(participant.Username)))  
+        if (otherInstances.Any(pt => new int[] { 5, 6 }.Contains(pt.RoleTypeID) && !participantSerivce.IsAdmin(participant.Username)))
         {
             context.ParticipantTeam.Remove(participantTeam);
             throw new ResourceCreationException() { ExceptionMessage = $"Participant is in an immutable role in this activity" };
@@ -301,7 +305,7 @@ public class TeamService(CCTContext context,
             .FirstOrDefault(t => t.ID == teamID);
         team.StatusID = 0;
 
-        foreach(var mt in team.MatchTeam)
+        foreach (var mt in team.MatchTeam)
             mt.StatusID = 0;
 
 
@@ -312,15 +316,15 @@ public class TeamService(CCTContext context,
 
     public async Task<TeamViewModel> UpdateTeamAsync(int teamID, TeamPatchViewModel updatedTeam)
     {
-        var team =  context.Team
+        var team = context.Team
             .Include(t => t.Activity)
                 .ThenInclude(t => t.Team)
             .FirstOrDefault(t => t.ID == teamID);
         if (updatedTeam.Name is not null)
         {
-            if (team.Activity.Team.Any(team => team.Name == updatedTeam.Name && team.ID != teamID)) 
-                throw new UnprocessibleEntity 
-                    { ExceptionMessage = $"Team name {updatedTeam.Name} has already been taken by another team in this activity" };
+            if (team.Activity.Team.Any(team => team.Name == updatedTeam.Name && team.ID != teamID))
+                throw new UnprocessibleEntity
+                { ExceptionMessage = $"Team name {updatedTeam.Name} has already been taken by another team in this activity" };
         }
         team.Name = updatedTeam.Name ?? team.Name;
         team.StatusID = updatedTeam.StatusID ?? team.StatusID;
@@ -379,17 +383,17 @@ public class TeamService(CCTContext context,
             );
         string subject = $"Gordon Rec-IM: {inviter.FirstName} {inviter.LastName} has {(isCustom ? "added" : "invited")} you to a team!";
 
-        emailService.SendEmails(new string[] {to_email},from_email,subject,messageBody,password);
+        emailService.SendEmails(new string[] { to_email }, from_email, subject, messageBody, password);
     }
-    
+
     public async Task<ParticipantTeamViewModel> AddParticipantToTeamAsync(int teamID, ParticipantTeamUploadViewModel participant, string? inviterUsername = null)
     {
         //new check for enabling non-recim participants to be invited
-        if(!context.Participant.Any(p => p.Username == participant.Username))
+        if (!context.Participant.Any(p => p.Username == participant.Username))
             await participantSerivce.PostParticipantAsync(participant.Username, 1); //pending user
 
         //check for participant is on the team
-        if (context.Team.FirstOrDefault(t => t.ID == teamID).ParticipantTeam.Any(pt => pt.ParticipantUsername == participant.Username 
+        if (context.Team.FirstOrDefault(t => t.ID == teamID).ParticipantTeam.Any(pt => pt.ParticipantUsername == participant.Username
             && pt.RoleTypeID != 0 && pt.RoleTypeID != 2)) //doesn't check for deleted or invited
             throw new UnprocessibleEntity { ExceptionMessage = $"Participant {participant.Username} is already in this team" };
 
@@ -408,15 +412,15 @@ public class TeamService(CCTContext context,
         else
         {
             participantTeam = new ParticipantTeam
-                {
-                    TeamID = teamID,
-                    ParticipantUsername = participant.Username,
-                    SignDate = DateTime.UtcNow,
-                    RoleTypeID = participant.RoleTypeID ?? 2, //3 -> Member, 2-> Requested Join
-                };
+            {
+                TeamID = teamID,
+                ParticipantUsername = participant.Username,
+                SignDate = DateTime.UtcNow,
+                RoleTypeID = participant.RoleTypeID ?? 2, //3 -> Member, 2-> Requested Join
+            };
             await context.ParticipantTeam.AddAsync(participantTeam);
         }
-        
+
         await context.SaveChangesAsync();
         if (participant.RoleTypeID == 2 && inviterUsername is not null) //if this is an invite, send an email
         {
@@ -482,7 +486,7 @@ public class TeamService(CCTContext context,
             && !attendees.Any(name => mp.ParticipantUsername == name));
         context.MatchParticipant.RemoveRange(attendanceToRemove);
 
-        var existingAttendance = context.MatchParticipant.Where(mp => mp.MatchID == matchID && mp.TeamID == teamID 
+        var existingAttendance = context.MatchParticipant.Where(mp => mp.MatchID == matchID && mp.TeamID == teamID
             && attendees.Any(name => mp.ParticipantUsername == name));
 
         var attendanceToAdd = attendees.Where(name => !existingAttendance.Any(ea => ea.ParticipantUsername == name));
@@ -496,7 +500,7 @@ public class TeamService(CCTContext context,
             };
             await context.MatchParticipant.AddAsync(created);
             res.Add(created);
-   
+
         }
         await context.SaveChangesAsync();
         return (res);

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -290,7 +290,7 @@ namespace Gordon360.Services
             IEnumerable<LookupViewModel>? GetTeamLookup(string type);
             double GetTeamSportsmanshipScore(int teamID);
             IEnumerable<TeamExtendedViewModel> GetTeams(bool active);
-            TeamExtendedViewModel GetTeamByID(int teamID);
+            TeamExtendedViewModel GetTeamByID(int teamID, bool isAdminView = false);
             IEnumerable<TeamExtendedViewModel> GetTeamInvitesByParticipantUsername(string username);
             ParticipantTeamViewModel GetParticipantTeam(int teamID, string username);
             Task<TeamViewModel> PostTeamAsync(TeamUploadViewModel newTeam, string username);
@@ -314,7 +314,7 @@ namespace Gordon360.Services
             bool GetParticipantIsCustom(string username);
             IEnumerable<BasicInfoViewModel> GetAllCustomParticipantsBasicInfo();
             IEnumerable<ParticipantStatusExtendedViewModel> GetParticipantStatusHistory(string username);
-            ParticipantExtendedViewModel? GetParticipantByUsername(string username, string? roleType = null);
+            ParticipantExtendedViewModel? GetParticipantByUsername(string username, string? roleType = null, bool isAdminView = false);
             AccountViewModel GetUnaffiliatedAccountByUsername(string username);
             IEnumerable<MatchExtendedViewModel> GetParticipantMatches(string username);
             IEnumerable<TeamExtendedViewModel> GetParticipantTeams(string username);


### PR DESCRIPTION
Per CTS Ticket #175058, we should display a team participant's hall to admins. This PR works in concert with gordon-cs/gordon-360-ui#2372, but neither of them depend on each other.

I added the participant's Hall to the ParticipantView in the database. I also updated the API to inlcude the Hall in the ParticipantExtendedViewModel, but only when the viewer is an admin.

This code is a little messy because we have to pass an extra parameter describing whether the view of the participant is for an Admin. However, given the spaghetti nature of the RecIM data logic, it seemed like the cleanest way to enforce that the Hall is only included in ParticipantExtendedViewModel when the viewer is an admin.