### PR TITLE
Remove StudentTimesheets database from appsettings

### DIFF
--- a/Gordon360/appsettings.json
+++ b/Gordon360/appsettings.json
@@ -15,7 +15,7 @@
   "ConnectionStrings": {
     "CCT": "<Default>",
     "MyGordon": "<Default>",
-    "StudentTimesheets": "<Default>"
+    "webSQL": "<Default>"
   },
   "DEFAULT_ACTIVITY_IMAGE_PATH": "<Default>",
   "DEFAULT_PROFILE_IMAGE_PATH": "<Default>",


### PR DESCRIPTION
Now that StudentTimesheets is long gone, we should update appsettings to reflect the actual database ConnectionStrings being used.