### PR TITLE
User auth for backend lost and found operations

### DIFF
--- a/Gordon360/Authorization/StateYourBusiness.cs
+++ b/Gordon360/Authorization/StateYourBusiness.cs
@@ -402,6 +402,14 @@ public class StateYourBusiness : ActionFilterAttribute
                 return user_groups.Contains(AuthGroup.NewsAdmin);
             case Resource.RECIM:
                 return _recimParticipantService.IsAdmin(user_name);
+            case Resource.LOST_AND_FOUND_MISSING_REPORT:
+                {
+                    if (user_groups.Contains(AuthGroup.LostAndFoundAdmin))
+                    {
+                        return true;
+                    }
+                    return false;
+                }
             default: return false;
         }
     }

--- a/Gordon360/Controllers/LostAndFoundController.cs
+++ b/Gordon360/Controllers/LostAndFoundController.cs
@@ -1,8 +1,10 @@
-﻿using Gordon360.Authorization;
+﻿using Azure;
+using Gordon360.Authorization;
 using Gordon360.Models.CCT;
 using Gordon360.Models.CCT.Context;
 using Gordon360.Models.ViewModels;
 using Gordon360.Services;
+using Gordon360.Static.Names;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 
@@ -22,6 +24,7 @@ namespace Gordon360.Controllers
 
         [HttpGet]
         [Route("missingitems")]
+        [StateYourBusiness(operation = Static.Names.Operation.READ_ALL, resource = Resource.LOST_AND_FOUND_MISSING_REPORT)]
         public ActionResult<IEnumerable<Missing>> GetMissingItems()
         {
             IEnumerable<Missing> result = lostAndFoundService.GetMissingItems();

--- a/Gordon360/Enums/AuthGroup.cs
+++ b/Gordon360/Enums/AuthGroup.cs
@@ -13,7 +13,8 @@ public enum AuthGroup
     RecIMSuperAdmin,
     SiteAdmin,
     Staff,
-    Student
+    Student,
+    LostAndFoundAdmin
 }
 
 public static class AuthGroupEnum
@@ -32,6 +33,7 @@ public static class AuthGroupEnum
         "360-SiteAdmin-SG" => AuthGroup.SiteAdmin,
         "360-Staff-SG" => AuthGroup.Staff,
         "360-Student-SG" => AuthGroup.Student,
+        "360-LostAndFoundAdmin-SG" => AuthGroup.LostAndFoundAdmin,
         _ => null
     };
 }

--- a/Gordon360/Static Classes/Names.cs
+++ b/Gordon360/Static Classes/Names.cs
@@ -36,6 +36,7 @@ public static class Resource
     public const string RECIM_PARTICIPANT_ADMIN = "The admin status of a RecIM participating user";
     public const string RECIM_SUPER_ADMIN = "A RecIM director level resource";
     public const string RECIM_SURFACE = "RecIM Surfaces/Playing fields/Locations";
+    public const string LOST_AND_FOUND_MISSING_REPORT = "Lost and Found missing item reports";
     public const string STUDENT_SCHEDULE = "A student's schedule events";
 
     // Partial resources, to be targetted by Operation.READ_PARTIAL


### PR DESCRIPTION
Example of doing user authentication on routes.  Added a stateYourBusiness check to see if the user has admin permissions before allowing them to get all missing item reports.