### PR TITLE
API for setting and getting the pref contact for an RA

### DIFF
--- a/Gordon360/Controllers/HousingController.cs
+++ b/Gordon360/Controllers/HousingController.cs
@@ -454,4 +454,67 @@ public class HousingController(CCTContext context, IProfileService profileServic
         }
     }
 
+
+    /// <summary>
+    /// Sets or updates an RA's preferred contact method
+    /// </summary>
+    /// <param name="raId">The ID of the RA</param>
+    /// <param name="preferredContactMethod">The contact method (e.g., "Phone", "Teams")</param>
+    /// <returns>True if the contact method was successfully set</returns>
+    [HttpPost("set-preferred-contact")]
+    public async Task<IActionResult> SetPreferredContact([FromQuery] string raId, [FromQuery] string preferredContactMethod)
+    {
+        if (string.IsNullOrWhiteSpace(raId) || string.IsNullOrWhiteSpace(preferredContactMethod))
+        {
+            return BadRequest("RA ID and contact method are required.");
+        }
+
+        try
+        {
+            var result = await housingService.SetPreferredContactMethodAsync(raId, preferredContactMethod);
+            if (result)
+            {
+                return Ok("Preferred contact method set successfully.");
+            }
+            else
+            {
+                return StatusCode(500, "An error occurred while setting the preferred contact method.");
+            }
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, $"Internal server error: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Retrieves the preferred contact information for an RA based on their contact preference.
+    /// If the RA has a contact preference set, it will return either their phone number or a Microsoft Teams link 
+    /// with their email embedded. If no preference exists, the method defaults to returning the RA's phone number.
+    /// </summary>
+    /// <param name="raId">The ID of the RA whose contact information is being requested.</param>
+    /// <returns>A string containing the preferred contact information (phone number or Teams link) or a default 
+    /// phone number if no preference is set.</returns>
+    [HttpGet("ra-contact/{raId}")]
+    public async Task<ActionResult<string>> GetRAContact(string raId)
+    {
+        try
+        {
+            var contactInfo = await housingService.GetPreferredContactAsync(raId);
+
+            if (string.IsNullOrEmpty(contactInfo))
+            {
+                return NotFound("RA contact information not found.");
+            }
+
+            return Ok(contactInfo);
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, $"Internal server error: {ex.Message}");
+        }
+    }
+
+
+
 }

--- a/Gordon360/Controllers/HousingController.cs
+++ b/Gordon360/Controllers/HousingController.cs
@@ -487,6 +487,34 @@ public async Task<IActionResult> SetPreferredContact([FromQuery] string raId, [F
 }
 
 /// <summary>
+/// Retrieves the preferred contact information for an RA based on their contact preference.
+/// If the RA has a contact preference set, it will return either their phone number or a Microsoft Teams link 
+/// with their email embedded. If no preference exists, the method defaults to returning the RA's phone number.
+/// </summary>
+/// <param name="raId">The ID of the RA whose contact information is being requested.</param>
+/// <returns>A string containing the preferred contact information (phone number or Teams link) or a default 
+/// phone number if no preference is set.</returns>
+[HttpGet("ra-contact/{raId}")]
+public async Task<ActionResult<string>> GetRAContact(string raId)
+{
+    try
+    {
+        var contactInfo = await housingService.GetPreferredContactAsync(raId);
+
+        if (string.IsNullOrEmpty(contactInfo))
+        {
+            return NotFound("RA contact information not found.");
+        }
+
+        return Ok(contactInfo);
+    }
+    catch (Exception ex)
+    {
+        return StatusCode(500, $"Internal server error: {ex.Message}");
+    }
+}
+
+/// <summary>
 /// Checks an RA in
 /// </summary>
 /// <param name="checkin">The viewmodel object of the RA checking in</param>
@@ -531,34 +559,6 @@ public async Task<ActionResult<string>> GetOnCallRA(string Hall_ID)
         }
 
         return Ok(raId);
-    }
-    catch (Exception ex)
-    {
-        return StatusCode(500, $"Internal server error: {ex.Message}");
-    }
-}
-
-/// <summary>
-/// Retrieves the preferred contact information for an RA based on their contact preference.
-/// If the RA has a contact preference set, it will return either their phone number or a Microsoft Teams link 
-/// with their email embedded. If no preference exists, the method defaults to returning the RA's phone number.
-/// </summary>
-/// <param name="raId">The ID of the RA whose contact information is being requested.</param>
-/// <returns>A string containing the preferred contact information (phone number or Teams link) or a default 
-/// phone number if no preference is set.</returns>
-[HttpGet("ra-contact/{raId}")]
-public async Task<ActionResult<string>> GetRAContact(string raId)
-{
-    try
-    {
-        var contactInfo = await housingService.GetPreferredContactAsync(raId);
-
-        if (string.IsNullOrEmpty(contactInfo))
-        {
-            return NotFound("RA contact information not found.");
-        }
-
-        return Ok(contactInfo);
     }
     catch (Exception ex)
     {

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -296,6 +296,13 @@
             <param name="model">The ViewModel that contains the hall ID and room range</param>
             <returns>The created Hall_Assignment_Ranges object</returns>
         </member>
+        <member name="M:Gordon360.Controllers.HousingController.CreateStatus(Gordon360.Models.ViewModels.RA_Status_ScheduleViewModel)">
+            <summary>
+            Creates a new status event for an RA schedule
+            </summary>
+            <param name="model">The ViewModel that contains the Schedule ID and RA ID</param>
+            <returns>The created RA_Status_Schedule object</returns>
+        </member>
         <member name="M:Gordon360.Controllers.HousingController.DeleteRoomRange(System.Int32)">
             <summary>
             Deletes a Room Range
@@ -310,6 +317,13 @@
             <param name="range_Id">The ID of the room range</param>
             <param name="ra_Id">The ID of the RA to assign</param>
             <returns>The created RA_Assigned_Ranges object</returns>
+        </member>
+        <member name="M:Gordon360.Controllers.HousingController.DeleteAssignment(System.Int32)">
+            <summary>
+            Deletes an RA range assignment
+            </summary>
+            <param name="rangeId">The Room range of the assignment to delete</param>
+            <returns> Returns if completed</returns>
         </member>
         <member name="M:Gordon360.Controllers.HousingController.GetResidentRA(System.String,System.String)">
             <summary>
@@ -336,6 +350,24 @@
             Retrieves the list of all assignments.
             </summary>
             <returns>Returns a list of all assignments</returns>
+        </member>
+        <member name="M:Gordon360.Controllers.HousingController.SetPreferredContact(System.String,System.String)">
+            <summary>
+            Sets or updates an RA's preferred contact method
+            </summary>
+            <param name="raId">The ID of the RA</param>
+            <param name="preferredContactMethod">The contact method (e.g., "Phone", "Teams")</param>
+            <returns>True if the contact method was successfully set</returns>
+        </member>
+        <member name="M:Gordon360.Controllers.HousingController.GetRAContact(System.String)">
+            <summary>
+            Retrieves the preferred contact information for a Resident Advisor (RA) based on their contact preference.
+            If the RA has a contact preference set, it will return either their phone number or a Microsoft Teams link 
+            with their email embedded. If no preference exists, the method defaults to returning the RA's phone number.
+            </summary>
+            <param name="raId">The ID of the Resident Advisor (RA) whose contact information is being requested.</param>
+            <returns>A string containing the preferred contact information (phone number or Teams link) or a default 
+            phone number if no preference is set.</returns>
         </member>
         <member name="M:Gordon360.Controllers.LogController.Post(System.String)">
             <summary>Create a new error log item to be added to database</summary>
@@ -1895,6 +1927,13 @@
             <param name="model">The ViewModel that contains the hall ID and room range</param>
             <returns>The created Hall_Assignment_Ranges object</returns>
         </member>
+        <member name="M:Gordon360.Services.HousingService.CreateStatusAsync(Gordon360.Models.ViewModels.RA_Status_ScheduleViewModel)">
+            <summary>
+            Creates a new status event for an RA schedule
+            </summary>
+            <param name="model">The RA_Status_ScheduleViewModel variables</param>
+            <returns>The created RA_Status_Schedule object</returns>
+        </member>
         <member name="M:Gordon360.Services.HousingService.DeleteRoomRangeAsync(System.Int32)">
             <summary>
             Deletes a Room Range
@@ -1909,6 +1948,13 @@
             <param name="rangeId">The ID of the room range</param>
             <param name="raId">The ID of the RA to assign</param>
             <returns>The created RA_Assigned_Ranges object</returns>
+        </member>
+        <member name="M:Gordon360.Services.HousingService.DeleteAssignmentAsync(System.Int32)">
+            <summary>
+            Deletes an RA range assignment
+            </summary>
+            <param name="rangeId">The Room range of the assignment to delete</param>
+            <returns> Returns if completed</returns>
         </member>
         <member name="M:Gordon360.Services.HousingService.GetResidentRAAsync(System.String,System.String)">
             <summary>
@@ -1935,6 +1981,24 @@
             Retrieves the list of all assignments.
             </summary>
             <returns>Returns a list of all assignments</returns>
+        </member>
+        <member name="M:Gordon360.Services.HousingService.SetPreferredContactMethodAsync(System.String,System.String)">
+            <summary>
+            Sets or updates an RA's preferred contact method
+            </summary>
+            <param name="raId">The ID of the RA</param>
+            <param name="preferredContactMethod">The contact method (e.g., "Phone", "Teams")</param>
+            <returns>True if the contact method was successfully set</returns>
+        </member>
+        <member name="M:Gordon360.Services.HousingService.GetPreferredContactAsync(System.String)">
+            <summary>
+            Retrieves the preferred contact information for a Resident Advisor (RA) based on their contact preference.
+            If the RA has a contact preference set, it will return either their phone number or a Microsoft Teams link 
+            with their email embedded. If no preference exists, the method defaults to returning the RA's phone number.
+            </summary>
+            <param name="raId">The ID of the Resident Advisor (RA) whose contact information is being requested.</param>
+            <returns>A string containing the preferred contact information (phone number or Teams link) or a default 
+            phone number if no preference is set.</returns>
         </member>
         <member name="T:Gordon360.Services.MembershipRequestService">
             <summary>

--- a/Gordon360/Models/ViewModels/Housing/RA_ContactPreferenceViewModel.cs
+++ b/Gordon360/Models/ViewModels/Housing/RA_ContactPreferenceViewModel.cs
@@ -1,0 +1,11 @@
+﻿using Gordon360.Extensions.System;
+using Gordon360.Models.CCT;
+using System;
+using System.Collections.Generic;
+
+namespace Gordon360.Models.ViewModels;
+    public class RA_ContactPreference
+{
+    public string Ra_ID { get; set; } // ID of the RA
+    public string PreferredContactMethod { get; set; } // e.g., "Phone", "Teams"
+}

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -234,6 +234,8 @@ namespace Gordon360.Services
         Task<List<HallAssignmentRangeViewModel>> GetAllRoomRangesAsync();
         Task<List<RA_StudentsViewModel>> GetAllRAsAsync();
         Task<List<RA_Assigned_RangesViewModel>> GetRangeAssignmentsAsync();
+        Task<bool> SetPreferredContactMethodAsync(string raId, string preferredContactMethod);
+        Task<string> GetPreferredContactAsync(string raId);
     }
 
     public interface IAcademicCheckInService


### PR DESCRIPTION
`HttpPost("set-preferred-contact")` - sets/updates the preferred contact (phone or teams) for the given raId

`[HttpGet("ra-contact/{raId}"` - gets the pref contact fir the raId, if raId not in table default return is phone number if in table checks and returns the preferred contact. The teams link option gets the RA's email then returns it in the following URL format `https://teams.microsoft.com/l/chat/0/0?users=RA-EMAIL-HERE`