### PR TITLE
HOTFIX General User Missing Items GET

### DIFF
--- a/Gordon360/Services/LostAndFoundService.cs
+++ b/Gordon360/Services/LostAndFoundService.cs
@@ -280,7 +280,7 @@ namespace Gordon360.Services
             else
             {
                 // If a non-admin user requests the reports of someone else
-                if (requestorUsername.Equals(requestedUsername, StringComparison.OrdinalIgnoreCase))
+                if (!requestorUsername.Equals(requestedUsername, StringComparison.OrdinalIgnoreCase))
                 {
                     throw new ResourceNotFoundException() { ExceptionMessage = "No missing item reports could be found" };
                 }


### PR DESCRIPTION
Fixes issue 139 General Users couldn't call GET /missingItems?user={username}.