### PR TITLE
Admin actions now returns in date order - FIX for Issue #147

### DIFF
--- a/Gordon360/Services/LostAndFoundService.cs
+++ b/Gordon360/Services/LostAndFoundService.cs
@@ -313,12 +313,12 @@ namespace Gordon360.Services
             // Perform a group join to create a MissingItemReportViewModel with actions taken data for each report
             // Only performs a single SQL query to the db, so much more performant than alternative solutions
             return context.MissingItemData
-                .GroupJoin(context.ActionsTakenData,
+                .GroupJoin(context.ActionsTakenData.OrderBy(action => action.actionDate),
                     missingItem => missingItem.ID,
                     action => action.missingID,
                     (missingItem, action) => MissingItemReportViewModel.From(missingItem, action));
         }
-
+        
         /// <summary>
         /// Gets a Missing by id, only allowed if it belongs to the username, or the user is an admin
         /// </summary>


### PR DESCRIPTION
This should fix the last checked date sometimes showing the wrong date, since the actions were previously returned in an arbitrary order by the endpoint.