### PR TITLE
Filtering and Pagination on API

### DIFF
--- a/Gordon360/Controllers/LostAndFoundController.cs
+++ b/Gordon360/Controllers/LostAndFoundController.cs
@@ -82,13 +82,20 @@ namespace Gordon360.Controllers
         /// <summary>
         /// Get the list of missing item reports for the currently authenticated user.
         /// </summary>
-        /// <param name="status">The selected status</param>
+        /// <param name="color">The selected color for filtering reports</param>
+        /// <param name="category">The selected category for filtering reports</param>
+        /// <param name="keywords">The selected keywords for filtering by keywords</param>
+        /// <param name="status">The selected status for filtering reports</param>
         /// <param name="user">Query parameter, default is null and route will get all missing items, or if user is set
         /// route will get missing items for the authenticated user</param>
         /// <returns>ObjectResult - an http status code, with an array of MissingItem objects in the body </returns>
         [HttpGet]
         [Route("missingitems")]
-        public ActionResult<IEnumerable<MissingItemReportViewModel>> GetMissingItems(string? status, string? user = null)
+        public ActionResult<IEnumerable<MissingItemReportViewModel>> GetMissingItems(string? user = null,
+                                                                                     string? status = null, 
+                                                                                     string? color = null, 
+                                                                                     string? category = null,
+                                                                                     string? keywords = null)
         {
             IEnumerable<MissingItemReportViewModel> result;
             var authenticatedUserUsername = AuthUtils.GetUsername(User);
@@ -96,7 +103,7 @@ namespace Gordon360.Controllers
             // If no username specified in the query, get all items
             if (user == null)
             {
-                result = lostAndFoundService.GetMissingItemsAll(authenticatedUserUsername, status);
+                result = lostAndFoundService.GetMissingItemsAll(authenticatedUserUsername, status, color, category, keywords);
             }
             else
             {

--- a/Gordon360/Controllers/LostAndFoundController.cs
+++ b/Gordon360/Controllers/LostAndFoundController.cs
@@ -88,10 +88,14 @@ namespace Gordon360.Controllers
         /// <param name="status">The selected status for filtering reports</param>
         /// <param name="user">Query parameter, default is null and route will get all missing items, or if user is set
         /// route will get missing items for the authenticated user</param>
+        /// <param name="lastId">The ID of the last fetched report to start from for pagination</param>
+        /// <param name="pageSize">The size of the page to fetch for pagination</param>
         /// <returns>ObjectResult - an http status code, with an array of MissingItem objects in the body </returns>
         [HttpGet]
         [Route("missingitems")]
         public ActionResult<IEnumerable<MissingItemReportViewModel>> GetMissingItems(string? user = null,
+                                                                                     int? lastId = null,
+                                                                                     int? pageSize = null,
                                                                                      string? status = null, 
                                                                                      string? color = null, 
                                                                                      string? category = null,
@@ -103,7 +107,7 @@ namespace Gordon360.Controllers
             // If no username specified in the query, get all items
             if (user == null)
             {
-                result = lostAndFoundService.GetMissingItemsAll(authenticatedUserUsername, status, color, category, keywords);
+                result = lostAndFoundService.GetMissingItemsAll(authenticatedUserUsername, lastId, pageSize, status, color, category, keywords);
             }
             else
             {

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -324,11 +324,14 @@
             <param name="status"></param>
             <returns>ObjectResult - the http status code result of the action</returns>
         </member>
-        <member name="M:Gordon360.Controllers.LostAndFoundController.GetMissingItems(System.String,System.String)">
+        <member name="M:Gordon360.Controllers.LostAndFoundController.GetMissingItems(System.String,System.String,System.String,System.String,System.String)">
             <summary>
             Get the list of missing item reports for the currently authenticated user.
             </summary>
-            <param name="status">The selected status</param>
+            <param name="color">The selected color for filtering reports</param>
+            <param name="category">The selected category for filtering reports</param>
+            <param name="keywords">The selected keywords for filtering by keywords</param>
+            <param name="status">The selected status for filtering reports</param>
             <param name="user">Query parameter, default is null and route will get all missing items, or if user is set
             route will get missing items for the authenticated user</param>
             <returns>ObjectResult - an http status code, with an array of MissingItem objects in the body </returns>
@@ -1959,11 +1962,13 @@
             <returns>an Enumerable of Missing Item Reports containing all missing item reports</returns>
             <exception cref="T:Gordon360.Exceptions.ResourceNotFoundException">If a user requests reports they are not permitted to access</exception>
         </member>
-        <member name="M:Gordon360.Services.LostAndFoundService.GetMissingItemsAll(System.String,System.String)">
+        <member name="M:Gordon360.Services.LostAndFoundService.GetMissingItemsAll(System.String,System.String,System.String,System.String,System.String)">
             <summary>
             Get all missing item reports
             Throw unauthorized access exception if the user doesn't have admin permissions
             </summary>
+            <param name="color"></param>
+            <param name="category"></param>
             <param name="status">The selected status</param>
             <param name="username">The username of the person making the request</param>
             <returns>An enumerable of Missing Item Reports, from the Missing Item Data view</returns>

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -324,7 +324,7 @@
             <param name="status"></param>
             <returns>ObjectResult - the http status code result of the action</returns>
         </member>
-        <member name="M:Gordon360.Controllers.LostAndFoundController.GetMissingItems(System.String,System.String,System.String,System.String,System.String)">
+        <member name="M:Gordon360.Controllers.LostAndFoundController.GetMissingItems(System.String,System.Nullable{System.Int32},System.Nullable{System.Int32},System.String,System.String,System.String,System.String)">
             <summary>
             Get the list of missing item reports for the currently authenticated user.
             </summary>
@@ -334,6 +334,8 @@
             <param name="status">The selected status for filtering reports</param>
             <param name="user">Query parameter, default is null and route will get all missing items, or if user is set
             route will get missing items for the authenticated user</param>
+            <param name="lastId">The ID of the last fetched report to start from for pagination</param>
+            <param name="pageSize">The size of the page to fetch for pagination</param>
             <returns>ObjectResult - an http status code, with an array of MissingItem objects in the body </returns>
         </member>
         <member name="M:Gordon360.Controllers.LostAndFoundController.GetMissingItem(System.Int32)">
@@ -1962,15 +1964,18 @@
             <returns>an Enumerable of Missing Item Reports containing all missing item reports</returns>
             <exception cref="T:Gordon360.Exceptions.ResourceNotFoundException">If a user requests reports they are not permitted to access</exception>
         </member>
-        <member name="M:Gordon360.Services.LostAndFoundService.GetMissingItemsAll(System.String,System.String,System.String,System.String,System.String)">
+        <member name="M:Gordon360.Services.LostAndFoundService.GetMissingItemsAll(System.String,System.Nullable{System.Int32},System.Nullable{System.Int32},System.String,System.String,System.String,System.String)">
             <summary>
             Get all missing item reports
             Throw unauthorized access exception if the user doesn't have admin permissions
             </summary>
-            <param name="color"></param>
-            <param name="category"></param>
-            <param name="status">The selected status</param>
+            <param name="color">The selected color for filtering reports</param>
+            <param name="category">The selected category for filtering reports</param>
+            <param name="keywords">The selected keywords for filtering by keywords</param>
+            <param name="status">The selected status for filtering reports</param>
             <param name="username">The username of the person making the request</param>
+            <param name="lastId">The ID of the last fetched report to start from for pagination</param>
+            <param name="pageSize">The size of the page to fetch for pagination</param>
             <returns>An enumerable of Missing Item Reports, from the Missing Item Data view</returns>
             <exception cref="T:System.UnauthorizedAccessException">If a user without admin permissions attempts to use</exception>
         </member>

--- a/Gordon360/Services/LostAndFoundService.cs
+++ b/Gordon360/Services/LostAndFoundService.cs
@@ -300,11 +300,14 @@ namespace Gordon360.Services
         /// Get all missing item reports
         /// Throw unauthorized access exception if the user doesn't have admin permissions
         /// </summary>
-        /// <param name="status">The selected status</param>
+        /// <param name="color">The selected color for filtering reports</param>
+        /// <param name="category">The selected category for filtering reports</param>
+        /// <param name="keywords">The selected keywords for filtering by keywords</param>
+        /// <param name="status">The selected status for filtering reports</param>
         /// <param name="username">The username of the person making the request</param>
         /// <returns>An enumerable of Missing Item Reports, from the Missing Item Data view</returns>
         /// <exception cref="UnauthorizedAccessException">If a user without admin permissions attempts to use</exception>
-        public IEnumerable<MissingItemReportViewModel> GetMissingItemsAll(string username, string status)
+        public IEnumerable<MissingItemReportViewModel> GetMissingItemsAll(string username, string? status, string? color, string? category, string? keywords)
         {
             if (!hasFullPermissions(username))
             {
@@ -315,6 +318,21 @@ namespace Gordon360.Services
             if (status is not null)
             {
                 missingItems = missingItems.Where(x => x.status == status);
+            }
+            if (color is not null)
+            {
+                missingItems = missingItems.Where(x => x.colors.Contains(color));
+            }
+            if (category is not null) 
+            { 
+                missingItems = missingItems.Where(x => x.category == category);
+            }
+            if (keywords is not null) 
+            {
+                missingItems = missingItems.Where(x => x.firstName.Contains(keywords) 
+                                                    || x.lastName.Contains(keywords) 
+                                                    || x.description.Contains(keywords) 
+                                                    || x.locationLost.Contains(keywords));
             }
 
             // Perform a group join to create a MissingItemReportViewModel with actions taken data for each report

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using System.Threading.Tasks;
 using RecIMActivityViewModel = Gordon360.Models.ViewModels.RecIM.ActivityViewModel;
@@ -232,7 +233,7 @@ namespace Gordon360.Services
         public int CreateMissingItemReport(MissingItemReportViewModel reportDetails, string username);
         public int CreateActionTaken(int id, ActionsTakenViewModel ActionsTaken, string username);
         IEnumerable<MissingItemReportViewModel> GetMissingItems(string requestedUsername, string requestorUsername);
-        IEnumerable<MissingItemReportViewModel> GetMissingItemsAll(string username, string status);
+        IEnumerable<MissingItemReportViewModel> GetMissingItemsAll(string username, string? status, string? color, string? category, string? keywords);
         Task UpdateMissingItemReportAsync(int id, MissingItemReportViewModel reportDetails, string username);
         Task UpdateReportStatusAsync(int id, string status, string username);
         MissingItemReportViewModel? GetMissingItem(int id, string username);

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -233,7 +233,13 @@ namespace Gordon360.Services
         public int CreateMissingItemReport(MissingItemReportViewModel reportDetails, string username);
         public int CreateActionTaken(int id, ActionsTakenViewModel ActionsTaken, string username);
         IEnumerable<MissingItemReportViewModel> GetMissingItems(string requestedUsername, string requestorUsername);
-        IEnumerable<MissingItemReportViewModel> GetMissingItemsAll(string username, string? status, string? color, string? category, string? keywords);
+        IEnumerable<MissingItemReportViewModel> GetMissingItemsAll(string username, 
+                                                                   int? lastId, 
+                                                                   int? pageSize, 
+                                                                   string? status, 
+                                                                   string? color, 
+                                                                   string? category, 
+                                                                   string? keywords);
         Task UpdateMissingItemReportAsync(int id, MissingItemReportViewModel reportDetails, string username);
         Task UpdateReportStatusAsync(int id, string status, string username);
         MissingItemReportViewModel? GetMissingItem(int id, string username);


### PR DESCRIPTION
All new parameters for filtering and pagination of missing item reports.  All parameters are optional, so this route is fully backwards compatible with the existing UI.

Doc comments describing the query parameters usage.
<img width="867" alt="Screen Shot 2025-01-29 at 15 41 04" src="https://github.com/user-attachments/assets/c78bc382-c2c3-4b19-af1c-0628d435f477" />

New interface for API route
<img width="440" alt="Screen Shot 2025-01-29 at 14 40 43" src="https://github.com/user-attachments/assets/e394966b-4f1f-457d-92e6-ab6fb2288a7a" />
