### PR TITLE
Fix events cache by increasing timeout

### DIFF
--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -1915,9 +1915,12 @@
         </member>
         <member name="M:Gordon360.Services.EventService.GetFirstEventDate">
             <summary>
-             Helper function to determine the current academic year
+            Get the first date of events for the current period, for use in querying the 25Live API
+            
+            During the regular undergrad school year, this is the middle of August (roughly the start of the fall term)
+            During the summer, this the middle of May (roughly the end of the spring term)
             </summary>
-            <returns></returns>
+            <returns>The first date of events we care about, in 'yyyyMMdd' format (e.g. '20250815' for August 15th, 2025)</returns>
         </member>
         <member name="M:Gordon360.Services.HousingService.CheckIfHousingAdmin(System.String)">
             <summary>
@@ -2140,6 +2143,7 @@
             </summary>
             <param name="idNum">The ID of the student</param>
             <returns>True if the student is a resident</returns>
+        </member>
         <member name="M:Gordon360.Services.LostAndFoundService.hasFullPermissions(System.String)">
             <summary>
             Check if the user has full admin permissions in the system

--- a/Gordon360/Services/EventCacheRefreshService.cs
+++ b/Gordon360/Services/EventCacheRefreshService.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace Gordon360.Services;
 
-public class EventCacheRefreshService(IMemoryCache cache) : IHostedService, IDisposable
+public sealed class EventCacheRefreshService(IMemoryCache cache) : IHostedService, IDisposable
 {
     private Timer? _timer = null;
 

--- a/Gordon360/Services/EventService.cs
+++ b/Gordon360/Services/EventService.cs
@@ -94,7 +94,8 @@ public class EventService(CCTContext context, IMemoryCache cache, IAccountServic
     public static async Task<IEnumerable<EventViewModel>> FetchEventsAsync()
     {
         using var client = new HttpClient();
-        client.DefaultRequestHeaders.Add("User-Agent", "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.2; .NET CLR 1.0.3705;)");
+        client.Timeout = TimeSpan.FromSeconds(200);
+        client.DefaultRequestHeaders.Add("User-Agent", "Gordon360/1.0.0");
 
         var response = await client.GetAsync(AllEventsURL);
         if (response != null && response.IsSuccessStatusCode)

--- a/Gordon360/Services/EventService.cs
+++ b/Gordon360/Services/EventService.cs
@@ -51,7 +51,7 @@ public class EventService(CCTContext context, IMemoryCache cache, IAccountServic
     /// <returns>All Public Events</returns>
     public IEnumerable<EventViewModel> GetPublicEvents()
     {
-        return Events.Where(e => e.IsPublic);
+        return Events.Where(e => e.IsPublic).OrderBy(e => e.StartDate);
     }
 
     /// <summary>
@@ -60,7 +60,7 @@ public class EventService(CCTContext context, IMemoryCache cache, IAccountServic
     /// <returns>All CLAW Events</returns>
     public IEnumerable<EventViewModel> GetCLAWEvents()
     {
-        return Events.Where(e => e.HasCLAWCredit);
+        return Events.Where(e => e.HasCLAWCredit).OrderBy(e => e.StartDate);
     }
 
     /// <summary>
@@ -88,7 +88,7 @@ public class EventService(CCTContext context, IMemoryCache cache, IAccountServic
                        from liveEvent in liveEvents.DefaultIfEmpty()
                        select new AttendedEventViewModel(liveEvent, chapelEvent);
 
-        return attendedEvents;
+        return attendedEvents.OrderBy(e => e.StartDate);
     }
 
     public static async Task<IEnumerable<EventViewModel>> FetchEventsAsync()

--- a/Gordon360/Services/EventService.cs
+++ b/Gordon360/Services/EventService.cs
@@ -126,26 +126,26 @@ public class EventService(CCTContext context, IMemoryCache cache, IAccountServic
     }
 
     /// <summary>
-    ///  Helper function to determine the current academic year
+    /// Get the first date of events for the current period, for use in querying the 25Live API
+    /// 
+    /// During the regular undergrad school year, this is the middle of August (roughly the start of the fall term)
+    /// During the summer, this the middle of May (roughly the end of the spring term)
     /// </summary>
-    /// <returns></returns>
+    /// <returns>The first date of events we care about, in 'yyyyMMdd' format (e.g. '20250815' for August 15th, 2025)</returns>
     private static string GetFirstEventDate()
     {
-        //Beginning date of fall semester (MM/DD)
-        var fallDate = "0815";
-        //Beginning date of summer (MM/DD)
-        var summerDate = "0515";
+        DateOnly today = DateOnly.FromDateTime(DateTime.Now);
 
-        // We need to determine what the current date is
-        DateTime today = DateTime.Today;
-        if (today.Month < 06)
+        DateOnly firstEventDate = today.Month switch
         {
-            return (today.Year - 1).ToString() + fallDate;
-        }
-        else if (today.Month > 07)
-        {
-            return today.Year.ToString() + fallDate;
-        }
-        return today.Year.ToString() + summerDate;
+            // In the Spring, the First Event Date is August 15th of the previous calendar year (i.e. the start of the fall semester)
+            < 6 => new DateOnly(today.Year - 1, 8, 15),
+            // In the fall, the First Event Date is August 15th of the current calendar year (i.e. the start of the fall semester)
+            > 7 => new DateOnly(today.Year, 8, 15),
+            // In the Summer, the First Event Date is May 15th of the current calendar year (i.e. ~ the start of the summer semester)
+            6 or 7 => new DateOnly(today.Year, 5, 15),
+        };
+
+        return firstEventDate.ToString("yyyyMMdd");
     }
 }

--- a/Gordon360/appsettings.json
+++ b/Gordon360/appsettings.json
@@ -30,13 +30,6 @@
     },
     "AlumniProfileUpdateRequestApprover": "<Default>"
   },
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
-    }
-  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Debug",


### PR DESCRIPTION
The EventService seems to be failing to retrieve events from 25Live. In my local testing the only reason I observed for this was because 25Live was sometimes taking more than 100 seconds to respond, triggering `HttpClient`'s default timeout and making the request fail.

I have increased the timeout to 200 seconds (since the request should only be sent every 10 minutes), which has not failed in my local testing.

I also fixed some warnings and improved the code in EventService and the Cache service that complements it.