### PR TITLE
Admin Missing Item Edit Permissions and Matching Found Item Route

### DIFF
--- a/Gordon360/Controllers/LostAndFoundController.cs
+++ b/Gordon360/Controllers/LostAndFoundController.cs
@@ -79,6 +79,23 @@ namespace Gordon360.Controllers
         }
 
         /// <summary>
+        /// Update the status of the item report with given id to the given status text
+        /// </summary>
+        /// <param name="missingItemId">The id of the report to update</param>
+        /// <param name="status"></param>
+        /// <returns>ObjectResult - the http status code result of the action</returns>
+        [HttpPut]
+        [Route("missingitems/{missingItemId}/linkItem/{foundItemID}")]
+        public async Task<ActionResult> UpdateReportAssociatedFoundItem(int missingItemId, string foundItemID)
+        {
+            var authenticatedUserUsername = AuthUtils.GetUsername(User);
+
+            await lostAndFoundService.UpdateReportAssociatedFoundItemAsync(missingItemId, foundItemID, authenticatedUserUsername);
+
+            return Ok();
+        }
+
+        /// <summary>
         /// Get the list of missing item reports for the currently authenticated user.
         /// </summary>
         /// <param name="color">The selected color for filtering reports</param>
@@ -247,6 +264,17 @@ namespace Gordon360.Controllers
             var authenticatedUserUsername = AuthUtils.GetUsername(User);
 
             await lostAndFoundService.UpdateFoundStatusAsync(itemId, status, authenticatedUserUsername);
+
+            return Ok();
+        }
+
+        [HttpPut]
+        [Route("founditems/{itemId}/linkReport/{missingReportID}")]
+        public async Task<ActionResult> UpdateFoundAssociatedMissingReport(string itemId, int missingReportID)
+        {
+            var authenticatedUserUsername = AuthUtils.GetUsername(User);
+
+            await lostAndFoundService.UpdateFoundAssociatedMissingReportAsync(itemId, missingReportID, authenticatedUserUsername);
 
             return Ok();
         }

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -2165,7 +2165,7 @@
                 Update the associated missing report for the found item
             </summary>
             <param name="foundItemID">The id of the found item to modify</param>
-            <param name="missingItemID"></param>
+            <param name="missingReportID"></param>
             <param name="username">The username of the person making the request</param>
             <returns>None</returns>
             <exception cref="T:Gordon360.Exceptions.ResourceCreationException">If not account can be found for the requesting user</exception>

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -324,6 +324,14 @@
             <param name="status"></param>
             <returns>ObjectResult - the http status code result of the action</returns>
         </member>
+        <member name="M:Gordon360.Controllers.LostAndFoundController.UpdateReportAssociatedFoundItem(System.Int32,System.String)">
+            <summary>
+            Update the status of the item report with given id to the given status text
+            </summary>
+            <param name="missingItemId">The id of the report to update</param>
+            <param name="status"></param>
+            <returns>ObjectResult - the http status code result of the action</returns>
+        </member>
         <member name="M:Gordon360.Controllers.LostAndFoundController.GetMissingItems(System.String,System.Nullable{System.Int32},System.Nullable{System.Int32},System.String,System.String,System.String,System.String)">
             <summary>
             Get the list of missing item reports for the currently authenticated user.
@@ -2034,6 +2042,15 @@
             <exception cref="T:System.UnauthorizedAccessException">If the report to be modified doesn't belong to the requesting user and the
             user is not an admin</exception>
         </member>
+        <member name="M:Gordon360.Services.LostAndFoundService.UpdateReportAssociatedFoundItemAsync(System.Int32,System.String,System.String)">
+            <summary>
+                Update the associated found item for a missing item report
+            </summary>
+            <param name="id"></param>
+            <param name="foundID"></param>
+            <param name="username"></param>
+            <returns></returns>
+        </member>
         <member name="M:Gordon360.Services.LostAndFoundService.GetMissingItems(System.String,System.String)">
             <summary>
             Get the list of missing item reports for given user.
@@ -2142,6 +2159,17 @@
             <returns>None</returns>
             <exception cref="T:Gordon360.Exceptions.ResourceCreationException">If not account can be found for the requesting user</exception>
             <exception cref="T:Gordon360.Exceptions.ResourceNotFoundException">If the found item report with given id cannot be found in the database</exception>
+        </member>
+        <member name="M:Gordon360.Services.LostAndFoundService.UpdateFoundAssociatedMissingReportAsync(System.String,System.Int32,System.String)">
+            <summary>
+                Update the associated missing report for the found item
+            </summary>
+            <param name="foundItemID">The id of the found item to modify</param>
+            <param name="missingItemID"></param>
+            <param name="username">The username of the person making the request</param>
+            <returns>None</returns>
+            <exception cref="T:Gordon360.Exceptions.ResourceCreationException">If not account can be found for the requesting user</exception>
+            <exception cref="T:Gordon360.Exceptions.ResourceNotFoundException">If the found item with given id cannot be found in the database</exception>
         </member>
         <member name="M:Gordon360.Services.LostAndFoundService.GetFoundItem(System.String,System.String)">
             <summary>

--- a/Gordon360/Models/CCT/Context/CCTContext.cs
+++ b/Gordon360/Models/CCT/Context/CCTContext.cs
@@ -194,7 +194,7 @@ public partial class CCTContext : DbContext
 
             entity.HasOne(d => d.missing).WithMany(p => p.ActionsTaken)
                 .OnDelete(DeleteBehavior.ClientSetNull)
-                .HasConstraintName("FK__ActionsTa__missi__11606D5A");
+                .HasConstraintName("FK__ActionsTa__missi__365CE7DF");
         });
 
         modelBuilder.Entity<ActionsTakenData>(entity =>
@@ -348,7 +348,7 @@ public partial class CCTContext : DbContext
         {
             entity.HasKey(e => e.ID).HasName("PK__tmp_ms_x__3214EC2792138BD9");
 
-            entity.HasOne(d => d.matchingMissing).WithMany(p => p.FoundItems).HasConstraintName("FK__FoundItem__match__4B8D0EEF");
+            entity.HasOne(d => d.matchingMissing).WithMany(p => p.FoundItems).HasConstraintName("FK__FoundItem__match__37510C18");
         });
 
         modelBuilder.Entity<GuestUsers>(entity =>
@@ -357,7 +357,7 @@ public partial class CCTContext : DbContext
 
             entity.HasOne(d => d.missing).WithMany(p => p.GuestUsers)
                 .OnDelete(DeleteBehavior.ClientSetNull)
-                .HasConstraintName("FK__GuestUser__missi__0E8400AF");
+                .HasConstraintName("FK__GuestUser__missi__3568C3A6");
         });
 
         modelBuilder.Entity<Housing_Applicants>(entity =>
@@ -479,7 +479,9 @@ public partial class CCTContext : DbContext
 
         modelBuilder.Entity<MissingReports>(entity =>
         {
-            entity.HasKey(e => e.ID).HasName("PK__MissingR__3214EC27985CEC3D");
+            entity.HasKey(e => e.ID).HasName("PK__tmp_ms_x__3214EC271C4C78EB");
+
+            entity.HasOne(d => d.matchingFound).WithMany(p => p.MissingReports).HasConstraintName("FK__MissingRe__match__38453051");
         });
 
         modelBuilder.Entity<PART_DEF>(entity =>

--- a/Gordon360/Models/CCT/LostAndFound/FoundItems.cs
+++ b/Gordon360/Models/CCT/LostAndFound/FoundItems.cs
@@ -80,6 +80,9 @@ public partial class FoundItems
     [InverseProperty("found")]
     public virtual ICollection<FoundActionsTaken> FoundActionsTaken { get; set; } = new List<FoundActionsTaken>();
 
+    [InverseProperty("matchingFound")]
+    public virtual ICollection<MissingReports> MissingReports { get; set; } = new List<MissingReports>();
+
     [ForeignKey("matchingMissingID")]
     [InverseProperty("FoundItems")]
     public virtual MissingReports matchingMissing { get; set; }

--- a/Gordon360/Models/CCT/LostAndFound/MissingItemData.cs
+++ b/Gordon360/Models/CCT/LostAndFound/MissingItemData.cs
@@ -14,9 +14,13 @@ public partial class MissingItemData
     public int ID { get; set; }
 
     [Required]
-    [StringLength(255)]
+    [StringLength(63)]
     [Unicode(false)]
     public string submitterID { get; set; }
+
+    [StringLength(10)]
+    [Unicode(false)]
+    public string matchingFoundID { get; set; }
 
     public bool forGuest { get; set; }
 
@@ -35,7 +39,7 @@ public partial class MissingItemData
     public string brand { get; set; }
 
     [Required]
-    [StringLength(255)]
+    [StringLength(511)]
     [Unicode(false)]
     public string description { get; set; }
 

--- a/Gordon360/Models/CCT/LostAndFound/MissingReports.cs
+++ b/Gordon360/Models/CCT/LostAndFound/MissingReports.cs
@@ -19,6 +19,10 @@ public partial class MissingReports
     [Unicode(false)]
     public string submitterID { get; set; }
 
+    [StringLength(10)]
+    [Unicode(false)]
+    public string matchingFoundID { get; set; }
+
     public bool forGuest { get; set; }
 
     [Required]
@@ -70,4 +74,8 @@ public partial class MissingReports
 
     [InverseProperty("missing")]
     public virtual ICollection<GuestUsers> GuestUsers { get; set; } = new List<GuestUsers>();
+
+    [ForeignKey("matchingFoundID")]
+    [InverseProperty("MissingReports")]
+    public virtual FoundItems matchingFound { get; set; }
 }

--- a/Gordon360/Services/LostAndFoundService.cs
+++ b/Gordon360/Services/LostAndFoundService.cs
@@ -230,7 +230,7 @@ namespace Gordon360.Services
             }
 
             // If the report doesn't belong to the requesting user
-            if (original.submitterID != idNum)
+            if (original.submitterID != idNum && !hasFullPermissions(username))
             {
                 throw new UnauthorizedAccessException("Cannot modify a report that doesn't belong to you!");
             }

--- a/Gordon360/Services/LostAndFoundService.cs
+++ b/Gordon360/Services/LostAndFoundService.cs
@@ -894,7 +894,7 @@ namespace Gordon360.Services
         ///     Update the associated missing report for the found item
         /// </summary>
         /// <param name="foundItemID">The id of the found item to modify</param>
-        /// <param name="missingItemID"></param>
+        /// <param name="missingReportID"></param>
         /// <param name="username">The username of the person making the request</param>
         /// <returns>None</returns>
         /// <exception cref="ResourceCreationException">If not account can be found for the requesting user</exception>

--- a/Gordon360/Services/LostAndFoundService.cs
+++ b/Gordon360/Services/LostAndFoundService.cs
@@ -3,6 +3,7 @@ using Gordon360.Models.CCT;
 using Gordon360.Models.CCT.Context;
 using Gordon360.Models.ViewModels;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Graph;
 using Serilog;
 using System;
 using System.Collections.Generic;
@@ -280,6 +281,36 @@ namespace Gordon360.Services
             }
 
             original.status = status;
+
+            await context.SaveChangesAsync();
+        }
+
+        /// <summary>
+        ///     Update the associated found item for a missing item report
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="foundID"></param>
+        /// <param name="username"></param>
+        /// <returns></returns>
+        public async Task UpdateReportAssociatedFoundItemAsync(int id, string foundID, string username)
+        {
+            // Get requesting user's ID number
+            var idNum = accountService.GetAccountByUsername(username).GordonID;
+
+            var original = await context.MissingReports.FindAsync(id);
+
+            if (original == null)
+            {
+                throw new ResourceNotFoundException() { ExceptionMessage = "The Missing Item Report was not found" };
+            }
+
+            // If a non-admin user attempts to update the associated found item of a report
+            if (original.submitterID != idNum && !hasFullPermissions(username))
+            {
+                throw new UnauthorizedAccessException("Cannot modify a report that doesn't belong to you!");
+            }
+
+            original.matchingFoundID = foundID;
 
             await context.SaveChangesAsync();
         }
@@ -855,6 +886,34 @@ namespace Gordon360.Services
             }
 
             original.status = status;
+
+            await context.SaveChangesAsync();
+        }
+
+        /// <summary>
+        ///     Update the associated missing report for the found item
+        /// </summary>
+        /// <param name="foundItemID">The id of the found item to modify</param>
+        /// <param name="missingItemID"></param>
+        /// <param name="username">The username of the person making the request</param>
+        /// <returns>None</returns>
+        /// <exception cref="ResourceCreationException">If not account can be found for the requesting user</exception>
+        /// <exception cref="ResourceNotFoundException">If the found item with given id cannot be found in the database</exception>
+        public async Task UpdateFoundAssociatedMissingReportAsync(string foundItemID, int missingReportID, string username)
+        {
+            if (!hasFullPermissions(username))
+            {
+                throw new ResourceNotFoundException();
+            }
+
+            var original = await context.FoundItems.FindAsync(foundItemID);
+
+            if (original == null)
+            {
+                throw new ResourceNotFoundException() { ExceptionMessage = "The Missing Item Report was not found" };
+            }
+
+            original.matchingMissingID = missingReportID;
 
             await context.SaveChangesAsync();
         }

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -240,6 +240,7 @@ namespace Gordon360.Services
                                                                    string? keywords);
         Task UpdateMissingItemReportAsync(int id, MissingItemReportViewModel reportDetails, string username);
         Task UpdateReportStatusAsync(int id, string status, string username);
+        Task UpdateReportAssociatedFoundItemAsync(int id, string foundID, string username);
         MissingItemReportViewModel? GetMissingItem(int id, string username);
         IEnumerable<ActionsTakenViewModel> GetActionsTaken(int id, string username, bool getPublicOnly = false, bool elevatedPermissions = false);
         public int GetMissingItemsCount(
@@ -261,6 +262,7 @@ namespace Gordon360.Services
         public FoundItemViewModel GetFoundItem(string foundItemID, string username);
         Task UpdateFoundItemAsync(string id, FoundItemViewModel itemDetails, string username);
         Task UpdateFoundStatusAsync(string id, string status, string username);
+        Task UpdateFoundAssociatedMissingReportAsync(string foundItemID, int missingReportID, string username);
         public int GetFoundItemsCount(
              string username,
              DateTime? latestDate,


### PR DESCRIPTION
Admin users can now edit missing item reports.

Updated missing item reports to now include a matching FoundID, for use when linking reports and items.

Added two new routes:
missingitems/{missingItemId}/linkItem/{foundItemID}
founditems/{itemId}/linkReport/{missingReportID}

These will update the matching ID numbers for the corresponding reports (instead of needing to use the main PUT route and pass all the item data in, even when changing this single field.