### PR TITLE
Modified status events to improve overall logic

### DIFF
--- a/Gordon360/Controllers/HousingController.cs
+++ b/Gordon360/Controllers/HousingController.cs
@@ -974,10 +974,6 @@ public class HousingController(CCTContext context, IProfileService profileServic
 
             return Ok(result);
         }
-        catch (InvalidOperationException ex)
-        {
-            return BadRequest(new { Message = ex.Message });
-        }
         catch (Exception ex)
         {
             return StatusCode(500, new { Message = "An error occurred while updating the status event.", Details = ex.Message });

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -2394,25 +2394,11 @@
             <returns>The list of daily tasks</returns>
         </member>
         <member name="M:Gordon360.Services.HousingService.CreateStatusEventAsync(Gordon360.Models.ViewModels.RA_StatusEventsViewModel)">
-             <summary>
-             Creates a new status event for an RA's schedule
-             </summary>
-             <param name="status">The RA_StatusEventsViewModel object containing necessary info</param>
-             Swagger is showing the time inputs in a tick format but the below works and should be used
-             {
-            "statusID": 0,
-            "raID": "RA123",
-            "statusName": "On Duty",
-            "isRecurring": true,
-            "frequency": "Weekly",
-            "interval": 1,
-            "start_Time": "08:00:00",
-            "end_Time": "09:00:00",
-            "startDate": "2025-02-21",
-            "endDate": "2025-02-21",
-            "createdDate": "2025-02-21T07:45:00Z"
-            }
-             <returns>The created status event</returns>
+            <summary>
+            Creates a new status event for an RA's schedule
+            </summary>
+            <param name="status">The RA_StatusEventsViewModel object containing necessary info</param>
+            <returns>The created status event</returns>
         </member>
         <member name="M:Gordon360.Services.HousingService.DeleteStatusEventAsync(System.Int32)">
             <summary>

--- a/Gordon360/Models/CCT/Context/CCTContext.cs
+++ b/Gordon360/Models/CCT/Context/CCTContext.cs
@@ -221,7 +221,7 @@ public partial class CCTContext : DbContext
 
             entity.HasOne(d => d.missing).WithMany(p => p.ActionsTaken)
                 .OnDelete(DeleteBehavior.ClientSetNull)
-                .HasConstraintName("FK__ActionsTa__missi__11606D5A");
+                .HasConstraintName("FK__ActionsTa__missi__365CE7DF");
         });
 
         modelBuilder.Entity<ActionsTakenData>(entity =>
@@ -327,6 +327,8 @@ public partial class CCTContext : DbContext
         modelBuilder.Entity<Daily_RA_Events>(entity =>
         {
             entity.ToView("Daily_RA_Events", "Housing");
+
+            entity.Property(e => e.Status_ID).ValueGeneratedOnAdd();
         });
 
         modelBuilder.Entity<DiningInfo>(entity =>
@@ -370,7 +372,7 @@ public partial class CCTContext : DbContext
 
             entity.HasOne(d => d.missing).WithMany(p => p.GuestUsers)
                 .OnDelete(DeleteBehavior.ClientSetNull)
-                .HasConstraintName("FK__GuestUser__missi__0E8400AF");
+                .HasConstraintName("FK__GuestUser__missi__3568C3A6");
         });
 
         modelBuilder.Entity<Hall_Assignment_Ranges>(entity =>
@@ -521,7 +523,7 @@ public partial class CCTContext : DbContext
 
         modelBuilder.Entity<MissingReports>(entity =>
         {
-            entity.HasKey(e => e.ID).HasName("PK__MissingR__3214EC27985CEC3D");
+            entity.HasKey(e => e.ID).HasName("PK__tmp_ms_x__3214EC271C4C78EB");
         });
 
         modelBuilder.Entity<PART_DEF>(entity =>
@@ -618,7 +620,7 @@ public partial class CCTContext : DbContext
 
         modelBuilder.Entity<RA_Status_Events>(entity =>
         {
-            entity.HasKey(e => e.Status_ID).HasName("PK__tmp_ms_x__519009AC813D76B1");
+            entity.HasKey(e => e.Status_ID).HasName("PK__RA_Statu__519009ACBC52F0C7");
 
             entity.Property(e => e.Created_Date).HasDefaultValueSql("(getdate())");
         });

--- a/Gordon360/Models/CCT/Housing/Daily_RA_Events.cs
+++ b/Gordon360/Models/CCT/Housing/Daily_RA_Events.cs
@@ -19,23 +19,17 @@ public partial class Daily_RA_Events
     public string Ra_ID { get; set; }
 
     [Required]
-    [StringLength(20)]
+    [StringLength(50)]
     [Unicode(false)]
     public string Status_Name { get; set; }
 
     public bool Is_Recurring { get; set; }
 
-    [StringLength(50)]
-    [Unicode(false)]
-    public string Frequency { get; set; }
-
-    public int? Interval { get; set; }
-
     [Column(TypeName = "date")]
     public DateTime Start_Date { get; set; }
 
     [Column(TypeName = "date")]
-    public DateTime? End_Date { get; set; }
+    public DateTime End_Date { get; set; }
 
     [Column(TypeName = "datetime")]
     public DateTime Created_Date { get; set; }

--- a/Gordon360/Models/CCT/Housing/RA_Status_Events.cs
+++ b/Gordon360/Models/CCT/Housing/RA_Status_Events.cs
@@ -20,17 +20,15 @@ public partial class RA_Status_Events
     public string Ra_ID { get; set; }
 
     [Required]
-    [StringLength(20)]
+    [StringLength(50)]
     [Unicode(false)]
     public string Status_Name { get; set; }
 
     public bool Is_Recurring { get; set; }
 
-    [StringLength(50)]
+    [StringLength(30)]
     [Unicode(false)]
-    public string Frequency { get; set; }
-
-    public int? Interval { get; set; }
+    public string DaysOfWeek { get; set; }
 
     public TimeSpan? Start_Time { get; set; }
 
@@ -40,7 +38,7 @@ public partial class RA_Status_Events
     public DateTime Start_Date { get; set; }
 
     [Column(TypeName = "date")]
-    public DateTime? End_Date { get; set; }
+    public DateTime End_Date { get; set; }
 
     [Column(TypeName = "datetime")]
     public DateTime Created_Date { get; set; }

--- a/Gordon360/Models/ViewModels/Housing/RA_StatusEventsViewModel.cs
+++ b/Gordon360/Models/ViewModels/Housing/RA_StatusEventsViewModel.cs
@@ -10,7 +10,7 @@ public class RA_StatusEventsViewModel
     public string RA_ID { get; set; }
     public string Status_Name { get; set; }
     public bool Is_Recurring { get; set; }
-    public string Days_Of_Week { get; set; }
+    public string? Days_Of_Week { get; set; }
     public TimeSpan? Start_Time { get; set; }
     public TimeSpan? End_Time { get; set; }
     public DateTime Start_Date { get; set; }

--- a/Gordon360/Models/ViewModels/Housing/RA_StatusEventsViewModel.cs
+++ b/Gordon360/Models/ViewModels/Housing/RA_StatusEventsViewModel.cs
@@ -10,8 +10,7 @@ public class RA_StatusEventsViewModel
     public string RA_ID { get; set; }
     public string Status_Name { get; set; }
     public bool Is_Recurring { get; set; }
-    public string Frequency { get; set; }
-    public int Interval { get; set; }
+    public string Days_Of_Week { get; set; }
     public TimeSpan? Start_Time { get; set; }
     public TimeSpan? End_Time { get; set; }
     public DateTime Start_Date { get; set; }

--- a/Gordon360/Services/HousingService.cs
+++ b/Gordon360/Services/HousingService.cs
@@ -1645,6 +1645,7 @@ public async Task<RA_StatusEventsViewModel> CreateStatusEventAsync(RA_StatusEven
     {
         var statusEvents = await context.Daily_RA_Events
             .Where(s => s.Ra_ID == raID)
+            .OrderBy(s => s.Start_Time)  
             .Select(s => new DailyStatusEventsViewModel
             {
                 Status_ID = s.Status_ID,


### PR DESCRIPTION
Removed frequency and interval from scheduling logic for status events. instead we have a dayys of week option for scheduling. RAs can specify the days an event should occur and the time period it should happen for