### PR TITLE
Adding access for ResLife Phone numbers

### DIFF
--- a/Gordon360/Authorization/StateYourBusiness.cs
+++ b/Gordon360/Authorization/StateYourBusiness.cs
@@ -425,7 +425,7 @@ public class StateYourBusiness : ActionFilterAttribute
             case Resource.HOUSING_RA_STATUS_EVENT:
                 return (user_groups.Contains(AuthGroup.HousingAdmin) || user_groups.Contains(AuthGroup.RD)|| user_groups.Contains(AuthGroup.HousingDeveloper));
             case Resource.HOUSING_PHONE_NUMBERS:
-                return (user_groups.Contains(AuthGroup.HousingAdmin) || user_groups.Contains(AuthGroup.RD) || user_groups.Contains(AuthGroup.RA) || user_groups.Contains(AuthGroup.HousingDeveloper));
+                return (user_groups.Contains(AuthGroup.HousingAdmin) || user_groups.Contains(AuthGroup.RD) || user_groups.Contains(AuthGroup.RA) || user_groups.Contains(AuthGroup.HallInfoViewer) || user_groups.Contains(AuthGroup.HousingDeveloper));
             case Resource.NEWS:
                 return user_groups.Contains(AuthGroup.NewsAdmin);
             case Resource.RECIM:


### PR DESCRIPTION
Staff view had one component that was not loading for GoPo. SYB was adjusted and works as expected in SP branch for the faculty.test account which is in the same permission group for ResLife as GoPo