### PR TITLE
adding email as part of advance search for lastname

### DIFF
--- a/Gordon360/Properties/launchSettings.json
+++ b/Gordon360/Properties/launchSettings.json
@@ -3,12 +3,12 @@
     "Development": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "https://localhost:51659/swagger",
+      "launchUrl": "https://localhost:51631/swagger",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "sqlDebugging": true,
-      "applicationUrl": "https://localhost:51659;http://localhost:51660"
+      "applicationUrl": "https://localhost:51631;http://localhost:51630"
     },
     "Train": {
       "commandName": "Project",

--- a/Gordon360/Services/AccountService.cs
+++ b/Gordon360/Services/AccountService.cs
@@ -147,11 +147,15 @@ public class AccountService(CCTContext context) : IAccountService
 
         if (lastname is not null)
         {
+
             accounts = accounts.Where(a =>
-                a.LastName.StartsWithIgnoreCase(lastname)
-                || a.MaidenName.StartsWithIgnoreCase(lastname)
-            );
+               a.LastName.StartsWithIgnoreCase(lastname)
+             || a.MaidenName.StartsWithIgnoreCase(lastname)
+              || (!string.IsNullOrEmpty(a.Email) &&a.Email.IndexOf('.')>=0 && a.Email.Split('.')[1].StartsWithIgnoreCase(lastname))
+          );
         }
+            
+           
 
         if (major is not null)
         {


### PR DESCRIPTION
some people has missing maiden name in the database so matching last name in advanace search to  last name in email will still find the person through their maiden name in email