### PR TITLE
s25 change daysleft from sessions to terms

### DIFF
--- a/Gordon360/Controllers/AcademicTermController.cs
+++ b/Gordon360/Controllers/AcademicTermController.cs
@@ -35,5 +35,12 @@ namespace Gordon360.Controllers
 
             return Ok(days);
         }
+
+        [HttpGet("undergradTerms")]
+        public async Task<IActionResult> GetUndergradTerms()
+        {
+            var terms = await service.GetUndergradTermsAsync();
+            return Ok(terms);
+        }
     }
 }

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -3184,10 +3184,10 @@
         </member>
         <member name="M:Gordon360.Services.ProfileService.UpdateMobilePhoneNumberAsync(System.String,System.String)">
             <summary>
-            Updates mobile phone number for a student (assuming its pre-validated input)
+            Updates mobile phone number 
             </summary>
-            <param name="username">The username for the user</param>
-            <param name="newMobilePhoneNumber">The pre-validated new phone number</param>
+            <param name="username">The username for the user whose number is updated</param>
+            <param name="newMobilePhoneNumber">The new mobile phone number to update for the user's phone number</param>
             <returns>updated student profile by there username</returns>
         </member>
         <member name="M:Gordon360.Services.ProfileService.UpdateOfficeLocationAsync(System.String,System.String,System.String)">
@@ -3243,7 +3243,7 @@
             <param name="username">The AD username associated with the account.</param>
             <returns>account information</returns>
         </member>
-        <member name="M:Gordon360.Services.RecIM.SeriesSerMatchesAsync(System.Int32,Gordon360.Models.ViewModels.RecIM.UploadScheduleRequest)">
+        <member name="M:Gordon360.Services.RecIM.SeriesService.ScheduleMatchesAsync(System.Int32,Gordon360.Models.ViewModels.RecIM.UploadScheduleRequest)">
             <summary>
             Scheduler does not currently handle overlaps
             eventually:

--- a/Gordon360/Services/AcademicTermService.cs
+++ b/Gordon360/Services/AcademicTermService.cs
@@ -62,4 +62,14 @@ public class AcademicTermService(CCTContext context) : IAcademicTermService
         daysInTerm
         };
     }
+    public async Task<IEnumerable<YearTermTableViewModel>> GetUndergradTermsAsync()
+    {
+        var terms = await context.YearTermTable
+            .Where(t => t.TRM_CDE == "FA" || t.TRM_CDE == "SP" || t.TRM_CDE == "SU")
+            .OrderByDescending(t => t.TRM_BEGIN_DTE)
+            .ToListAsync();
+
+        return terms.Select(t => new YearTermTableViewModel(t));
+    }
+
 }

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -339,6 +339,7 @@ namespace Gordon360.Services
         Task<YearTermTableViewModel?> GetCurrentTermAsync();
         Task<IEnumerable<YearTermTableViewModel>> GetAllTermsAsync();
         Task<double[]> GetDaysLeftAsync();
+        Task<IEnumerable<YearTermTableViewModel>> GetUndergradTermsAsync();
     }
 
     namespace RecIM


### PR DESCRIPTION
I changed daysleft function to use terms instead of sessions. I added a getUndergradTerms filter to only get Fall, Spring and Summer terms instead of getting all terms (which includes graduate terms).