### PR TITLE
Localhost fix for getImageURL

### DIFF
--- a/Gordon360/Services/PosterService.cs
+++ b/Gordon360/Services/PosterService.cs
@@ -164,7 +164,11 @@ public class PosterService(CCTContext context,
         if (serverAddress is not string) throw new Exception("Could not upload poster: Server Address is null");
 
         if (serverAddress.Contains("localhost"))
-            serverAddress = "";
+        {
+            // During development, if the UI is on a different machine than the API, you might need to 
+            // change the line below from serverAddress += "/"; to serverAddress = "";
+            serverAddress += "/";
+        }
         var url = $"{serverAddress}browseable/uploads/posters/images/{filename}";
         return url;
     }

--- a/Gordon360/Services/PosterService.cs
+++ b/Gordon360/Services/PosterService.cs
@@ -163,6 +163,8 @@ public class PosterService(CCTContext context,
         var serverAddress = serverUtils.GetAddress();
         if (serverAddress is not string) throw new Exception("Could not upload poster: Server Address is null");
 
+        if (serverAddress.Contains("localhost"))
+            serverAddress = "";
         var url = $"{serverAddress}browseable/uploads/posters/images/{filename}";
         return url;
     }


### PR DESCRIPTION
During development, the value of `serverAddress` set in `Gordon360/Services/PosterService.cs` is a URL that contains the string `localhost` and ends with a port number - but not a trailing slash.   When run on the 360API or 360APITrain servers, however, the value of `serverAddress` does end with a slash.  This PR deals with this issue in the same way that it is handled in `Gordon360/Services/NewsService.cs`.

It's worth noting that when the development API is running in Visual Studio the localhost URL uses an SSL address.  When the UI is running on a different machine it will not be able to use this URL to access poster images.  A comment in `PosterService.cs` suggests a work around for this.