### PR TITLE
Change getCurrentPosters logic to return priority first, then posters the user is involved in, and then all other posters

### DIFF
--- a/Gordon360/Controllers/PostersController.cs
+++ b/Gordon360/Controllers/PostersController.cs
@@ -31,15 +31,15 @@ public class PostersController(IPosterService posterService) : GordonControllerB
     }
 
     /// <summary>
-    /// Gets all non-expired posters
+    /// Gets all non-expired posters in the order based on the username
     /// </summary>
     /// <returns></returns>
     /// <exception cref="NotImplementedException"></exception>
     [HttpGet]
-    [Route("")]
-    public ActionResult<IEnumerable<PosterViewModel>> GetCurrentPosters()
+    [Route("current/{username}")]
+    public ActionResult<IEnumerable<PosterViewModel>> GetCurrentPosters(string username)
     {
-        var res = posterService.GetCurrentPosters();
+        var res = posterService.GetCurrentPosters(username);
         return Ok(res);
     }
 

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -44,9 +44,9 @@
             <returns></returns>
             <exception cref="T:System.NotImplementedException"></exception>
         </member>
-        <member name="M:Gordon360.Controllers.Api.PostersController.GetCurrentPosters">
+        <member name="M:Gordon360.Controllers.Api.PostersController.GetCurrentPosters(System.String)">
             <summary>
-            Gets all non-expired posters
+            Gets all non-expired posters in the order based on the username
             </summary>
             <returns></returns>
             <exception cref="T:System.NotImplementedException"></exception>

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -340,7 +340,7 @@ namespace Gordon360.Services
     public interface IPosterService
     {
         IEnumerable<PosterViewModel> GetPosters();
-        IEnumerable<PosterViewModel> GetCurrentPosters();
+        IEnumerable<PosterViewModel> GetCurrentPosters(string username);
         IEnumerable<PosterViewModel> GetCurrentPostersByActivityCode(string activityCode);
         IEnumerable<PosterViewModel> GetPersonalizedPostersByUsername(string username);
         IEnumerable<string> GetPosterStatuses();


### PR DESCRIPTION
Changed the logic of getCurrentPosters to sort it like it should be sorted in PosterSwiper. Connected to the frontend pull request.  

WARNING! DO NOT MERGE ONE AT A TIME!! This changes the logic for a api call in the frontend, so it will indeed break the frontend!!! I will link the frontend as soon as I create a pull request