### PR TITLE
Removed deprecated allcourses route

### DIFF
--- a/Gordon360/Controllers/ScheduleController.cs
+++ b/Gordon360/Controllers/ScheduleController.cs
@@ -15,31 +15,6 @@ namespace Gordon360.Controllers;
 public class ScheduleController(IScheduleService scheduleService) : GordonControllerBase
 {
     /// <summary>
-    ///  Gets all session objects for a user
-    /// </summary>
-    /// <returns>A IEnumerable of session objects as well as the schedules</returns>
-    [HttpGet]
-    [Route("{username}/allcourses")]
-    [Obsolete("This method is deprecated. Use '/{username}/allcourses-by-term' which is grouped by term.")]
-    public async Task<ActionResult<CoursesBySessionViewModel>> GetAllCourses(string username)
-    {
-        var groups = AuthUtils.GetGroups(User);
-        var authenticatedUsername = AuthUtils.GetUsername(User);
-
-        IEnumerable<CoursesBySessionViewModel> result;
-        if (authenticatedUsername.EqualsIgnoreCase(username) || groups.Contains(AuthGroup.FacStaff))
-        {
-            result = await scheduleService.GetAllCoursesAsync(username);
-        }
-        else
-        {
-            result = await scheduleService.GetAllInstructorCoursesAsync(username);
-        }
-
-        return Ok(result);
-    }
-
-    /// <summary>
     /// Gets all term-based course schedules for a user, filtered to only include officially published terms.
     /// </summary>
     /// <returns>A list of published term schedule objects</returns>

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -37,11 +37,6 @@
             <summary> Gets whether the user has checked in or not. True if they have checked in, false if they have not checked in </summary>
             <returns> The HTTP status indicating whether the request was completed and returns the check in status of the student </returns>
         </member>
-        <member name="M:Gordon360.Controllers.AcademicTermController.GetCurrentTermForFinalExams">
-            <summary>
-            Gets the most recent academic term that is either Spring or Fall
-            </summary>
-            <returns>The current term used to fetch final exams</returns>
         <member name="M:Gordon360.Controllers.Api.PostersController.GetPosters">
             <summary>
             Gets all posters that havent been deleted
@@ -124,6 +119,12 @@
             </summary>
             <returns></returns>
              <exception cref="T:System.NotImplementedException"></exception>
+        </member>
+        <member name="M:Gordon360.Controllers.AcademicTermController.GetCurrentTermForFinalExams">
+            <summary>
+            Gets the most recent academic term that is either Spring or Fall
+            </summary>
+            <returns>The current term used to fetch final exams</returns>
         </member>
         <member name="M:Gordon360.Controllers.AccountsController.SearchAsync(System.String)">
             <summary>
@@ -1688,6 +1689,13 @@
             <param name="response"></param>
             <returns>The accepted TeamInviteViewModel</returns>
         </member>
+        <member name="M:Gordon360.Controllers.RegistrationController.GetRegistrationWindow">
+            <summary>
+            Retrieves the registration window data for the currently logged-in user.
+            Returns a 404 if registration info is not found (either missing account or date info).
+            </summary>
+            <returns>A RegistrationPeriodViewModel with eligibility and timing details</returns>
+        </member>
         <member name="M:Gordon360.Controllers.RequestsController.Get">
             <summary>
             Gets all Membership Request Objects
@@ -1746,17 +1754,11 @@
             <param name="membershipRequestID">The id of the membership request to delete</param>
             <returns>The deleted request as a RequestView</returns>
         </member>
-        <member name="M:Gordon360.Controllers.ScheduleController.GetAllCourses(System.String)">
-            <summary>
-             Gets all session objects for a user
-            </summary>
-            <returns>A IEnumerable of session objects as well as the schedules</returns>
-        </member>
         <member name="M:Gordon360.Controllers.ScheduleController.GetAllCoursesByTerm(System.String)">
             <summary>
-             Gets all term objects for a user
+            Gets all term-based course schedules for a user, filtered to only include officially published terms.
             </summary>
-            <returns>A IEnumerable of term objects as well as the schedules</returns>
+            <returns>A list of published term schedule objects</returns>
         </member>
         <member name="M:Gordon360.Controllers.ScheduleController.GetCanReadStudentSchedules">
             <summary>
@@ -3269,6 +3271,14 @@
             <param name="newsID">The SNID (id of news item)</param>
             <returns>The news item</returns>
         </member>
+        <member name="F:Gordon360.Services.NewsService.ExcludedCategoryIds">
+            <summary>
+            Filters out categories that are not relevant for the student news feed.
+            Student News categories are set by fetching their respective ids from the databasase
+            in this instance, "2" and "3" are excluded. which relate to "Lost Items" and "Found Items"
+            NOTE: the categories are hardcoded here, but could be made more dynamic in the future
+            </summary>
+        </member>
         <member name="M:Gordon360.Services.NewsService.GetNewsPersonalUnapprovedAsync(System.String)">
             <summary>
             Gets unapproved unexpired news submitted by user.
@@ -3540,6 +3550,16 @@
             with the context that surfaces need to be booked ahead of time on 25Live
             </summary>
             <returns>Matches created as well as number of teams in the next round</returns>
+        </member>
+        <member name="M:Gordon360.Services.RegistrationService.GetRegistrationWindowAsync(System.String)">
+            <summary>
+            Gets the registration window for a given user and evaluates their eligibility to register.
+            </summary>
+            <param name="username">The AD username of the student.</param>
+            <returns>
+            A RegistrationPeriodViewModel containing registration start/end dates and eligibility status.
+            Returns null if either the account or registration window is missing.
+            </returns>
         </member>
         <member name="T:Gordon360.Services.ScheduleService">
             <summary>


### PR DESCRIPTION
The api/allcourses route has been replaced by the api/allcourses-by-term route.  The UI no longer makes use of the old route so the code for it was removed.