### PR TITLE
Hardcode correct server url in Train and Prod

### DIFF
--- a/Gordon360/Utilities/ServerUtils.cs
+++ b/Gordon360/Utilities/ServerUtils.cs
@@ -1,22 +1,26 @@
-﻿using Microsoft.AspNetCore.Hosting.Server;
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using System.Linq;
 
 namespace Gordon360.Utilities;
 
-public class ServerUtils
+public class ServerUtils(IServer server, IWebHostEnvironment env)
 {
-    private readonly IServer _server;
-
-    public ServerUtils(IServer server)
-    {
-        _server = server;
-    }
-
     public string? GetAddress()
     {
-        var addresses = _server.Features.Get<IServerAddressesFeature>()?.Addresses;
-        var serverAddress = addresses?.FirstOrDefault(a => a.StartsWith("https")) ?? addresses?.FirstOrDefault();
-        return serverAddress;
+        switch (env.EnvironmentName)
+        {
+            case "Train":
+                return "https://360ApiTrain.gordon.edu/";
+            case "Production":
+                return "https://360Api.gordon.edu/";
+            default:
+                {
+                    var addresses = server.Features.Get<IServerAddressesFeature>()?.Addresses;
+                    var serverAddress = addresses?.FirstOrDefault(a => a.StartsWith("https")) ?? addresses?.FirstOrDefault();
+                    return serverAddress;
+                }
+        }
     }
 }


### PR DESCRIPTION
The current method of determining the server URL relies on IIS Host bindings, which are fragile to network changes. I am hardcoding the currently correct server URL for the Train and Production environments, to prevent issues where images are served from an internal url.