### PR TITLE
update field names and sources

### DIFF
--- a/Gordon360/Controllers/ProfilesController.cs
+++ b/Gordon360/Controllers/ProfilesController.cs
@@ -461,8 +461,8 @@ public class ProfilesController(IProfileService profileService,
 
         var result = await profileService.UpdateOfficeLocationAsync(username, officeLocation.BuildingCode, officeLocation.RoomNumber);
         return Ok(new {
-            OnCampusBuilding = result.OnCampusBuilding,
-            OnCampusRoom = result.OnCampusRoom,
+            result.BuildingDescription,
+            result.OnCampusRoom,
         });
     }
 
@@ -513,8 +513,8 @@ public class ProfilesController(IProfileService profileService,
         var result = await profileService.UpdateMailStopAsync(username, value);
         return Ok(new
         {
-            MailLocation = result.Mail_Location,
-            MailDescription = result.Mail_Description
+            result.Mail_Location,
+            result.Mail_Description
         });
 
     }

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -1251,6 +1251,16 @@
             <param name="username"> The username for which to retrieve info </param>
             <returns> Graduation information of the given user. </returns>
         </member>
+        <member name="M:Gordon360.Controllers.ProfilesController.IsUserAuthorized(System.String,Gordon360.Enums.AuthGroup)">
+            <summary>
+            Gets whether or not permission to modify a user is granted, based on
+            whether the user being modified is the active user or whether the user
+            is part of a group that would grant access
+            </summary>
+            <param name="username">username of the profile being modified</param>
+            <param name="group">group that allows current user to modify profile</param>
+            <returns>true or false based on whether access is granted</returns>
+        </member>
         <member name="M:Gordon360.Controllers.RecIM.ActivitiesController.GetActivities(System.Nullable{System.Boolean})">
             <summary>Gets a list of all Activities by parameter </summary>
             <param name="active"> Optional active parameter denoting whether or not an activity has been completed </param>


### PR DESCRIPTION
Makes the office_location API call return the building description rather than the building code. 

Updates name of return fields to match names of profile fields, and removes warning by changing syntax to be more idiomatic.

Fixes #1262